### PR TITLE
issue: fix translation issue in facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "extract_messages": "ngx-translate-extract -k -c -s -i ./projects/admin/src -o ./projects/admin/src/app/translate/i18n/en_US.json --fi '  '",
-    "update_catalog": "ngx-translate-extract -k -c -s -i ./projects/admin/src -o ./projects/admin/src/app/translate/i18n/{de,en,fr,it}.json --fi '  '"
+    "admin_extract_messages": "ngx-translate-extract -k -c -s -i ./projects/admin/src -o ./projects/admin/src/app/translate/i18n/en_US.json --fi '  '",
+    "admin_update_catalog": "ngx-translate-extract -k -c -s -i ./projects/admin/src -o ./projects/admin/src/app/translate/i18n/{de,en,fr,it}.json --fi '  '",
+    "public-search_extract_messages": "ngx-translate-extract -k -c -s -i ./projects/public-search/src -o ./projects/public-search/src/app/translate/i18n/en_US.json --fi '  '",
+    "public-search_update_catalog": "ngx-translate-extract -k -c -s -i ./projects/public-search/src -o ./projects/public-search/src/app/translate/i18n/{de,en,fr,it}.json --fi '  '"
   },
   "dependencies": {
     "@angular/animations": "~8.1.2",
@@ -49,7 +51,7 @@
     "@cospired/i18n-iso-languages": "^2.0.5",
     "@ngx-translate/core": "^11.0.1",
     "@ngx-translate/http-loader": "^4.0.0",
-    "@rero/ng-core": "0.0.11",
+    "@rero/ng-core": "^0.0.11",
     "angular-datatables": "^8.0.0",
     "angular6-json-schema-form": "^7.3.0",
     "bootstrap": "^4.3.1",

--- a/projects/public-search/src/app/app-routing.module.ts
+++ b/projects/public-search/src/app/app-routing.module.ts
@@ -19,6 +19,8 @@ import { Routes, RouterModule } from '@angular/router';
 import { RecordSearchComponent, DetailComponent } from '@rero/ng-core';
 import { DocumentBriefComponent } from './document-brief/document-brief.component';
 import { PersonBriefComponent } from './person-brief/person-brief.component';
+import { TranslateService } from '@ngx-translate/core';
+import { AggregationFilter } from './record/aggregation-filter';
 
 const routes: Routes = [
   {
@@ -36,7 +38,8 @@ const routes: Routes = [
         {
           key: 'documents',
           component: DocumentBriefComponent,
-          label: 'Documents'
+          label: 'Documents',
+          aggregations: AggregationFilter.filter
         },
         {
           key: 'persons',
@@ -62,6 +65,7 @@ const routes: Routes = [
           key: 'documents',
           component: DocumentBriefComponent,
           label: 'Documents',
+          aggregations: AggregationFilter.filter,
           preFilters: {
             view: 'highlands'
           }
@@ -89,6 +93,7 @@ const routes: Routes = [
         {
           key: 'documents',
           label: 'Documents',
+          aggregations: AggregationFilter.filter,
           component: DocumentBriefComponent,
           preFilters: {
             view: 'aoste'
@@ -108,4 +113,8 @@ const routes: Routes = [
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {
+  constructor(private translateService: TranslateService) {
+    AggregationFilter.translateService = translateService;
+  }
+}

--- a/projects/public-search/src/app/app.component.ts
+++ b/projects/public-search/src/app/app.component.ts
@@ -14,10 +14,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component } from '@angular/core';
+import { Component, OnInit, Injector } from '@angular/core';
+import { TranslateService } from '@rero/ng-core';
 
 @Component({
   selector: 'public-search-root',
   templateUrl: './app.component.html'
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  lang: string = document.documentElement.lang;
+
+   constructor(private injector: Injector) { }
+
+  ngOnInit(): void {
+    this.injector.get(TranslateService).setLanguage(this.lang);
+  }
+}

--- a/projects/public-search/src/app/app.module.ts
+++ b/projects/public-search/src/app/app.module.ts
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, LOCALE_ID } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 
-import { CoreConfigService, RecordModule, CoreModule, SharedModule } from '@rero/ng-core';
+import { CoreConfigService, RecordModule, CoreModule, SharedModule, TranslateService } from '@rero/ng-core';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -28,6 +28,9 @@ import { PersonBriefComponent } from './person-brief/person-brief.component';
 import { MefTitlePipe } from './pipes/mef-title.pipe';
 import { BirthDatePipe } from './pipes/birth-date.pipe';
 import { BioInformationsPipe } from './pipes/bio-informations.pipe';
+import { TranslateModule, TranslateLoader as BaseTranslateLoader } from '@ngx-translate/core';
+import { TranslateLoader } from './translate/loader/translate-loader';
+import { BsLocaleService } from 'ngx-bootstrap';
 
 @NgModule({
   declarations: [
@@ -44,13 +47,26 @@ import { BioInformationsPipe } from './pipes/bio-informations.pipe';
     HttpClientModule,
     CoreModule,
     RecordModule,
-    SharedModule
+    SharedModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: BaseTranslateLoader,
+        useClass: TranslateLoader,
+      },
+      isolate: false
+    })
   ],
   providers: [
     {
       provide: CoreConfigService,
       useClass: AppConfigService
-    }
+    },
+    {
+      provide: LOCALE_ID,
+      useFactory: (translate: TranslateService) => translate.currentLanguage,
+      deps: [TranslateService]
+    },
+    BsLocaleService
   ],
   entryComponents: [
     DocumentBriefComponent,

--- a/projects/public-search/src/app/manual_translations.ts
+++ b/projects/public-search/src/app/manual_translations.ts
@@ -14,26 +14,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { TestBed, async } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AppComponent } from './app.component';
 
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
-describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ]
-    }).compileComponents();
-  }));
-
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
-  });
-});
+// _('Your string');
+// Document type
+_('article');
+_('book');
+_('ebook');
+_('journal');
+_('score');
+_('sound');
+_('video');

