### PR TITLE
public-search: implement proxy rules for detail views

### DIFF
--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -24,7 +24,7 @@
     </div>
     <div class="card-body w-100 py-0">
       <h4 class="card-title mb-1">
-        <a target="_self" [routerLink]="[detailUrl.link]">{{ record.metadata.title }}</a>
+        <a target="_self" [href]="detailUrl.link">{{ record.metadata.title }}</a>
       </h4>
       <article class="card-text">
         <!-- author -->

--- a/projects/public-search/src/app/person-brief/person-brief.component.html
+++ b/projects/public-search/src/app/person-brief/person-brief.component.html
@@ -16,7 +16,7 @@
 -->
 <div *ngIf="record">
 <h5 class="card-title mb-0 rero-ils-person">
-  <a [routerLink]="[detailUrl.link]">{{record.metadata | mefTitle}}</a>
+  <a [href]="detailUrl.link">{{record.metadata | mefTitle}}</a>
   <small *ngIf="record.metadata.rero" class="badge badge-secondary ml-1">RERO</small>
   <small *ngIf="record.metadata.gnd" class="badge badge-secondary ml-1">GND</small>
   <small *ngIf="record.metadata.bnf" class="badge badge-secondary ml-1">BNF</small>

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -35,13 +35,67 @@
       "^/api": "https://localhost:5000/lang"
     }
   },
-  "/static/images/*": {
+  "/static/*": {
     "target": "https://localhost:5000",
     "secure": false,
     "logLevel": "debug",
     "changeOrigin": true,
     "pathRewrite": {
-      "^/static/images": "https://localhost:5000/static/images"
+      "^/static": "https://localhost:5000/static"
+    }
+  },
+  "/global/documents/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/global/documents": "https://localhost:5000/global/documents"
+    }
+  },
+  "/aoste/documents/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/aoste/documents": "https://localhost:5000/aoste/documents"
+    }
+  },
+  "/highlands/documents/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/highlands/documents": "https://localhost:5000/highlands/documents"
+    }
+  },
+  "/global/persons/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/global/persons": "https://localhost:5000/global/persons"
+    }
+  },
+  "/aoste/persons/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/aoste/persons": "https://localhost:5000/aoste/persons"
+    }
+  },
+  "/highlands/persons/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/highlands/persons": "https://localhost:5000/highlands/persons"
     }
   }
 }


### PR DESCRIPTION
* Adds proxy rules for documents and persons detail views.
* Adapt html templates accordingly.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To fix links to documents and persons detail views with proxy configuration.
Part of https://github.com/rero/rero-ils-ui/issues/43.

## How to test?

Got to documents and persons brief views and test links.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?