### PR TITLE
editor: fix post when cancelling

### DIFF
--- a/projects/admin/src/app/record/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
+++ b/projects/admin/src/app/record/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.html
@@ -270,7 +270,7 @@
 
     <div class="clearfix">
       <div class="btn-group float-right" role="group" aria-label="Form Button">
-        <button type="cancel" class="btn btn-warning" (click)="onCancel()" translate>Cancel</button>
+        <button class="btn btn-warning" (click)="onCancel($event)" translate>Cancel</button>
         <button type="submit" class="btn btn-success" [disabled]="circulationForm.invalid" translate>Submit</button>
       </div>
     </div>

--- a/projects/admin/src/app/record/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.ts
+++ b/projects/admin/src/app/record/custom-editor/circulation-settings/circulation-policy/circulation-policy.component.ts
@@ -214,7 +214,8 @@ export class CirculationPolicyComponent implements OnInit {
         this.circulationPolicyService.save(this.circulationPolicy);
       }
 
-      onCancel() {
+      onCancel(event) {
+        event.preventDefault();
         this.location.back();
       }
 

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.html
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.html
@@ -163,7 +163,7 @@
   </tabset>
   <div class="clearfix">
     <div class="btn-group float-right" role="group" aria-label="Basic example">
-      <button type="cancel" class="btn btn-warning" (click)="onCancel()" translate>Cancel</button>
+      <button class="btn btn-warning" (click)="onCancel($event)" translate>Cancel</button>
       <button type="submit" class="btn btn-success" [disabled]="libForm.invalid" translate>Submit</button>
     </div>
   </div>

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
@@ -115,7 +115,8 @@ export class LibraryComponent implements OnInit {
     this.libraryForm.reset();
   }
 
-  onCancel() {
+  onCancel(event) {
+    event.preventDefault();
     this.location.back();
     this.libraryForm.reset();
   }


### PR DESCRIPTION
* Disables POST when clicking on cancel button (prevent default).

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Why are you opening this PR?

Part of https://github.com/rero/rero-ils-ui/issues/43:
29. New circulation policies > Cancel. Got a an error: rero_ils_admin_ui.4706512e.js:2 POST https://ilsdev.test.rero.ch/api/circ_policies/ 400 (BAD REQUEST) on console.log.

## How to test?

Go to the ci-po or the library editor and click on cancel button. There should be no POST any more.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
