### PR TITLE
build: Record module wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: node_js
 node_js:
   - "10"
 
-cache:
-  directories:
-    - ./node_modules
+# Can be reactived when this issue will be resolved: https://github.com/cospired/i18n-iso-languages/issues/17
+#cache:
+#  directories:
+#    - ./node_modules
 
 install:
   - npm install

--- a/projects/public-search/src/app/app-routing.module.ts
+++ b/projects/public-search/src/app/app-routing.module.ts
@@ -20,7 +20,7 @@ import { Routes, RouterModule } from '@angular/router';
 const routes: Routes = [
   {
     path: 'global/search',
-    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
+    loadChildren: () => import('./record-wrapper.module').then(m => m.RecordWrapperModule),
     data: {
       showSearchInput: true,
       adminMode: false,

--- a/projects/public-search/src/app/app.component.html
+++ b/projects/public-search/src/app/app.component.html
@@ -14,11 +14,5 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<h1>Public search app</h1>
-<ul>
-    <li>
-        <a href="#" routerLink="/global/search/documents">Documents</a>
-    </li>
-</ul>
 <router-outlet></router-outlet>
 

--- a/projects/public-search/src/app/record-wrapper.module.ts
+++ b/projects/public-search/src/app/record-wrapper.module.ts
@@ -14,25 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { TestBed, async } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AppComponent } from './app.component';
+import { NgModule } from '@angular/core';
 
-describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  }));
+import { RecordModule } from '@rero/ng-core';
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
-  });
-});
+@NgModule({
+  imports: [
+    RecordModule
+  ],
+})
+export class RecordWrapperModule { }


### PR DESCRIPTION
* FIX Create a wrapper module for RecordModule to avoid errors on production build with loadChildren routes.
* BETTER Remove unnecessary html and test.

Signed-off-by: Sébastien Délèze <sebastien.deleze@rero.ch>