### PR TITLE
public-search: show the search input for persons

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@cospired/i18n-iso-languages": "^2.0.5",
     "@ngx-translate/core": "^11.0.1",
     "@ngx-translate/http-loader": "^4.0.0",
-    "@rero/ng-core": "^0.0.17",
+    "@rero/ng-core": "^0.0.18",
     "angular-datatables": "^8.0.0",
     "angular6-json-schema-form": "^7.3.0",
     "bootstrap": "^4.3.1",

--- a/projects/public-search/src/app/app-routing.module.ts
+++ b/projects/public-search/src/app/app-routing.module.ts
@@ -68,7 +68,8 @@ const routes: Routes = [
           key: _('persons'),
           component: PersonBriefComponent,
           label: _('Persons'),
-          aggregationsExpand: ['sources']
+          aggregationsExpand: ['sources'],
+          showSearchInput: true
         }
       ]
     }
@@ -101,7 +102,8 @@ const routes: Routes = [
           key: _('persons'),
           component: PersonBriefComponent,
           label: _('Persons'),
-          aggregationsExpand: ['sources']
+          aggregationsExpand: ['sources'],
+          showSearchInput: true
         }
       ]
     }
@@ -134,7 +136,8 @@ const routes: Routes = [
           key: _('persons'),
           component: PersonBriefComponent,
           label: _('Persons'),
-          aggregationsExpand: ['sources']
+          aggregationsExpand: ['sources'],
+          showSearchInput: true
         }
       ]
     }
@@ -167,7 +170,8 @@ const routes: Routes = [
           key: _('persons'),
           component: PersonBriefComponent,
           label: _('Persons'),
-          aggregationsExpand: ['sources']
+          aggregationsExpand: ['sources'],
+          showSearchInput: true
         }
       ]
     }


### PR DESCRIPTION
* Enables the search input on all the public-views persons tabs.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

- To fix: rero/rero-ils-ui#43. Persons search input visibility.

__Note:__ This depend to a new ng-core release. Needs the following PR: https://github.com/rero/ng-core/pull/76

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
