### PR TITLE
public-search: complete brief view

### DIFF
--- a/projects/public-search/src/app/app-routing.module.ts
+++ b/projects/public-search/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { RecordSearchComponent, DetailComponent } from '@rero/ng-core';
 import { DocumentBriefComponent } from './document-brief/document-brief.component';
+import { PersonBriefComponent } from './person-brief/person-brief.component';
 
 const routes: Routes = [
   {
@@ -36,10 +37,16 @@ const routes: Routes = [
           key: 'documents',
           component: DocumentBriefComponent,
           label: 'Documents'
+        },
+        {
+          key: 'persons',
+          component: PersonBriefComponent,
+          label: 'Persons'
         }
       ]
     }
-  }, {
+  },
+  {
     path: 'highlands/search',
     children: [
       { path: ':type', component: RecordSearchComponent },
@@ -58,10 +65,16 @@ const routes: Routes = [
           preFilters: {
             view: 'highlands'
           }
+        },
+        {
+          key: 'persons',
+          component: PersonBriefComponent,
+          label: 'Persons'
         }
       ]
     }
-  }, {
+  },
+  {
     path: 'aoste/search',
     children: [
       { path: ':type', component: RecordSearchComponent },
@@ -80,6 +93,11 @@ const routes: Routes = [
           preFilters: {
             view: 'aoste'
           }
+        },
+        {
+          key: 'persons',
+          component: PersonBriefComponent,
+          label: 'Persons'
         }
       ]
     }

--- a/projects/public-search/src/app/app.module.ts
+++ b/projects/public-search/src/app/app.module.ts
@@ -18,18 +18,25 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 
-import { CoreConfigService, RecordModule, CoreModule } from '@rero/ng-core';
+import { CoreConfigService, RecordModule, CoreModule, SharedModule } from '@rero/ng-core';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { AppConfigService } from './app-config.service';
 import { DocumentBriefComponent } from './document-brief/document-brief.component';
