### PR TITLE
public-search: update redirection to detailed views

### DIFF
--- a/projects/admin/src/app/record/aggregation-filter.ts
+++ b/projects/admin/src/app/record/aggregation-filter.ts
@@ -22,13 +22,13 @@ export class AggregationFilter {
   static translateService: TranslateService;
 
   static filter(aggregations: object): Observable<any> {
-    const Obs = new Observable((observer: Subscriber<any>): void => {
+    const obs = new Observable((observer: Subscriber<any>): void => {
       observer.next(AggregationFilter.aggregationFilter(aggregations));
       AggregationFilter.translateService.onLangChange.subscribe(() => {
         observer.next(AggregationFilter.aggregationFilter(aggregations));
       });
     });
-    return Obs;
+    return obs;
   }
 
   static aggregationFilter(aggregations: object) {

--- a/projects/admin/src/app/record/record-status.ts
+++ b/projects/admin/src/app/record/record-status.ts
@@ -35,7 +35,7 @@ export class RecordStatus {
   }
 
   static canDelete(record: any): Observable<DeleteRecordStatus> {
-    const Obs = new Observable((observer: Subscriber<any>): void => {
+    const obs = new Observable((observer: Subscriber<any>): void => {
       if (
         record.permissions
         && record.permissions.cannot_delete
@@ -50,7 +50,7 @@ export class RecordStatus {
       }
     });
 
-    return Obs;
+    return obs;
   }
 
   private static generateMessage(record: any) {

--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -24,7 +24,7 @@
     </div>
     <div class="card-body w-100 py-0">
       <h4 class="card-title mb-1">
-        <a target="_self" href="/{{ view }}/documents/{{ record.metadata.pid }}">{{ record.metadata.title }}</a>
+        <a target="_self" href="/{{ detailUrl }}">{{ record.metadata.title }}</a>
       </h4>
       <article class="card-text">
         <!-- author -->
@@ -35,7 +35,7 @@
               {{ author.qualifier ? author.qualifier : '' }}
               {{ author.date ? author.date : '' }}
             </span>
-            <a *ngIf="author.pid" href="/{{ view }}/persons/{{ author.pid }}">
+            <a *ngIf="author.pid" href="/{{ viewcode }}/persons/{{ author.pid }}">
               {{ authorName(author) }}
               {{ author.qualifier ? author.qualifier : '' }}
               {{ author.date ? author.date : '' }}

--- a/projects/public-search/src/app/document-brief/document-brief.component.ts
+++ b/projects/public-search/src/app/document-brief/document-brief.component.ts
@@ -25,14 +25,15 @@ import { RecordService as LocalRecordService } from '../record.service';
   styleUrls: ['./document-brief.component.scss']
 })
 export class DocumentBriefComponent {
-
-  // TODO: adapt following line when issue #23 of ng-core is closed
+  private coverUrl: string;
   private pathArray = window.location.pathname.split('/');
+  private _record: any;
 
-  @Input()
-  set record(value) {
+  @Input() detailUrl: string;
+  @Input() viewcode = this.pathArray[1];
+  @Input() set record(value) {
     if (value !== undefined) {
-      this.Record = value;
+      this._record = value;
       this.coverUrl = `/static/images/icon_${value.metadata.type}.png`;
       if (value.metadata.cover_art) {
         this.coverUrl = value.metadata.cover_art;
@@ -51,15 +52,8 @@ export class DocumentBriefComponent {
   }
 
   get record() {
-    return this.Record;
+    return this._record;
   }
-
-  private Record: any;
-
-  coverUrl: string;
-
-  // TODO: adapt following line when issue #23 of ng-core is closed
-  public view = this.pathArray[1];
 
   constructor(
     private translate: TranslateService,

--- a/projects/public-search/src/app/person-brief/person-brief.component.html
+++ b/projects/public-search/src/app/person-brief/person-brief.component.html
@@ -16,7 +16,7 @@
 -->
 <div *ngIf="record">
 <h5 class="card-title mb-0 rero-ils-person">
-  <a href="{{'/'+ view +'/persons/'+record.metadata.pid}}">{{record.metadata | mefTitle}}</a>
+  <a href="{{ detailUrl }}">{{record.metadata | mefTitle}}</a>
   <small *ngIf="record.metadata.rero" class="badge badge-secondary ml-1">RERO</small>
   <small *ngIf="record.metadata.gnd" class="badge badge-secondary ml-1">GND</small>
   <small *ngIf="record.metadata.bnf" class="badge badge-secondary ml-1">BNF</small>

--- a/projects/public-search/src/app/person-brief/person-brief.component.ts
+++ b/projects/public-search/src/app/person-brief/person-brief.component.ts
@@ -22,15 +22,9 @@ import { Component, OnInit, Input } from '@angular/core';
   templateUrl: './person-brief.component.html'
 })
 export class PersonBriefComponent implements OnInit {
-
-  // TODO: adapt following line when issue #23 of ng-core is closed
-  private pathArray = window.location.pathname.split('/');
-
   @Input()
   record: any;
-
-  // TODO: adapt following line when issue #23 of ng-core is closed
-  public view = this.pathArray[1];
+  detailUrl: string;
 
   constructor() { }
 

--- a/projects/public-search/src/app/record/aggregation-filter.ts
+++ b/projects/public-search/src/app/record/aggregation-filter.ts
@@ -22,13 +22,13 @@ export class AggregationFilter {
   static translateService: TranslateService;
 
   static filter(aggregations: object): Observable<any> {
-    const Obs = new Observable((observer: Subscriber<any>): void => {
+    const obs = new Observable((observer: Subscriber<any>): void => {
       observer.next(AggregationFilter.aggregationFilter(aggregations));
       AggregationFilter.translateService.onLangChange.subscribe(() => {
         observer.next(AggregationFilter.aggregationFilter(aggregations));
       });
     });
-    return Obs;
+    return obs;
   }
 
   static aggregationFilter(aggregations: object) {

--- a/tslint.json
+++ b/tslint.json
@@ -75,6 +75,13 @@
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true
+    "use-pipe-transform-interface": true,
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "check-format",
+        "allow-leading-underscore"
+      ]
+    }
   }
 }


### PR DESCRIPTION
BETTER: Replaces hard coded redirection to detailed views.

## How to test on localhost:4200
`npm install`
`npm run start-public-search-proxy --open`

## Check
Record titles should link to corresponding `viewcode/documents/pid`
Person name should redirect to corresponding `viewcode/persons/pid`