### PR TITLE
editor: fix uniqueness check value for locations

### DIFF
--- a/projects/admin/src/app/routes/locations-route.ts
+++ b/projects/admin/src/app/routes/locations-route.ts
@@ -48,7 +48,7 @@ export class LocationsRoute extends BaseRoute implements RouteInterface {
             canAdd: () => this._routeToolService.canSystemLibrarian(),
             canUpdate: (record: any) => this._routeToolService.canUpdate(record, this.recordType),
             canDelete: (record: any) => this._routeToolService.canDelete(record, this.recordType),
-            preCreateRecord: (record: any) => {
+            preprocessRecordEditor: (record: any) => {
               record.library = {
                 $ref: this._routeToolService.apiService.getRefEndpoint(
                   'libraries',


### PR DESCRIPTION
Several fields needs to be unique by library, such as is_online, pickup name, etc. , when a location is created
or updated. This check did not work since a refactoring.

Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Unique validation for is_online and pickup name for locations.

## How to test?

- Create or edit a new location for a library with existing online or pickup location. An error should appears when we try to create a second online location or a location with an existing pickup name.

## Note

- a validation should be done in the backend to detect frontend validation failure.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
