### PR TITLE
circulation: set focus in input search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -601,9 +601,9 @@
       }
     },
     "@rero/ng-core": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.0.27.tgz",
-      "integrity": "sha512-sGMdET0m/m110QhgLst89VMhGPPYsW9bDXAD0arkc2RVHDtuZMvCdtIoOpjc3aLo3LOfMBO4G8/XcZbQFSa7BQ==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.0.29.tgz",
+      "integrity": "sha512-bzDFRVYUUw4Dg6kOJrJHEo94vAHdGL4ClfbEXeI9TkpQCdrAIjEDZiE0uZwezcBZIRDHrQf8Jjwzxm867Uk99g==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ngx-formly/core": "^5.5.10",
     "@ngx-translate/core": "^11.0.1",
     "@ngx-translate/http-loader": "^4.0.0",
-    "@rero/ng-core": "^0.0.27",
+    "@rero/ng-core": "0.0.29",
     "bootstrap": "^4.3.1",
     "crypto-js": "^3.1.9-1",
     "document-register-element": "^1.7.2",

--- a/projects/admin/src/app/circulation/item/item.component.html
+++ b/projects/admin/src/app/circulation/item/item.component.html
@@ -14,61 +14,65 @@
    You should have received a copy of the GNU Affero General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ng-container *ngIf="item">
