### PR TITLE
transactions: fix patron transaction detail display

### DIFF
--- a/projects/admin/src/app/circulation/circulation.module.ts
+++ b/projects/admin/src/app/circulation/circulation.module.ts
@@ -16,35 +16,41 @@
  */
 
 
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { RecordModule } from '@rero/ng-core';
 import { BsDropdownModule, CollapseModule } from 'ngx-bootstrap';
-import { CardComponent } from './patron/card/card.component';
 import { CheckinComponent } from './checkin/checkin.component';
 import { CirculationRoutingModule } from './circulation-routing.module';
-import { CommonModule } from '@angular/common';
-import { FormlyModule } from '@ngx-formly/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ItemComponent } from './item/item.component';
 import { ItemsListComponent } from './items-list/items-list.component';
+import { MainRequestComponent } from './main-request/main-request.component';
+import { CardComponent } from './patron/card/card.component';
 import { LoanComponent } from './patron/loan/loan.component';
 import { MainComponent } from './patron/main/main.component';
-import { MainRequestComponent } from './main-request/main-request.component';
-import { NgModule } from '@angular/core';
-import { PatronTransactionsComponent } from './patron/patron-transactions/patron-transactions.component';
 import {
-  PatronTransactionComponent
-} from './patron/patron-transactions/patron-transaction/patron-transaction.component';
+  PatronTransactionEventFormComponent
+} from './patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component';
 import {
   PatronTransactionEventComponent
 } from './patron/patron-transactions/patron-transaction-event/patron-transaction-event.component';
 import {
-  PatronTransactionEventFormComponent
-} from './patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component';
-import { PickupComponent } from './patron/pickup/pickup.component';
+  DefaultTransactionComponent
+} from './patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component';
+import {
+  OverdueTransactionComponent
+} from './patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component';
+import {
+  PatronTransactionComponent
+} from './patron/patron-transactions/patron-transaction/patron-transaction.component';
+import { PatronTransactionsComponent } from './patron/patron-transactions/patron-transactions.component';
 import { PickupItemComponent } from './patron/pickup/pickup-item/pickup-item.component';
+import { PickupComponent } from './patron/pickup/pickup.component';
 import { ProfileComponent } from './patron/profile/profile.component';
-import { RecordModule } from '@rero/ng-core';
-import { RequestedComponent } from './patron/requested/requested.component';
 import { RequestedItemComponent } from './patron/requested/requested-item/requested-item.component';
+import { RequestedComponent } from './patron/requested/requested.component';
 import { RequestedItemsListComponent } from './requested-items-list/requested-items-list.component';
 
 
@@ -66,7 +72,9 @@ import { RequestedItemsListComponent } from './requested-items-list/requested-it
     PatronTransactionsComponent,
     PatronTransactionComponent,
     PatronTransactionEventComponent,
