### PR TITLE
styles: display small badges on person search view

### DIFF
--- a/projects/admin/src/app/scss/styles.scss
+++ b/projects/admin/src/app/scss/styles.scss
@@ -88,9 +88,9 @@ json-schema-form {
   a.collapsed i.fa-caret-down {
     transform: rotate(-90deg);
   }
+}
 
-  .rero-ils-person small {
-    font-size: $font-size-very-small;
-    vertical-align: top;
-  }
+.rero-ils-person small {
+  font-size: $font-size-very-small;
+  vertical-align: top;
 }


### PR DESCRIPTION
* Fixes css file to display small badges on person search view
* Closes #169

## How to test?

- Log in as a librarian.
- Display the professional person search view.
- Badges should be small as expected

before
![image](https://user-images.githubusercontent.com/10031585/74935435-878e7600-53e8-11ea-8e09-229503b32121.png)

after
![image](https://user-images.githubusercontent.com/10031585/74935217-2d8db080-53e8-11ea-851c-1cee460e1ca2.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
