### PR TITLE
record: disable locations buttons for external librarians

### DIFF
--- a/projects/admin/src/app/app-routing.module.ts
+++ b/projects/admin/src/app/app-routing.module.ts
@@ -155,7 +155,9 @@ const routes: Routes = [
         {
           key: 'libraries',
           label: 'Libraries',
-          component: LibrariesBriefViewComponent
+          component: LibrariesBriefViewComponent,
+          canUpdate: RecordStatus.canUpdate,
+          canDelete: RecordStatus.canDelete
         }
       ]
     }

--- a/projects/admin/src/app/record/brief-view/libraries-brief-view.component.ts
+++ b/projects/admin/src/app/record/brief-view/libraries-brief-view.component.ts
@@ -85,11 +85,11 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
     <div id="collapseBasic" [collapse]="isCollapsed">
       <ul *ngIf="locations.length" class="list-group list-group-flush">
         <li *ngFor="let location of locations;" class="list-group-item p-1">{{ location.metadata.name }}
-          <a (click)="deleteLocation(location.metadata.pid)"
+          <a (click)="deleteLocation(location.metadata.pid)" *ngIf="hasPermissionToDelete(location)"
           class="float-right text-secondary ml-2" title="{{ 'Delete' | translate }}">
           <i class="fa fa-trash" aria-hidden="true"></i>
           </a>
-          <a class="ml-2 float-right text-secondary" routerLinkActive="active"
+          <a *ngIf="hasPermissionToUpdate(location)" class="ml-2 float-right text-secondary" routerLinkActive="active"
              [routerLink]="['/records/locations', location.metadata.pid]"
              title="{{ 'Edit' | translate }}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -119,21 +119,21 @@ export class LibrariesBriefViewComponent implements ResultItem {
   constructor(
     private recordService: RecordService,
     private toastService: ToastrService
-  ) {}
+  ) { }
 
   toggleCollapse() {
     if (this.isCollapsed) {
       const libraryPid = this.record.metadata.pid;
       this.recordService
-          .getRecords('locations', `library.pid:${libraryPid}`, 1, 100)
-          .subscribe(data => {
-            if (data.hits.total) {
-              this.locations = data.hits.hits;
-            } else {
-              this.locations = [];
-            }
-            this.isCollapsed = !this.isCollapsed;
-          });
+        .getRecords('locations', `library.pid:${libraryPid}`, 1, 100)
+        .subscribe(data => {
+          if (data.hits.total) {
+            this.locations = data.hits.hits;
+          } else {
+            this.locations = [];
+          }
+          this.isCollapsed = !this.isCollapsed;
+        });
     } else {
       this.isCollapsed = !this.isCollapsed;
     }
@@ -146,6 +146,28 @@ export class LibrariesBriefViewComponent implements ResultItem {
         this.toastService.success(_('Record deleted'), _('locations'));
       }
     });
+  }
+
+  hasPermissionToUpdate(location) {
+    if (location
+      && location.permissions
+      && location.permissions.cannot_update
+      && location.permissions.cannot_update.permission
+      && location.permissions.cannot_update.permission === 'permission denied') {
+      return false;
+    }
+    return true;
+  }
+
+  hasPermissionToDelete(location) {
+    if (location
+      && location.permissions
+      && location.permissions.cannot_delete
+      && location.permissions.cannot_delete.permission
+      && location.permissions.cannot_delete.permission === 'permission denied') {
+      return false;
+    }
+    return true;
   }
 
 }

--- a/projects/admin/src/app/record/record-status.ts
+++ b/projects/admin/src/app/record/record-status.ts
@@ -24,12 +24,30 @@ export class RecordStatus {
 
   static translateService: TranslateService;
 
+  static canUpdate(record: any) {
+    if (
+      record.permissions
+      && record.permissions.cannot_update
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   static canDelete(record: any): Observable<DeleteRecordStatus> {
     const Obs = new Observable((observer: Subscriber<any>): void => {
-      observer.next({can: !RecordStatus.generateMessage(record), message: RecordStatus.generateMessage(record)});
-      RecordStatus.translateService.onLangChange.subscribe(() => {
-        observer.next({can: !RecordStatus.generateMessage(record), message: RecordStatus.generateMessage(record)});
-      });
+      if (
+        record.permissions
+        && record.permissions.cannot_delete
+        && record.permissions.cannot_delete.permission
+        && record.permissions.cannot_delete.permission === 'permission denied') {
+        observer.next({ can: false, message: '' });
+      } else {
+        observer.next({ can: !RecordStatus.generateMessage(record), message: RecordStatus.generateMessage(record) });
+        RecordStatus.translateService.onLangChange.subscribe(() => {
+          observer.next({ can: !RecordStatus.generateMessage(record), message: RecordStatus.generateMessage(record) });
+        });
+      }
     });
 
     return Obs;
@@ -71,8 +89,8 @@ export class RecordStatus {
       }
       messages.unshift(
         messages.length === 1 ?
-        RecordStatus.translateService.instant(_('You cannot delete the record for the following reason:')) :
-        RecordStatus.translateService.instant(_('You cannot delete the record for the following reasons:'))
+          RecordStatus.translateService.instant('You cannot delete the record for the following reason:') :
+          RecordStatus.translateService.instant('You cannot delete the record for the following reasons:')
       );
 
       return messages.join('\n');
@@ -115,7 +133,7 @@ export class RecordStatus {
         '=1': RecordStatus.translateService.instant(_('has 1 organisation attached')),
         other: RecordStatus.translateService.instant(_('has # organisations attached'))
       },
-      patron_types: {
+      patron_types: {
         '=1': RecordStatus.translateService.instant(_('has 1 patron type attached')),
         other: RecordStatus.translateService.instant(_('has # patron types attached'))
       },


### PR DESCRIPTION
* Enables locations and libraries edit and delete buttons for librarians from external libraries.
* Closes #488

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

# How to test:
- should connect to the `dev` of `rero-ils`
- login as a `librarian: reroilstest+virgile@gmail.com` 
- display available libraries and locations @  http://localhost:4200/records/libraries?size=10&page=1&q=
- you will have edit/delete buttons enabled only for one library and its locations.

- login as a `system_librarian: reroilstest@gmail.com` 
- display available libraries and locations @  http://localhost:4200/records/libraries?size=10&page=1&q=
- you will have edit/delete buttons enabled for all libraries and locations of this organisation