### PR TITLE
circulation: set focus on search input

### DIFF
--- a/projects/admin/src/app/circulation/checkout/checkout.component.html
+++ b/projects/admin/src/app/circulation/checkout/checkout.component.html
@@ -22,6 +22,7 @@
         [placeholder]="placeholder | translate"
         [searchText]="searchText"
         (search)="searchValueUpdated($event)"
+        [focus]="searchInputFocus"
       ></ng-core-search-input>
     </div>
     <div class="col col-md-6 mb-4">

--- a/projects/admin/src/app/circulation/checkout/checkout.component.ts
+++ b/projects/admin/src/app/circulation/checkout/checkout.component.ts
@@ -46,6 +46,9 @@ export class CheckoutComponent implements OnInit {
     return this._itemsList;
   }
 
+  /** Focus attribute of the search input */
+  searchInputFocus = false;
+
   /** Constructor
    * @param  userService: User Service
    * @param  recordService: Record Service
@@ -70,6 +73,7 @@ export class CheckoutComponent implements OnInit {
     this.patronService.currentPatron$.subscribe(
       patron => (this.patronInfo = patron)
     );
+    this.searchInputFocus = true;
   }
 
   /** Search value with search input
@@ -87,6 +91,7 @@ export class CheckoutComponent implements OnInit {
    * @param itemBarcode: item barcode
    */
   automaticCheckinCheckout(itemBarcode) {
+    this.searchInputFocus = false;
     this.itemsService.automaticCheckin(itemBarcode).subscribe(item => {
       // TODO: remove this when policy will be in place
       if (
@@ -121,6 +126,7 @@ export class CheckoutComponent implements OnInit {
       }
       this._itemsList.unshift(item);
       this.searchText = '';
+      this.searchInputFocus = true;
     });
   }
 


### PR DESCRIPTION
* Sets focus on search input on init and after actions.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To complete https://tree.taiga.io/project/rero21-reroils/task/1272?kanban-status=1224897

## How to test?

Go to User services ->Circulation: the focus should be set on search input.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