-  <!-- BARCODE -->
-  <div class="col-lg-3">
-    <button type="button" class="pl-0 pt-0 btn" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed"
-      aria-controls="collapse">
-      <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }" class="fa" aria-hidden="true"></i>
-    </button>
-    <a [routerLink]="['/records','items','detail', item.pid]">{{ item.barcode }}</a>
-  </div>
-  <!-- TITLE -->
-  <div class="col-lg-6"><a [routerLink]="['/records','documents','detail', item.document.pid]">{{ item.document.title | truncateText: 12 }}</a>
-  </div>
-  <!-- CIRCULATION INFO -->
-  <div class="col-lg-3">
-    <ul class="list-unstyled mb-0">
-      <ng-container [ngSwitch]="item.status">
-        <li *ngSwitchCase="'on_loan'">{{ item.status | translate }} <i class="fa fa-arrow-right" aria-hidden="true"></i>
-          {{ item.loan.dueDate | dateTranslate :'shortDate' }}</li>
-        <li *ngSwitchCase="'in_transit'">{{ item.status | translate }} (to
-          {{ getTransitLocationPid(item) | getRecord: 'locations' : 'field' : 'code' | async }})</li>
-        <li *ngSwitchCase="'on_shelf'">{{ item.status | translate }}</li>
-        <li *ngSwitchDefault>{{ item.status | translate }}</li>
-      </ng-container>
-      <!-- RENEWALS, FEES, REQUESTS -->
-      <li>
-        <span title="{{'Renewals' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="item.loan && item.loan.extension_count">
-          {{ item.loan.extension_count }} <i class="fa fa-refresh"></i>
-        </span>
-        <span title="{{'Fees' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="totalAmountOfFee > 0">
-          {{ totalAmountOfFee | currency: organisation.default_currency }}</span>
-        <span title="{{'Requests' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="item.pending_loans && item.pending_loans.length">
-          {{ item.pending_loans.length }} <i class="fa fa-exclamation-circle"></i>
-        </span>
-      </li>
-    </ul>
-  </div>
-  <!-- COLLAPSED DETAILS -->
-  <div class="col-sm-6 mt-2">
-    <ul class="list-unstyled mb-0" id="collapse" [collapse]="isCollapsed" [isAnimated]="true">
-      <li>{{ 'Location' | translate }}:
-        {{ item.loan.pickup_location_pid | getRecord: 'locations' : 'field' : 'code' | async }} {{ item.location.name }}
-      </li>
-      <li *ngIf="item.loan && item.loan.extension_count">{{ 'Renewals' | translate }}: {{ item.loan.extension_count }}
-      </li>
-      <li *ngIf="totalAmountOfFee > 0">{{ 'Fees' | translate }}:
-        {{ totalAmountOfFee | currency: organisation.default_currency }}</li>
-      <li *ngIf="notifications && notifications.length > 0">{{ 'Notifications' | translate }}:
-        <ul class="list-unstyled pl-2 mb-0">
-          <li *ngFor="let notification of notifications">
-            {{ notification.metadata.process_date | dateTranslate :'shortDate' }}:
-            {{ notification.metadata.notification_type | translate}}</li>
-        </ul>
-      </li>
-      <li *ngIf="item.pending_loans">{{ 'Requests' | translate }}: {{ item.pending_loans.length }}</li>
-      <li *ngIf="item.pending_loans">{{ 'For' | translate }}: {{ item.pending_loans[0].patron.name }}</li>
-    </ul>
-  </div>
-</ng-container>
+  <div [ngClass]="{'border-danger': patronLoan && (item.status === 'in_transit' || item.pending_loans || totalAmountOfFee > 0),
+    'text-secondary': item.status !== 'on_loan'}"
+ class="row p-2 mb-1 border rounded align-middle"  *ngIf="item">
+   <!-- BARCODE -->
+   <div class="col-lg-3">
+     <button type="button" class="pl-0 pt-0 btn" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed"
+       aria-controls="collapse">
+       <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }" class="fa" aria-hidden="true"></i>
+     </button>
+     <a [routerLink]="['/records','items','detail', item.pid]">{{ item.barcode }}</a>
+   </div>
+   <!-- TITLE -->
+   <div class="col-lg-6"><a [routerLink]="['/records','documents','detail', item.document.pid]">{{ item.document.title | truncateText: 12 }}</a>
+   </div>
+   <!-- CIRCULATION INFO -->
+   <div class="col-lg-3">
+     <ul class="list-unstyled mb-0">
+       <ng-container [ngSwitch]="item.status">
+         <li *ngSwitchCase="'on_loan'">{{ item.status | translate }} <i class="fa fa-arrow-right" aria-hidden="true"></i>
+           {{ item.loan.dueDate | dateTranslate :'shortDate' }}</li>
+         <li *ngSwitchCase="'in_transit'">{{ item.status | translate }} (to
+           {{ getTransitLocationPid(item) | getRecord: 'locations' : 'field' : 'code' | async }})</li>
+         <li *ngSwitchCase="'on_shelf'">{{ item.status | translate }}</li>
+         <li *ngSwitchDefault>{{ item.status | translate }}</li>
+       </ng-container>
+       <!-- RENEWALS, FEES, REQUESTS -->
+       <li>
+         <span title="{{'Renewals' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="item.loan && item.loan.extension_count">
+           {{ item.loan.extension_count }} <i class="fa fa-refresh"></i>
+         </span>
+         <span title="{{'Fees' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="totalAmountOfFee > 0">
+           {{ totalAmountOfFee | currency: organisation.default_currency }}</span>
+         <span title="{{'Requests' | translate }}" class="badge badge-secondary font-weight-normal mr-1" *ngIf="item.pending_loans && item.pending_loans.length">
+           {{ item.pending_loans.length }} <i class="fa fa-exclamation-circle"></i>
+         </span>
+       </li>
+     </ul>
+   </div>
+   <!-- COLLAPSED DETAILS -->
+   <div class="col-sm-6 mt-2">
+     <ul class="list-unstyled mb-0" id="collapse" [collapse]="isCollapsed" [isAnimated]="true">
+       <li>{{ 'Location' | translate }}:
+         {{ item.loan.pickup_location_pid | getRecord: 'locations' : 'field' : 'code' | async }} {{ item.location.name }}
+       </li>
+       <li *ngIf="item.loan && item.loan.extension_count">{{ 'Renewals' | translate }}: {{ item.loan.extension_count }}
+       </li>
+       <li *ngIf="totalAmountOfFee > 0">{{ 'Fees' | translate }}:
+         {{ totalAmountOfFee | currency: organisation.default_currency }}</li>
+       <ng-container *ngIf="notifications$ | async as notifications">
+         <li *ngIf="notifications.length > 0">{{ 'Notifications' | translate }}:
+           <ul class="list-unstyled pl-2 mb-0">
+             <li *ngFor="let notification of notifications">
+               {{ notification.metadata.process_date | dateTranslate :'shortDate' }}:
+               {{ notification.metadata.notification_type | translate}}</li>
+           </ul>
+         </li>
+       </ng-container>
+       <li *ngIf="item.pending_loans">{{ 'Requests' | translate }}: {{ item.pending_loans.length }}</li>
+       <li *ngIf="item.pending_loans">{{ 'For' | translate }}: {{ item.pending_loans[0].patron.name }}</li>
+     </ul>
+   </div>
+ </div>