--- a/projects/public-search/src/app/record/aggregation-filter.spec.ts
+++ b/projects/public-search/src/app/record/aggregation-filter.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { AggregationFilter } from './aggregation-filter';
+import { TranslateService, TranslateModule, TranslateLoader as BaseTranslateLoader } from '@ngx-translate/core';
+import { TranslateLoader } from '../translate/loader/translate-loader';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TestBed } from '@angular/core/testing';
+
+const aggregations = {
+  author__en: {
+    buckets: [
+      { doc_count: 3, key: 'Bach, Johann Sebastian' },
+      { doc_count: 2, key: 'Auzias, Dominique' }
+    ],
+    doc_count_error_upper_bound: 0,
+    sum_other_doc_count: 517
+  },
+  author__fr: {
+    buckets: [
+      { doc_count: 3, key: 'Bach, Johann Sebastien' },
+      { doc_count: 2, key: 'Auzias, Dominique' }
+    ],
+    doc_count_error_upper_bound: 0,
+    sum_other_doc_count: 517
+  },
+  document_type: {
+    buckets: [
+      { doc_count: 206, key: 'book' },
+      { doc_count: 100, key: 'ebook' }
+    ],
+    doc_count_error_upper_bound: 0,
+    sum_other_doc_count: 0
+  },
+  organisation: {
+    buckets: [
+      { doc_count: 100, key: 'org1' },
+      { doc_count: 10, key: 'org2' }
+    ],
+    doc_count_error_upper_bound: 0,
+    sum_other_doc_count: 0
+  }
+};
+
+describe('AggregationFilter', () => {
+  let translate: TranslateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: BaseTranslateLoader,
+            useClass: TranslateLoader,
+          },
+          isolate: false
+        })
+      ],
+      providers: [TranslateService]
+    }).compileComponents();
+    translate = TestBed.get(TranslateService);
+    translate.use('en');
+  });
+
+  it('should filter aggregations', () => {
+    AggregationFilter.translateService = translate;
+    AggregationFilter.filter(aggregations).subscribe(data => {
+      const keys = Object.keys(data);
+      expect(keys).toEqual(['author', 'document_type', 'organisation']);
+      expect(keys.length).toBe(3);
+      expect(keys.indexOf('author') > -1).toBeTruthy();
+    });
+  });
+});

--- a/projects/public-search/src/app/record/aggregation-filter.ts
+++ b/projects/public-search/src/app/record/aggregation-filter.ts
@@ -1,0 +1,48 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { TranslateService } from '@ngx-translate/core';
+import { Observable, Subscriber } from 'rxjs';
+
+export class AggregationFilter {
+
+  static translateService: TranslateService;
+
+  static filter(aggregations: object): Observable<any> {
+    const Obs = new Observable((observer: Subscriber<any>): void => {
+      observer.next(AggregationFilter.aggregationFilter(aggregations));
+      AggregationFilter.translateService.onLangChange.subscribe(() => {
+        observer.next(AggregationFilter.aggregationFilter(aggregations));
+      });
+    });
+    return Obs;
+  }
+
+  static aggregationFilter(aggregations: object) {
+    const aggs = {};
+    Object.keys(aggregations).forEach(aggregation => {
+      if (aggregation.indexOf('__') > -1) {
+        const splitted = aggregation.split('__');
+        if (AggregationFilter.translateService.currentLang === splitted[1]) {
+          aggs[splitted[0]] = aggregations[aggregation];
+        }
+      } else {
+        aggs[aggregation] = aggregations[aggregation];
+      }
+    });
+    return aggs;
+  }
+}

