### PR TITLE
document: display library name instead of code

### DIFF
--- a/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.html
+++ b/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.html
@@ -24,7 +24,7 @@
   </div>
   <!-- PICKUP LOCATION -->
   <div class="col-sm-3">
-    {{ loan.metadata.pickup_location_pid | getRecord:'locations':'field':'name' | async }}
+    {{ loan.metadata.pickup_location_pid | getRecord: 'locations' : 'field' : 'name' | async }}
   </div>
   <div class="col-sm-2">
     &nbsp;

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-item/holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-item/holding-item.component.html
@@ -12,39 +12,38 @@
    GNU Affero General Public License for more details.
   
    You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="item && permissions">
-<div class="col-sm-4">
-  <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
-    {{ item.metadata.barcode }}
-  </a>
-</div>
-<div class="col-sm-2">
-  {{ item.metadata.status | translate }}
-</div>
-<div class="col-sm-2">
-  {{ item.metadata.call_number }}
-</div>
-<div class="col-sm-4 text-right">
-  <ng-container *ngIf="isAvailableActions; else noactions">
-    <button *ngIf="permissions.update.can" type="button" class="btn btn-primary btn-sm"
-      [routerLink]="['/records', 'items', 'edit', item.metadata.pid]">
-      <i class="fa fa-pencil"></i> {{ 'Edit' | translate }}
-    </button>
-
-    <button *ngIf="permissions.delete.can; else notDelete" type="button" class="btn btn-primary btn-sm ml-1"
-      (click)="delete(item.metadata.pid)">
-      <i class="fa fa-trash"></i> {{ 'Delete' | translate }}
-    </button>
-    <ng-template #notDelete>
-      <button type="button" class="btn btn-dark btn-sm ml-1" (click)="showDeleteMessage()">
+  <div class="offset-sm-1 col-sm-3">
+    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
+      {{ item.metadata.barcode }}
+    </a>
+  </div>
+  <div class="col-sm-2">
+    {{ item.metadata.status | translate }}
+  </div>
+  <div class="col-sm-2">
+    {{ item.metadata.call_number }}
+  </div>
+  <div class="col-sm-4 text-right">
+    <ng-container *ngIf="isAvailableActions; else noactions">
+      <button *ngIf="permissions.update.can" type="button" class="btn btn-primary btn-sm"
+        [routerLink]="['/records', 'items', 'edit', item.metadata.pid]">
+        <i class="fa fa-pencil"></i> {{ 'Edit' | translate }}
+      </button>
+      <button *ngIf="permissions.delete.can; else notDelete" type="button" class="btn btn-primary btn-sm ml-1"
+        (click)="delete(item.metadata.pid)">
         <i class="fa fa-trash"></i> {{ 'Delete' | translate }}
       </button>
+      <ng-template #notDelete>
+        <button type="button" class="btn btn-dark btn-sm ml-1" (click)="showDeleteMessage()">
+          <i class="fa fa-trash"></i> {{ 'Delete' | translate }}
+        </button>
+      </ng-template>
+    </ng-container>
+    <ng-template #noactions>
+      &nbsp;
     </ng-template>
-  </ng-container>
-  <ng-template #noactions>
-    &nbsp;
-  </ng-template>
-</div>
+  </div>
 </ng-container>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -15,46 +15,42 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="(items && items.length > 0) || (harvested &&  holding.metadata?.electronic_location?.length > 0)">
-    <div class="card mt-2">
-        <div class="card-header">
-          <div class="row">
-            <div class="col-sm-4">
-              <ng-container *ngIf="this.holding.metadata.location.pid | getRecord:'locations' | async as location">
-                <button class="btn btn-link" (click)="toggleCollapse()" aria-expanded="false" aria-controls="itemsList">
-                  <i [ngClass]="{ 'fa-caret-down':!isItemsCollapsed, 'fa-caret-right': isItemsCollapsed }" class="fa"
-                    aria-hidden="true"></i>
-                </button>
-                {{ location.metadata.code }}: {{ location.metadata.name }}
-              </ng-container>
-            </div>
-            <div class="col-sm-2">
-              {{ holding.metadata.circulation_category.pid | getRecord: 'item_types' : 'field' : 'name' | async }}
-            </div>
-          </div>
+  <div class="card mt-2">
+    <div class="card-header">
+      <div class="row">
+        <div class="col-sm-1">
+          <button class="btn btn-link" (click)="toggleCollapse()" aria-expanded="false" aria-controls="itemsList">
+            <i [ngClass]="{ 'fa-caret-down':!isItemsCollapsed, 'fa-caret-right': isItemsCollapsed }" class="fa"
+              aria-hidden="true"></i>
+          </button>
         </div>
-        <div class="card-body" *ngIf="!isItemsCollapsed">
-            <div class="row" *ngIf="!harvested">
-                <div class="col-sm-4 font-weight-bold" translate>Barcode</div>
-                <div class="col-sm-2 font-weight-bold" translate>Status</div>
-                <div class="col-sm-2 font-weight-bold" translate>Call number</div>
-            </div>
-          <div class="row" *ngIf="harvested">
-            <ul class="list-unstyled mb-0 col-sm-auto">
-              <li *ngFor="let elocation of holding.metadata.electronic_location">
-                <a href="{{ elocation.uri | translate }}">{{ elocation.source | translate }}</a>
-              </li>
-            </ul>
-          </div>
-          <ng-container *ngIf="items && items.length > 0">
-            <admin-holding-item
-              *ngFor="let item of items"
-              class="row mt-1"
-              [holding]="holding"
-              [item]="item"
-              (deleteItem)="deleteItem($event)">
-            </admin-holding-item>
-          </ng-container>
+        <div *ngIf="holding.metadata.location.pid | getRecord: 'locations' | async as location" class="col-sm-3">
+          {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}:
+          {{ location.metadata.name }}
+        </div>
+        <div class="col-sm-2">
+          {{ holding.metadata.circulation_category.pid | getRecord: 'item_types' : 'field' : 'name' | async }}
         </div>
       </div>
+    </div>
+    <div class="card-body" *ngIf="!isItemsCollapsed">
+      <div class="row" *ngIf="!harvested">
+        <div class="offset-sm-1 col-sm-3 font-weight-bold" translate>Barcode</div>
+        <div class="col-sm-2 font-weight-bold" translate>Status</div>
+        <div class="col-sm-2 font-weight-bold" translate>Call number</div>
+      </div>
+      <div class="row" *ngIf="harvested">
+        <ul class="list-unstyled mb-0 col-sm-auto">
+          <li *ngFor="let elocation of holding.metadata.electronic_location">
+            <a href="{{ elocation.uri | translate }}">{{ elocation.source | translate }}</a>
+          </li>
+        </ul>
+      </div>
+      <ng-container *ngIf="items && items.length > 0">
+        <admin-holding-item *ngFor="let item of items" class="row mt-1" [holding]="holding" [item]="item"
+          (deleteItem)="deleteItem($event)">
+        </admin-holding-item>
+      </ng-container>
+    </div>
+  </div>
 </ng-container>
-


### PR DESCRIPTION
* Changes the display in the document detailed view for holdings: the
library name replace the library code.
* Enhances the holdings column alignment in the document detailed view to
be more consistent with the public detailed view.
* Closes #776.

Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Should fixes #776

## How to test?

- Go to a document detailed view with holding check the holding location in the card header.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