--- a/projects/admin/src/app/circulation/items-list/items-list.component.html
+++ b/projects/admin/src/app/circulation/items-list/items-list.component.html
@@ -42,8 +42,7 @@
   <div class="row align-items-start" *ngFor="let item of checkedOutItems">
     <!-- CONTENT -->
     <div class="col mr-1">
-      <admin-item [patron]="patron" [item]="item" class="row p-2 mb-1 border rounded align-middle"
-        (hasFees)="hasFees($event)">
+      <admin-item [patron]="patron" [item]="item">
       </admin-item>
     </div>
     <div *ngIf="patron" class="col-md-2 text-left pl-0 mb-2">
@@ -75,9 +74,7 @@
   <!-- CHECKED IN ITEMS  : RED BORDER FOR TRANSIT, REQUEST OR FEE | GREYED BY DEFAULT-->
   <div class="row align-items-start" *ngFor="let item of checkedInItems">
     <div class="col">
-      <admin-item [patron]="patron" [item]="item"
-        [ngClass]="{'border-danger': item.status === 'in_transit' || item.pending_loans || hasFees($event)}"
-        class="row p-2 mb-1 border border-secondary rounded align-middle text-secondary" (hasFees)="hasFees($event)">
+      <admin-item [patron]="patron" [item]="item">
       </admin-item>
     </div>
     <div *ngIf="patron" class="col-md-2">

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.html
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.html
@@ -22,6 +22,7 @@
         [placeholder]="placeholder | translate"
         [searchText]="searchText"
         (search)="searchValueUpdated($event)"
+        [focus]="searchInputFocus"
       ></ng-core-search-input>
     </div>
   </div>

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -47,6 +47,9 @@ export class LoanComponent implements OnInit {
   /** List of checked in items */
   public checkedInItems = [];
 
+  /** Focus attribute of the search input */
+  searchInputFocus = false;
+
   /**
    * Constructor
    * @param itemsService: Items Service
@@ -73,6 +76,7 @@ export class LoanComponent implements OnInit {
         });
       }
     });
+    this.searchInputFocus = true;
   }
 
   /** Search value with search input
@@ -131,6 +135,7 @@ export class LoanComponent implements OnInit {
    * @param items: checked in and checked out items
    */
   applyItems(items: Item[]) {
+    this.searchInputFocus = false;
     const observables = [];
     for (const item of items) {
       if (item.currentAction !== ItemAction.no) {
@@ -159,7 +164,7 @@ export class LoanComponent implements OnInit {
           }
         });
         this.searchText = '';
-        // TODO set focus in search input (enhancement, needs to adapt ng-core)
+        this.searchInputFocus = true;
       },
       err => {
         let errorMessage = '';


### PR DESCRIPTION
* Sets focus on search input after actions.
* Fixes "hasFees" condition to highlight the checked in items.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1272?kanban-status=1224895

## How to test?

Needs https://github.com/rero/ng-core/pull/122
Go to on loan tab of circulation ui.
Do some actions (checkin, checkout, renewal).
Focus should be set on search input after each action.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
