### PR TITLE
public-search: repare detail links

### DIFF
--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -24,7 +24,7 @@
     </div>
     <div class="card-body w-100 py-0">
       <h4 class="card-title mb-1">
-        <a target="_self" href="/{{ detailUrl }}">{{ record.metadata.title }}</a>
+        <a target="_self" [routerLink]="[detailUrl.link]">{{ record.metadata.title }}</a>
       </h4>
       <article class="card-text">
         <!-- author -->

--- a/projects/public-search/src/app/document-brief/document-brief.component.spec.ts
+++ b/projects/public-search/src/app/document-brief/document-brief.component.spec.ts
@@ -24,6 +24,8 @@ import { BioInformationsPipe } from './../pipes/bio-informations.pipe';
 import { DocumentBriefComponent } from './document-brief.component';
 import { HttpClientModule } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
+import { AppRoutingModule } from '../app-routing.module';
+import { PersonBriefComponent } from '../person-brief/person-brief.component';
 
 describe('DocumentBriefComponent', () => {
   let component: DocumentBriefComponent;
@@ -31,8 +33,19 @@ describe('DocumentBriefComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DocumentBriefComponent, MefTitlePipe, BirthDatePipe, BioInformationsPipe ],
-      imports: [ RecordModule, HttpClientModule, TranslateModule.forRoot() ]
+      declarations: [
+        DocumentBriefComponent,
+        MefTitlePipe,
+        BirthDatePipe,
+        BioInformationsPipe,
+        PersonBriefComponent
+      ],
+      imports: [
+        RecordModule,
+        HttpClientModule,
+        TranslateModule.forRoot(),
+        AppRoutingModule
+      ]
     })
     .compileComponents();
   }));

--- a/projects/public-search/src/app/person-brief/person-brief.component.html
+++ b/projects/public-search/src/app/person-brief/person-brief.component.html
@@ -16,7 +16,7 @@
 -->
 <div *ngIf="record">
 <h5 class="card-title mb-0 rero-ils-person">
-  <a href="{{ detailUrl }}">{{record.metadata | mefTitle}}</a>
+  <a [routerLink]="[detailUrl.link]">{{record.metadata | mefTitle}}</a>
   <small *ngIf="record.metadata.rero" class="badge badge-secondary ml-1">RERO</small>
   <small *ngIf="record.metadata.gnd" class="badge badge-secondary ml-1">GND</small>
   <small *ngIf="record.metadata.bnf" class="badge badge-secondary ml-1">BNF</small>

--- a/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
+++ b/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
@@ -21,6 +21,11 @@ import { MefTitlePipe } from './../pipes/mef-title.pipe';
 import { BirthDatePipe } from './../pipes/birth-date.pipe';
 import { BioInformationsPipe } from './../pipes/bio-informations.pipe';
 import { PersonBriefComponent } from './person-brief.component';
+import { AppRoutingModule } from 'projects/admin/src/app/app-routing.module';
+import { FrontpageComponent } from 'projects/admin/src/app/frontpage/frontpage.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientModule } from '@angular/common/http';
+import { RecordModule } from '@rero/ng-core';
 
 describe('PersonBriefComponent', () => {
   let component: PersonBriefComponent;
@@ -28,7 +33,20 @@ describe('PersonBriefComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PersonBriefComponent, MefTitlePipe, BirthDatePipe, BioInformationsPipe ]
+      declarations: [
+        PersonBriefComponent,
+        MefTitlePipe,
+        BirthDatePipe,
+        BioInformationsPipe,
+        FrontpageComponent
+      ],
+      imports:
+      [
+        RecordModule,
+        HttpClientModule,
+        TranslateModule.forRoot(),
+        AppRoutingModule
+      ]
     })
     .compileComponents();
   }));


### PR DESCRIPTION
* BETTER Repares documents and persons detail links.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Implements task 1184 of US 987

## How to test?

- Clone the PR
- If needed: `npm install`
- `npm run start-public-search-proxy` (needs localhost:5000 to be served in https and login as admin or system librarian)
- Go to public search view
- On mouse hover on documents or persons link, the url should not be Object[Object] anymore but the corresponding url to access detail page on rero-ils.

### To test on rero-ils :

After cloning this PR:
- `npm pack`
- Go to assets folder of rero-ils instance
- `npm install [path/to/rero-ils-ui.tgz]`
-  Go to public search view
- Click on documents or persons links and check that navigation is successful

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?