### PR TITLE
git: publish on github registry

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,32 @@
+name: GPR publication
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+          scope: '@rero-test'
+      - name: GIT setup
+        run: |
+          git config --global user.email "<software@rero.ch>"
+          git config --global user.name "RERO"
+      - run: npm ci
+      - run: npm version prerelease --preid=$(cut -c1-7 <<< $GITHUB_SHA) --allow-same-version
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://npm.pkg.github.com/rero
+registry=https://registry.npmjs.com/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rero/rero-ils-ui"
+    "url": "https://github.com/rero/rero-ils-ui.git"
   },
   "description": "User interface for RERO integrated library system (RERO ILS).",
   "keywords": [


### PR DESCRIPTION
* Adds config file to automate publication on Github Package Registry.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To automate testing using published package.

## How to test?

N/A

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
