### PR TITLE
build: Optimization on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: node_js
 node_js:
   - "10"
 
-cache:
-  directories:
-    - ./node_modules
+# Can be reactived when this issue will be resolved: https://github.com/cospired/i18n-iso-languages/issues/17
+#cache:
+#  directories:
+#    - ./node_modules
 
 install:
   - npm install

--- a/angular.json
+++ b/angular.json
@@ -36,7 +36,7 @@
                   "with": "projects/admin/src/environments/environment.prod.ts"
                 }
               ],
-              "optimization": true,
+              "optimization": false,
               "outputHashing": "none",
               "sourceMap": false,
               "extractCss": true,
@@ -44,7 +44,7 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
+              "buildOptimizer": false,
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
* BETTER Disable optimizations on production build to avoid errors when application is loaded in Invenio webpack.
* FIX Deactivate cache on node_modules in Travis configuration, to avoid error on @cospired package on travis tests.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>