--- a/projects/public-search/src/app/translate/i18n/de.json
+++ b/projects/public-search/src/app/translate/i18n/de.json
@@ -1,0 +1,11 @@
+{
+  "article": "Artikel",
+  "available": "verfügbar",
+  "book": "Buch",
+  "ebook": "E-Book",
+  "journal": "Zeitschrift",
+  "not available": "nicht verfügbar",
+  "score": "Partitur",
+  "sound": "Ton",
+  "video": "Video"
+}

--- a/projects/public-search/src/app/translate/i18n/en.json
+++ b/projects/public-search/src/app/translate/i18n/en.json
@@ -1,0 +1,11 @@
+{
+  "article": "article",
+  "available": "available",
+  "book": "book",
+  "ebook": "ebook",
+  "journal": "journal",
+  "not available": "not available",
+  "score": "score",
+  "sound": "sound",
+  "video": "video"
+}

--- a/projects/public-search/src/app/translate/i18n/en_US.json
+++ b/projects/public-search/src/app/translate/i18n/en_US.json
@@ -1,0 +1,11 @@
+{
+  "article": "article",
+  "available": "available",
+  "book": "book",
+  "ebook": "ebook",
+  "journal": "journal",
+  "not available": "not available",
+  "score": "score",
+  "sound": "sound",
+  "video": "video"
+}

--- a/projects/public-search/src/app/translate/i18n/fr.json
+++ b/projects/public-search/src/app/translate/i18n/fr.json
@@ -1,0 +1,11 @@
+{
+  "article": "article",
+  "available": "disponible",
+  "book": "livre",
+  "ebook": "e-book",
+  "journal": "journal",
+  "not available": "non disponible",
+  "score": "partition",
+  "sound": "son",
+  "video": "vidéo"
+}

--- a/projects/public-search/src/app/translate/i18n/it.json
+++ b/projects/public-search/src/app/translate/i18n/it.json
@@ -1,0 +1,11 @@
+{
+  "article": "articolo",
+  "available": "disponibile",
+  "book": "libro",
+  "ebook": "e-book",
+  "journal": "giornale",
+  "not available": "non disponibile",
+  "score": "partitura",
+  "sound": "suono",
+  "video": "video"
+}

--- a/projects/public-search/src/app/translate/loader/translate-loader.spec.ts
+++ b/projects/public-search/src/app/translate/loader/translate-loader.spec.ts
@@ -14,26 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { TestBed, async } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AppComponent } from './app.component';
 
+import { TranslateLoader } from './translate-loader';
+import { AppConfigService } from '../../app-config.service';
 
-describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ]
-    }).compileComponents();
-  }));
-
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
+describe('TranslateLoader', () => {
+  it('should create an instance', () => {
+    expect(new TranslateLoader(new AppConfigService())).toBeTruthy();
   });
 });

--- a/projects/public-search/src/app/translate/loader/translate-loader.ts
+++ b/projects/public-search/src/app/translate/loader/translate-loader.ts
@@ -1,0 +1,50 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TranslateLoader as NgCoreTranslateLoader } from '@rero/ng-core';
+import { AppConfigService } from '../../app-config.service';
+
+import fr from '../i18n/fr.json';
+import de from '../i18n/de.json';
+import en from '../i18n/en.json';
+import it from '../i18n/it.json';
+
+export class TranslateLoader extends NgCoreTranslateLoader {
+
+  /**
+   * Store translations in available languages.
+   */
+  private applicationTranslations: object = { fr, de, en, it };
+
+  /**
+   * Constructor
+   * @param config - ConfigService, invenio core configuration
+   */
+  constructor(private appService: AppConfigService) {
+    super(appService);
+    this.loadApplicationTranslations();
+  }
+
+  /**
+   * Load application translations
+   */
+  private loadApplicationTranslations() {
+    for (const lang of this.appService.languages) {
+      this.translations[lang] = {...this.translations[lang], ...this.applicationTranslations[lang]};
+    }
+  }
+}


### PR DESCRIPTION
* Adds aggregation filters.
* Adds document type facet translation.
* Closes rero/rero-ils#529

## Remark
As discussed with PO, issue is fixed in rero-ils-ui: https://github.com/rero/rero-ils/issues/529#issuecomment-545420652

## How to test?
Clone this PR
`npm install`
`npm run build`
`start-public-search-proxy --open`

## Check
* Document type facets must be correctly translated:
Change language in `./projects/public-search/src/index.html` line 18 to check other languages.
<img width="263" alt="Screen Shot 2019-10-25 at 09 19 53" src="https://user-images.githubusercontent.com/28982829/67551229-b0d41980-f708-11e9-8a4d-f00b6654917c.png">

* Author must appear only once (not Author_[lang])
<img width="264" alt="Screen Shot 2019-10-25 at 09 24 39" src="https://user-images.githubusercontent.com/28982829/67551479-525b6b00-f709-11e9-9d9a-7b75c4b05bb4.png">