-    PatronTransactionEventFormComponent
+    PatronTransactionEventFormComponent,
+    OverdueTransactionComponent,
+    DefaultTransactionComponent
   ],
   imports: [
     CommonModule,

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event/patron-transaction-event.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event/patron-transaction-event.component.html
@@ -43,13 +43,15 @@
           </div>
         </div>
       </ng-container>
-      <div class="row" *ngIf="event.library.pid | getRecord:'libraries' | async as library">
-        <div class="col-2 offset-1 label-title">
-          <i class="fa fa-map-marker pr-1"></i>
-          <ng-container translate>Library</ng-container>
+      <ng-container *ngIf="event.library">
+        <div class="row" *ngIf="event.library.pid | getRecord:'libraries' | async as library">
+          <div class="col-2 offset-1 label-title">
+            <i class="fa fa-map-marker pr-1"></i>
+            <ng-container translate>Library</ng-container>
+          </div>
+          <div class="col-9">{{ library.metadata.name }}</div>
         </div>
-        <div class="col-9">{{ library.metadata.name }}</div>
-      </div>
+      </ng-container>
     </ng-container>
   </div>
 </ng-container>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.html
@@ -1,0 +1,6 @@
+<ng-container *ngIf="transaction">
+  <div class="row" *ngIf="transaction.note">
+    <div class="col-sm-2 label-title text-right" translate>Note</div>
+    <div class="col-sm-10">{{ transaction.note }}</div>
+  </div>
+</ng-container>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.spec.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DefaultTransactionComponent } from './default-transaction.component';
+
+describe('DefaultTransactionComponent', () => {
+  let component: DefaultTransactionComponent;
+  let fixture: ComponentFixture<DefaultTransactionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DefaultTransactionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DefaultTransactionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/default-transaction/default-transaction.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { PatronTransaction } from '../../../../patron-transaction';
+
+@Component({
+  selector: 'admin-default-transaction',
+  templateUrl: './default-transaction.component.html'
+})
+export class DefaultTransactionComponent {
+
+  /** Patron transaction */
+  @Input() transaction: PatronTransaction;
+
+}

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.html
@@ -1,0 +1,25 @@
+<ng-container *ngIf="transaction">
+  <div class="row" *ngIf="transaction.note">
+    <div class="col-sm-2 label-title text-right" translate>Note</div>
+    <div class="col-sm-10">{{ transaction.note }}</div>
+  </div>
+  <div class="row" *ngIf="transaction.document.pid | getRecord:'documents' | async as document">
+    <div class="col-sm-2 label-title text-right" translate>Document</div>
+    <div class="col-sm-10">
+      <a [routerLink]="['/records','documents','detail', transaction.document.pid]"
+         *ngIf="getMainTitle(document.metadata.title) != null">
+        {{ getMainTitle(document.metadata.title) | truncateText: 15 }}
+      </a>
+    </div>
+  </div>
+  <div class="row" *ngIf="item">
+    <div class="col-sm-2 label-title text-right" translate>Item</div>
+    <div class="col-sm-10">
+      <a [routerLink]="['/records','items','detail', item.pid]">{{ item.barcode }}</a>
+    </div>
+  </div>
+  <div class="row" *ngIf="transaction.loan.pid | getRecord: 'loans' | async as loan">
+    <div class="col-sm-2 label-title text-right" translate>Loan started at</div>
+    <div class="col-sm-10">{{ loan.metadata.start_date | dateTranslate: 'shortDate' }}</div>
+  </div>
+</ng-container>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.spec.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.spec.ts
@@ -1,0 +1,36 @@
+import { CoreModule, RecordModule } from '@rero/ng-core';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverdueTransactionComponent } from './overdue-transaction.component';
+
+
+describe('OverdueTransactionComponent', () => {
+  let component: OverdueTransactionComponent;
+  let fixture: ComponentFixture<OverdueTransactionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CoreModule,
+        RecordModule,
+        RouterTestingModule,
+        HttpClientModule,
+      ],
+      declarations: [
+        OverdueTransactionComponent
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverdueTransactionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/overdue-transaction/overdue-transaction.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { RecordService } from '@rero/ng-core';
+import { map, mergeMap } from 'rxjs/operators';
+import { MainTitleService } from '../../../../../service/main-title.service';
+import { Item } from '../../../../items';
+import { PatronTransaction } from '../../../../patron-transaction';
+
+@Component({
+  selector: 'admin-overdue-transaction',
+  templateUrl: './overdue-transaction.component.html'
+})
+export class OverdueTransactionComponent implements OnInit {
+
+  /** Patron transaction */
+  @Input() transaction: PatronTransaction;
+
+  /** item linked to this transaction if transaction linked to a loan */
+  item: Item;
+
+  constructor(
+    private _recordService: RecordService,
+    private _mainTitleService: MainTitleService
+  ) { }
+
+  /** Load item informations if the transaction is linked to a loan */
+  ngOnInit(): void {
+    if (this.transaction && this.transaction.loan && this.transaction.loan.pid) {
+      this._recordService.getRecord('loans', this.transaction.pid).pipe(
+        map(data => data.metadata),
+        mergeMap( data => this._recordService.getRecord('items', data.item_pid)),
+        map(data => new Item(data.metadata))
+      ).subscribe((data) => this.item = data);
+    }
+  }
+
+  /**
+   * Get main title (correspondig to 'bf_Title' type, present only once in metadata)
+   * @param titleMetadata: title metadata
+   */
+  getMainTitle(titleMetadata: any): string {
+    return this._mainTitleService.getMainTitle(titleMetadata);
+  }
+}

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
@@ -22,30 +22,9 @@
     <div *ngIf="!isCollapsed" class="mt-2">
       <!-- Transaction detail ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
       <h6 translate>Details</h6>
-      <section class="offset-md-1 mb-3">
-        <div class="row" *ngIf="transaction.note">
-          <div class="col-sm-2 label-title text-right" translate>Note</div>
-          <div class="col-sm-10">{{ transaction.note }}</div>
-        </div>
-        <div class="row" *ngIf="transaction.document.pid | getRecord:'documents' | async as document">
-          <div class="col-sm-2 label-title text-right" translate>Document</div>
-          <div class="col-sm-10">
-            <a [routerLink]="['/records','documents','detail', transaction.document.pid]"
-              *ngIf="getMainTitle(document.metadata.title) != null">
-              {{ getMainTitle(document.metadata.title) | truncateText: 15 }}
-            </a>
-          </div>
-        </div>
-        <div class="row" *ngIf="item">
-          <div class="col-sm-2 label-title text-right" translate>Item</div>
-          <div class="col-sm-10">
-            <a [routerLink]="['/records','items','detail', item.pid]">{{ item.barcode }}</a>
-          </div>
-        </div>
-        <div class="row" *ngIf="transaction.loan.pid | getRecord: 'loans' | async as loan">
-          <div class="col-sm-2 label-title text-right" translate>Checked out on</div>
-          <div class="col-sm-10">{{ loan.metadata.start_date | dateTranslate: 'shortDate' }}</div>
-        </div>
+      <section class="offset-md-1 mb-3" [ngSwitch]="transaction?.type">
+        <admin-overdue-transaction [transaction]="transaction" *ngSwitchCase="'overdue'"></admin-overdue-transaction>
+        <admin-default-transaction [transaction]="transaction" *ngSwitchDefault></admin-default-transaction>
       </section>
       <!-- Transaction history ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
       <h6 translate>Transaction history</h6>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.spec.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.spec.ts
@@ -1,12 +1,14 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CoreModule, RecordModule } from '@rero/ng-core';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { DefaultTransactionComponent } from './default-transaction/default-transaction.component';
+import { OverdueTransactionComponent } from './overdue-transaction/overdue-transaction.component';
 import { PatronTransactionComponent } from './patron-transaction.component';
-import { CoreModule, RecordModule } from '@rero/ng-core';
-import { RouterTestingModule } from '@angular/router/testing';
 import { PatronTransactionEventComponent } from '../patron-transaction-event/patron-transaction-event.component';
-import { HttpClientModule } from '@angular/common/http';
-import { TranslateModule } from '@ngx-translate/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('PatronTransactionComponent', () => {
   let component: PatronTransactionComponent;
@@ -23,6 +25,8 @@ describe('PatronTransactionComponent', () => {
         BrowserAnimationsModule
       ],
       declarations: [
+        DefaultTransactionComponent,
+        OverdueTransactionComponent,
         PatronTransactionComponent,
         PatronTransactionEventComponent
       ]

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.ts
@@ -1,13 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { RecordService } from '@rero/ng-core';
 import { BsModalService } from 'ngx-bootstrap';
-import { MainTitleService } from 'projects/admin/src/app/service/main-title.service';
-import { map, mergeMap } from 'rxjs/operators';
 import { OrganisationService } from '../../../../service/organisation.service';
-import { Item } from '../../../items';
 import { PatronTransaction, PatronTransactionEventType, PatronTransactionStatus } from '../../../patron-transaction';
 import { PatronTransactionService } from '../../../patron-transaction.service';
-import { PatronTransactionEventFormComponent } from '../patron-transaction-event-form/patron-transaction-event-form.component';
+import {
+  PatronTransactionEventFormComponent
+} from '../patron-transaction-event-form/patron-transaction-event-form.component';
 
 
 @Component({
@@ -18,8 +16,6 @@ export class PatronTransactionComponent implements OnInit {
 
   /** Patron transaction */
   @Input() transaction: PatronTransaction;
-  /** item linked to this transaction if transaction linked to a loan */
-  item: Item;
 
   /** Is collapsed */
   isCollapsed = true;
@@ -28,29 +24,14 @@ export class PatronTransactionComponent implements OnInit {
   public patronTransactionStatus = PatronTransactionStatus;
 
   constructor(
-    private _recordService: RecordService,
     private _organisationService: OrganisationService,
     private _patronTransactionService: PatronTransactionService,
-    private _modalService: BsModalService,
-    private _mainTitleService: MainTitleService
-  ) {}
+    private _modalService: BsModalService
+  ) { }
 
   ngOnInit() {
-    this._loadLinkedItem();
     if (this.transaction) {
       this._patronTransactionService.loadTransactionHistory(this.transaction);
-    }
-  }
-
-
-  /** Load item informations if the transaction is linked to a loan */
-  private _loadLinkedItem() {
-    if (this.transaction && this.transaction.loan && this.transaction.loan.pid) {
-      this._recordService.getRecord('loans', this.transaction.pid).pipe(
-        map(data => data.metadata),
-        mergeMap( data => this._recordService.getRecord('items', data.item_pid)),
-        map(data => new Item(data.metadata))
-      ).subscribe((data) => this.item = data);
     }
   }
 
@@ -109,13 +90,5 @@ export class PatronTransactionComponent implements OnInit {
       transactions: [this.transaction]
     };
     this._modalService.show(PatronTransactionEventFormComponent, {initialState});
-  }
-
-  /**
-   * Get main title (correspondig to 'bf_Title' type, present only once in metadata)
-   * @param titleMetadata: title metadata
-   */
-  getMainTitle(titleMetadata: any): string {
-    return this._mainTitleService.getMainTitle(titleMetadata);
   }
 }

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.spec.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.spec.ts
@@ -1,12 +1,13 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { PatronTransactionsComponent } from './patron-transactions.component';
-import { TranslateModule } from '@ngx-translate/core';
-import { PatronTransactionComponent } from './patron-transaction/patron-transaction.component';
 import { CoreModule, RecordModule } from '@rero/ng-core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { PatronTransactionEventComponent } from './patron-transaction-event/patron-transaction-event.component';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DefaultTransactionComponent } from './patron-transaction/default-transaction/default-transaction.component';
+import { OverdueTransactionComponent } from './patron-transaction/overdue-transaction/overdue-transaction.component';
+import { PatronTransactionComponent } from './patron-transaction/patron-transaction.component';
+import { PatronTransactionEventComponent } from './patron-transaction-event/patron-transaction-event.component';
+import { PatronTransactionsComponent } from './patron-transactions.component';
 
 describe('PatronTransactionsComponent', () => {
   let component: PatronTransactionsComponent;
@@ -22,6 +23,8 @@ describe('PatronTransactionsComponent', () => {
         HttpClientModule
       ],
       declarations: [
+        DefaultTransactionComponent,
+        OverdueTransactionComponent,
         PatronTransactionsComponent,
         PatronTransactionComponent,
         PatronTransactionEventComponent


### PR DESCRIPTION
When you expand a transaction to display detail, we try to display informations about a document and an item.
These metadata are only sense for a 'overdue' transaction.
This PR check the patron transaction type to display information depending of it

Linked to https://github.com/rero/rero-ils/pull/865 and https://github.com/rero/rero-ils/pull/868

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
