### PR TITLE
document: fix cover image in brief view

### DIFF
--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -18,7 +18,12 @@
 <article *ngIf="record" class="card flex-row border-0">
     <div class="align-self-start d-flex justify-content-center">
       <figure class="mb-0 thumb-brief">
-        <img class="img-responsive border border-light " [src]="coverUrl">
+        <ng-container *ngIf="record.metadata.cover_art; else noLink">
+          <a href="coverUrl"><img class="img-responsive border border-light " [src]="coverUrl"></a>
+        </ng-container>
+        <ng-template #noLink>
+          <img class="img-responsive border border-light " [src]="coverUrl">
+        </ng-template>
         <figcaption class="text-center">{{ record.metadata.type | translate }}</figcaption>
       </figure>
     </div>

--- a/projects/public-search/src/app/translate/loader/translate-loader.ts
+++ b/projects/public-search/src/app/translate/loader/translate-loader.ts
@@ -22,7 +22,9 @@ import fr from '../i18n/fr.json';
 import de from '../i18n/de.json';
 import en from '../i18n/en.json';
 import it from '../i18n/it.json';
+import { Injectable } from '@angular/core';
 
+@Injectable()
 export class TranslateLoader extends NgCoreTranslateLoader {
 
   /**


### PR DESCRIPTION
* Display cover image as link if electronic location type is coverImage.
Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To complete US 1262 https://tree.taiga.io/project/rero21-reroils/us/1262?milestone=257446

## How to test?

Needs https://github.com/rero/rero-ils/pull/848

1. Edit a record to add an electronic location with a type `Covert art` (suggested url: https://d2v9ipibika81v.cloudfront.net/uploads/sites/21/Africa-990x684.jpg)
1. Go to the brief view in public interface
1. Check that the cover image is a working link

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