-import { TranslatePipe } from '@ngx-translate/core';
+import { PersonBriefComponent } from './person-brief/person-brief.component';
+import { MefTitlePipe } from './pipes/mef-title.pipe';
+import { BirthDatePipe } from './pipes/birth-date.pipe';
+import { BioInformationsPipe } from './pipes/bio-informations.pipe';
 
 @NgModule({
   declarations: [
     AppComponent,
-    DocumentBriefComponent
+    DocumentBriefComponent,
+    PersonBriefComponent,
+    MefTitlePipe,
+    BirthDatePipe,
+    BioInformationsPipe
   ],
   imports: [
     BrowserModule,
@@ -37,7 +44,7 @@ import { TranslatePipe } from '@ngx-translate/core';
     HttpClientModule,
     CoreModule,
     RecordModule,
-    TranslatePipe
+    SharedModule
   ],
   providers: [
     {
@@ -46,7 +53,8 @@ import { TranslatePipe } from '@ngx-translate/core';
     }
   ],
   entryComponents: [
-    DocumentBriefComponent
+    DocumentBriefComponent,
+    PersonBriefComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -15,6 +15,58 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<ng-container *ngIf="record">
-<h4 *ngIf="record.metadata.title">{{ record.metadata.title }}</h4>
-</ng-container>
+<article *ngIf="record" class="card flex-row border-0">
+    <div class="align-self-start d-flex justify-content-center">
+      <figure class="mb-0 thumb-brief">
+        <img class="img-responsive border border-light " [src]="coverUrl">
+        <figcaption class="text-center">{{ record.metadata.type | translate }}</figcaption>
+      </figure>
+    </div>
+    <div class="card-body w-100 py-0">
+      <h4 class="card-title mb-1">
+        <a target="_self" href="/{{ view }}/documents/{{ record.metadata.pid }}">{{ record.metadata.title }}</a>
+      </h4>
+      <article class="card-text">
+        <!-- author -->
+        <ul class="list-inline mb-0" *ngIf="record.metadata.authors && record.metadata.authors.length > 0">
+          <li class="list-inline-item" *ngFor="let author of record.metadata.authors.slice(0,3); let last = last">
+            <span *ngIf="!author.pid">
+              {{ authorName(author) }}
+              {{ author.qualifier ? author.qualifier : '' }}
+              {{ author.date ? author.date : '' }}
+            </span>
+            <a *ngIf="author.pid" href="/{{ view }}/persons/{{ author.pid }}">
+              {{ authorName(author) }}
+              {{ author.qualifier ? author.qualifier : '' }}
+              {{ author.date ? author.date : '' }}
+            </a>
+            {{ last ? '' : '; ' }}
+
+          </li>
+          <li *ngIf="record.metadata.authors && record.metadata.authors.length > 3">; …</li>
+        </ul>
+
+        <!-- is_part_of -->
+        <span *ngIf="record.metadata.is_part_of">{{ record.metadata.is_part_of }}</span>
+
+        <!-- publisher_statements -->
+        <span *ngIf="record.metadata.publisherStatement">
+          {{ record.metadata.publisherStatement[0] }}
+        </span>
+
+        <div *ngIf="record.metadata.type !== 'ebook'">
+          <i class="fa fa-circle text-{{ record.metadata.available ? 'success' : 'danger' }}" aria-hidden="true"></i>&nbsp;
+          <span translate *ngIf="record.metadata.available">available</span>
+          <span translate *ngIf="!record.metadata.available">not available</span>
+        </div>
+        <div *ngIf="record.explanation">
+          <a class="badge badge-info collapsed"
+              data-toggle="collapse" href="#{{'score'+record.metadata.pid }}"
+              aria-expanded="false">
+              score: {{ record.explanation.value }}
+          </a>
+          <pre class="collapse border border-secondary mt-1" id="{{'score'+record.metadata.pid }}">{{record.explanation|json}}</pre>
+        </div>
+      </article>
+    </div>
+</article>

--- a/projects/public-search/src/app/document-brief/document-brief.component.scss
+++ b/projects/public-search/src/app/document-brief/document-brief.component.scss
@@ -1,0 +1,37 @@
+/*
+
+  RERO ILS
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+ .thumb-brief
+  img {
+    max-height: 90px;
+    width: 58px;
+  }
+
+@media (max-width: 960px) {
+  .thumb-brief
+    img {
+      max-width: 48px;
+    }
+  }
+
+pre {
+  white-space: pre-wrap;
+  max-height: 300px;
+  font-size: 0.7em;
+}

--- a/projects/public-search/src/app/document-brief/document-brief.component.ts
+++ b/projects/public-search/src/app/document-brief/document-brief.component.ts
@@ -16,17 +16,76 @@
  */
 
 import { Component, Input } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { RecordService as LocalRecordService } from '../record.service';
 
 @Component({
   selector: 'public-search-document-brief',
-  templateUrl: './document-brief.component.html'
+  templateUrl: './document-brief.component.html',
+  styleUrls: ['./document-brief.component.scss']
 })
 export class DocumentBriefComponent {
 
-  @Input()
-  record: any;
+  // TODO: adapt following line when issue #23 of ng-core is closed
+  private pathArray = window.location.pathname.split('/');
 
   @Input()
-  type: string;
+  set record(value) {
+    if (value !== undefined) {
+      this.Record = value;
+      this.coverUrl = `/static/images/icon_${value.metadata.type}.png`;
+      if (value.metadata.cover_art) {
+        this.coverUrl = value.metadata.cover_art;
+      } else if (value.metadata.identifiedBy) {
+        let isbn;
+        for (const identifier of value.metadata.identifiedBy) {
+          if (identifier.type === 'bf:Isbn') {
+            isbn = identifier.value;
+          }
+        }
+        if (isbn) {
+          this.getCover(isbn);
+        }
+      }
+    }
+  }
 
+  get record() {
+    return this.Record;
+  }
+
+  private Record: any;
+
+  coverUrl: string;
+
+  // TODO: adapt following line when issue #23 of ng-core is closed
+  public view = this.pathArray[1];
+
+  constructor(
+    private translate: TranslateService,
+    private localRecordService: LocalRecordService
+  ) {  }
+
+    /**
+     * Get author name
+     */
+  authorName(author) {
+    const nameIndex = `name_${this.translate.currentLang}`;
+    let nameLng = author[nameIndex];
+    if (!nameLng) {
+      nameLng = author.name;
+    }
+    return nameLng;
+  }
+
+    /**
+     * Load cover image
+     */
+  getCover(isbn: string) {
+    this.localRecordService.getCover(isbn).subscribe(result => {
+      if (result.success) {
+        this.coverUrl = result.image;
+      }
+    });
+  }
 }

--- a/projects/public-search/src/app/person-brief/person-brief.component.html
+++ b/projects/public-search/src/app/person-brief/person-brief.component.html
@@ -1,0 +1,28 @@
+<!--
+ RERO ILS UI
+ Copyright (C) 2019 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div *ngIf="record">
+<h5 class="card-title mb-0 rero-ils-person">
+  <a href="{{'/'+ view +'/persons/'+record.metadata.pid}}">{{record.metadata | mefTitle}}</a>
+  <small *ngIf="record.metadata.rero" class="badge badge-secondary ml-1">RERO</small>
+  <small *ngIf="record.metadata.gnd" class="badge badge-secondary ml-1">GND</small>
+  <small *ngIf="record.metadata.bnf" class="badge badge-secondary ml-1">BNF</small>
+</h5>
+<div class="card-text px-2">
+  <p class="mb-0" *ngIf="record.metadata | birthDate">{{ record.metadata | birthDate }}</p>
+  <p class="mb-0" *ngIf="record.metadata | bioInformations">{{ record.metadata | bioInformations }}</p>
+</div>
+</div>

--- a/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
+++ b/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
@@ -16,28 +16,25 @@
  */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CoreModule, SharedModule } from '@rero/ng-core';
 
 import { MefTitlePipe } from './../pipes/mef-title.pipe';
 import { BirthDatePipe } from './../pipes/birth-date.pipe';
 import { BioInformationsPipe } from './../pipes/bio-informations.pipe';
-import { DocumentBriefComponent } from './document-brief.component';
-import { HttpClientModule } from '@angular/common/http';
+import { PersonBriefComponent } from './person-brief.component';
 
-describe('DocumentBriefComponent', () => {
-  let component: DocumentBriefComponent;
-  let fixture: ComponentFixture<DocumentBriefComponent>;
+describe('PersonBriefComponent', () => {
+  let component: PersonBriefComponent;
+  let fixture: ComponentFixture<PersonBriefComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DocumentBriefComponent, MefTitlePipe, BirthDatePipe, BioInformationsPipe ],
-      imports: [ CoreModule, SharedModule, HttpClientModule ]
+      declarations: [ PersonBriefComponent, MefTitlePipe, BirthDatePipe, BioInformationsPipe ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DocumentBriefComponent);
+    fixture = TestBed.createComponent(PersonBriefComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/projects/public-search/src/app/person-brief/person-brief.component.ts
+++ b/projects/public-search/src/app/person-brief/person-brief.component.ts
@@ -1,0 +1,40 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'public-search-person-brief',
+  templateUrl: './person-brief.component.html'
+})
+export class PersonBriefComponent implements OnInit {
+
+  // TODO: adapt following line when issue #23 of ng-core is closed
+  private pathArray = window.location.pathname.split('/');
+
+  @Input()
+  record: any;
+
+  // TODO: adapt following line when issue #23 of ng-core is closed
+  public view = this.pathArray[1];
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/projects/public-search/src/app/pipes/bio-informations.pipe.spec.ts
+++ b/projects/public-search/src/app/pipes/bio-informations.pipe.spec.ts
@@ -1,0 +1,27 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { BioInformationsPipe } from './bio-informations.pipe';
+
+describe('BioInformationsPipe', () => {
+  it('create an instance', () => {
+    const pipe = new BioInformationsPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/public-search/src/app/pipes/bio-informations.pipe.ts
+++ b/projects/public-search/src/app/pipes/bio-informations.pipe.ts
@@ -1,0 +1,36 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'bioInformations'
+})
+export class BioInformationsPipe implements PipeTransform {
+
+  transform(value: any): any {
+    for (const source of ['rero', 'bnf', 'gnd']) {
+      if (value[source] && value[source].biographical_information) {
+        return value[source].biographical_information;
+      }
+    }
+    return null;
+  }
+
+}

--- a/projects/public-search/src/app/pipes/birth-date.pipe.spec.ts
+++ b/projects/public-search/src/app/pipes/birth-date.pipe.spec.ts
@@ -1,0 +1,27 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { BirthDatePipe } from './birth-date.pipe';
+
+describe('BirthDatePipe', () => {
+  it('create an instance', () => {
+    const pipe = new BirthDatePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/public-search/src/app/pipes/birth-date.pipe.ts
+++ b/projects/public-search/src/app/pipes/birth-date.pipe.ts
@@ -1,0 +1,36 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'birthDate'
+})
+export class BirthDatePipe implements PipeTransform {
+
+  transform(value: any): any {
+    for (const source of ['rero', 'bnf', 'gnd']) {
+      if (value[source] && value[source].date_of_birth) {
+        return value[source].date_of_birth;
+      }
+    }
+    return null;
+  }
+
+}

--- a/projects/public-search/src/app/pipes/mef-title.pipe.spec.ts
+++ b/projects/public-search/src/app/pipes/mef-title.pipe.spec.ts
@@ -1,0 +1,27 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { MefTitlePipe } from './mef-title.pipe';
+
+describe('MefTitlePipe', () => {
+  it('create an instance', () => {
+    const pipe = new MefTitlePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/public-search/src/app/pipes/mef-title.pipe.ts
+++ b/projects/public-search/src/app/pipes/mef-title.pipe.ts
@@ -1,0 +1,35 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'mefTitle'
+})
+export class MefTitlePipe implements PipeTransform {
+
+  transform(value: any): any {
+    for (const source of ['rero', 'bnf', 'gnd']) {
+      if (value[source] && value[source].preferred_name_for_person) {
+        return value[source].preferred_name_for_person;
+      }
+    }
+    return value.pid;
+  }
+}

--- a/projects/public-search/src/app/record.service.spec.ts
+++ b/projects/public-search/src/app/record.service.spec.ts
@@ -1,0 +1,37 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RecordService } from './record.service';
+
+
+describe('myService', () => {
+
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [HttpClientTestingModule],
+    providers: [RecordService]
+  }));
+
+  it('should be created', () => {
+    const service: RecordService = TestBed.get(RecordService);
+    expect(service).toBeTruthy();
+  });
+
+});

--- a/projects/public-search/src/app/record.service.ts
+++ b/projects/public-search/src/app/record.service.ts
@@ -1,0 +1,48 @@
+/*
+
+RERO ILS
+Copyright (C) 2019 RERO
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RecordService {
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  /**
+   * Get cover image
+   * @param isbn - string, International Standard Book Number
+   */
+  getCover(isbn: string) {
+    const url = `/api/cover/${isbn}`;
+    return this.http.get<any>(url).pipe(
+      catchError(e => {
+        if (e.status === 404) {
+          return of(null);
+        }
+      })
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,8 @@
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
+  },
+  "paths": {
+    "@app/*": ["src/app/*"]
   }
 }


### PR DESCRIPTION
## Why are you opening this PR?

Implements tasks #1061 of US986
* NEW Adds documents and person filters
* NEW Adds detailed display of search results

## How to test?
`cd rero-ils-ui`
`git fetch rero pull/8/head:PR8`
`git checkout PR8`
`npm run build`
`ng serve public-search`

**/!\ rero-ils server must be running**

## Expected results
* Brief view should look like the screenshot below
* Filtering with facets should work
* Clicking on a link should redirect to flask detail view (document title & person name)

<img width="1193" alt="Screen Shot 2019-10-16 at 16 27 30" src="https://user-images.githubusercontent.com/28982829/66928596-ee161880-f031-11e9-9939-5138d26fa575.png">
