### PR TITLE
ui: link to rero-ils

### DIFF
--- a/projects/admin/src/app/menu/menu.component.html
+++ b/projects/admin/src/app/menu/menu.component.html
@@ -16,7 +16,7 @@
 -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark d-flex">
   <div class="container">
-    <a routerLink="/" class="navbar-brand pr-2 text-sm">
+    <a href="/" class="navbar-brand pr-2 text-sm">
       RERO ILS
     </a>
     <ng-core-autocomplete


### PR DESCRIPTION
* Replaces the link of the logo to go back to public view from admin ui.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To allow users to go to the public view from the admin ui.

## How to test?

`npm run pack`
`cd INVENIO_INSTANCE_PATH/static` (rero-ils)
`npm install path/to/rero-ils-ui//rero-rero-ils-ui-x.x.x.tgz`
Go to localhost:5000/professional
Click on RERO ILS logo
You should go back to Rero Ils home page (not admin home page).

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
