### PR TITLE
document: filter results by org in admin view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,9 +3041,9 @@
       }
     },
     "@rero/ng-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.1.0.tgz",
-      "integrity": "sha512-p1tcGer2kyvc7VMaIgvGD6OYeNs1yAWymTOsPo66TdSJXbghd4+L1AkE8uIAv/78Phr7U/lZi/DyD4rP9lQmpw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.2.1.tgz",
+      "integrity": "sha512-C23IL0kJFjf21X9c/yW93E82PLNrI4tyzZkQVVeA56OfUFUXlOYBp1K5VSqbVuyAvxt6FcmpQFzf13ebu4niaw==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -7324,8 +7324,7 @@
           "version": "2.1.1",
           "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7349,15 +7348,13 @@
           "version": "1.0.0",
           "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7374,22 +7371,19 @@
           "version": "1.1.0",
           "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7520,8 +7514,7 @@
           "version": "2.0.3",
           "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7535,7 +7528,6 @@
           "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7552,7 +7544,6 @@
           "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7561,15 +7552,13 @@
           "version": "0.0.8",
           "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7590,7 +7579,6 @@
           "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7679,8 +7667,7 @@
           "version": "1.0.1",
           "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7694,7 +7681,6 @@
           "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7790,8 +7776,7 @@
           "version": "5.1.2",
           "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7833,7 +7818,6 @@
           "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7855,7 +7839,6 @@
           "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7904,15 +7887,13 @@
           "version": "1.0.2",
           "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@ngx-formly/bootstrap": "^5.5.10",
     "@ngx-formly/core": "^5.5.10",
     "@ngx-translate/core": "^12.1.1",
-    "@rero/ng-core": "0.1.0",
+    "@rero/ng-core": "0.2.1",
     "bootstrap": "^4.3.1",
     "crypto-js": "^3.1.9-1",
     "document-register-element": "^1.7.2",

--- a/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
+++ b/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
@@ -22,7 +22,7 @@
   </div>
   <ul class="list-group list-group-flush" *ngIf="item.entries">
     <li class="list-group-item p-0" *ngFor="let entry of item.entries">
-      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink"><i *ngIf="entry.iconCssClass"
+      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink" [queryParams]="entry.queryParams"><i *ngIf="entry.iconCssClass"
         [ngClass]="entry.iconCssClass" aria-hidden="true"></i> {{ entry.name | translate }}</a>
     </li>
   </ul>

--- a/projects/admin/src/app/menu/menu.component.html
+++ b/projects/admin/src/app/menu/menu.component.html
@@ -23,6 +23,7 @@
     <ng-core-autocomplete
       [recordTypes]="recordTypes"
       [action]="'/records/documents'"
+      [extraQueryParams]="autocompleteQueryParams"
       [internalRouting]="true"
       class="flex-grow-1">
     </ng-core-autocomplete>

--- a/projects/admin/src/app/menu/menu.component.ts
+++ b/projects/admin/src/app/menu/menu.component.ts
@@ -39,6 +39,8 @@ export class MenuComponent implements OnInit {
 
   linksMenu: any;
 
+  autocompleteQueryParams: any = {page: '1', size: '10'};
+
   librariesSwitchMenu = {
     navCssClass: 'navbar-nav',
     entries: [{
@@ -85,6 +87,7 @@ export class MenuComponent implements OnInit {
   ngOnInit() {
     this.initLinksMenu();
     const currentUser = this._userService.getCurrentUser();
+    this.autocompleteQueryParams.organisation = currentUser.library.organisation.pid;
     this.languages = this._configService.languages;
     for (const lang of this.languages) {
       const data: any = { name: lang };
@@ -113,6 +116,7 @@ export class MenuComponent implements OnInit {
     this.recordTypes = [{
       type: 'documents',
       field: 'autocomplete_title',
+      preFilters: {organisation: currentUser.library.organisation.pid},
       getSuggestions: (query, documents) => this.getDocumentsSuggestions(query, documents)
     }, {
       type: 'persons',

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -66,7 +66,6 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               'author__en',
               'author__de',
               'author__it',
-              'library',
               'organisation',
               'language',
               'subject',

--- a/projects/admin/src/app/routes/route-tool.service.ts
+++ b/projects/admin/src/app/routes/route-tool.service.ts
@@ -65,6 +65,7 @@ export class RouteToolService {
 
   /**
    * Constructor
+   *
    * @param _translateService - TranslateService
    * @param _recordPermissionService - RecordPermissionMessageService
    * @param _userService - UserService
@@ -85,6 +86,7 @@ export class RouteToolService {
 
   /**
    * Enabled action
+   *
    * @param message - string
    * @return Observable
    */
@@ -94,6 +96,7 @@ export class RouteToolService {
 
   /**
    * Disabled action
+   *
    * @param message - string
    * @return Observable
    */
@@ -103,6 +106,7 @@ export class RouteToolService {
 
   /**
    * Access only for system librarian
+   *
    * @param message - string
    * @return Observable
    */
@@ -114,6 +118,7 @@ export class RouteToolService {
 
   /**
    * Can Add
+   *
    * @param record - Object
    * @return Observable
    */
@@ -140,6 +145,7 @@ export class RouteToolService {
 
   /**
    * Can Delete
+   *
    * @param record - Object
    * @return Observable
    */
@@ -193,6 +199,7 @@ export class RouteToolService {
 
   /**
    * Aggregation filter
+   *
    * @param aggregations - Object
    */
   aggregationFilter(aggregations: object): Observable<any> {
@@ -207,21 +214,20 @@ export class RouteToolService {
 
   /**
    * Aggregation filter
+   *
    * @param aggregations - Object
    * @return array
    */
   private aggFilter(aggregations: object) {
     const aggs = {};
     Object.keys(aggregations).map(aggregation => {
-      if ('organisation' !== aggregation) {
-        if (aggregation.indexOf('__') > -1) {
-          const splitted = aggregation.split('__');
-          if (this._translateService.currentLang === splitted[1]) {
-            aggs[aggregation] = aggregations[aggregation];
-          }
-        } else {
+      if (aggregation.indexOf('__') > -1) {
+        const splitted = aggregation.split('__');
+        if (this._translateService.currentLang === splitted[1]) {
           aggs[aggregation] = aggregations[aggregation];
         }
+      } else {
+        aggs[aggregation] = aggregations[aggregation];
       }
     });
     return aggs;
@@ -229,6 +235,7 @@ export class RouteToolService {
 
   /**
    * Get route param by name
+   *
    * @param name - string
    * @return mixed - string | null
    */

--- a/projects/admin/src/app/service/menu.service.ts
+++ b/projects/admin/src/app/service/menu.service.ts
@@ -7,6 +7,9 @@ import { UserService } from './user.service';
 })
 export class MenuService {
 
+  /**
+   * Menu content
+   */
   linksMenu = {
     navCssClass: 'navbar-nav',
     entries: [
@@ -32,6 +35,7 @@ export class MenuService {
         entries: [{
           name: this._translateService.instant('Documents'),
           routerLink: '/records/documents',
+          queryParams: this._myDocumentsQueryParams(),
           iconCssClass: 'fa fa-file-o'
         }, {
           name: this._translateService.instant('Create a bibliographic record'),
@@ -75,7 +79,7 @@ export class MenuService {
           iconCssClass: 'fa fa-users'
         }, {
           name: this._translateService.instant('My organisation'),
-          routerLink: `/records/organisations/detail/${this._userService.getCurrentUser().library.organisation.pid}`,
+          routerLink: this._myOrganisationRouterLink(),
           iconCssClass: 'fa fa-university'
         }, {
           name: this._translateService.instant('My library'),
@@ -90,12 +94,41 @@ export class MenuService {
     ]
   };
 
+  /**
+   * Constructor
+   *
+   * @param _translateService : TranslateService
+   * @param _userService : UserService
+   */
   constructor(
     private _translateService: TranslateService,
     private _userService: UserService,
   ) {}
 
+  /**
+   * Router link to my library
+   *
+   * @return logged user library url for router link
+   */
   private _myLibraryRouterLink() {
     return `/records/libraries/detail/${this._userService.getCurrentUser().currentLibrary}`;
+  }
+
+  /**
+   * Router link to my organisation
+   *
+   * @return logged user organisation url for router link
+   */
+  private _myOrganisationRouterLink() {
+    return `/records/organisations/detail/${this._userService.getCurrentUser().library.organisation.pid}`;
+  }
+
+  /**
+   * Query params to filter documents by organisation
+   *
+   * @return organisation pid as a dictionary
+   */
+  private _myDocumentsQueryParams() {
+    return {organisation: this._userService.getCurrentUser().library.organisation.pid};
   }
 }

--- a/projects/public-search/src/app/service/routing-init.service.ts
+++ b/projects/public-search/src/app/service/routing-init.service.ts
@@ -36,6 +36,7 @@ export class RoutingInitService {
 
   /**
    * Constructor
+   *
    * @param _translateService - TranslateService
    */
   constructor(
@@ -45,6 +46,7 @@ export class RoutingInitService {
 
   /**
    * Route Config
+   *
    * @param viewcode - string
    */
   routeConfig(viewcode: string) {
@@ -95,6 +97,11 @@ export class RoutingInitService {
     };
   }
 
+  /**
+   * List of aggregations
+   *
+   * @param viewcode - viewcode
+   */
   private aggregations(viewcode: string) {
     if (this._appConfigService.globalViewName === viewcode) {
       return [
@@ -124,7 +131,8 @@ export class RoutingInitService {
   }
 
   /**
-   * filter aggregations
+   * Filter aggregations
+   *
    * @return Observable
    */
   private filter(aggregations: object): Observable<any> {
@@ -139,9 +147,11 @@ export class RoutingInitService {
 
   /**
    * Aggregation filter
+   *
    * @return array of value
    */
   private aggregationFilter(aggregations: object) {
+    // TODO replace organisation facet by library facet when the viewcode is not global (needs backend adaptation)
     const aggs = {};
     Object.keys(aggregations).forEach(aggregation => {
       if (aggregation.indexOf('__') > -1) {


### PR DESCRIPTION
* Fixes display of organisation facet in dcoument brief view.
* Modifies links to documents brief view to include current organisation as a default parameter.
* Closes #140.
* Removes useless code.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1377?kanban-status=1224895

## How to test?

Needs https://github.com/rero/rero-ils/pull/852 and last version of ng-core.
### Public search
1. Go to documents brief view
1. You should have an `organisation` facet in global view
1. You should have a `library` facet in organisation views.

### Admin
1. Go to documents brief view
1. The results should be filtered by current organisation by default (test with different users).
1. You should have a hierarchical facet (`organisation` + `libraries`)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
