### PR TITLE
transactions: bug fixing

### DIFF
--- a/projects/admin/src/app/circulation/patron-transaction.ts
+++ b/projects/admin/src/app/circulation/patron-transaction.ts
@@ -47,6 +47,7 @@ export class PatronTransaction {
   note?: string = null;
   document?: any = null;
   loan?: any = null;
+  patron: any = null;
 
   constructor(obj?: any) {
     Object.assign(this, obj);

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
@@ -57,8 +57,8 @@
     </div>
   </div>
   <div class="col-md-1 text-left pl-0 mb-2" dropdown>
-    <ng-container *ngIf="transaction.status === patronTransactionStatus.OPEN">
-      <button class="btn btn-secondary btn-block d-md-block dropdown-toggle" type="button" dropdownToggle aria-controls="dropdown-animated" translate>Action</button>
+    <div class="position-relative" *ngIf="transaction.status === patronTransactionStatus.OPEN">
+      <button class="btn btn-outline-secondary btn-block d-md-block dropdown-toggle" type="button" dropdownToggle aria-controls="dropdown-animated" translate>Action</button>
       <ul id="dropdown-animated" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-animated">
         <li role="menuitem">
           <a class="dropdown-item" (click)="patronTransactionAction('pay', 'full')">{{ 'Pay' | translate }} {{ transaction.total_amount | currency: organisation.default_currency }}</a>
@@ -71,10 +71,10 @@
           <a class="dropdown-item" (click)="patronTransactionAction('dispute')" translate>Dispute</a>
         </li>
         <li role="menuitem">
-          <a class="dropdown-item" (click)="patronTransactionAction('cancel')" translate>Cancel</a>
+          <a class="dropdown-item" (click)="patronTransactionAction('cancel')" translate>Delete</a>
         </li>
       </ul>
-    </ng-container>
+    </div>
   </div>
 </ng-container>
 

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
@@ -13,7 +13,7 @@
       </div>
       <!-- Pay all patron-transactions button -->
       <div class="col-sm-1 pl-0">
-        <button class="btn btn-primary btn-block d-none d-lg-block"
+        <button class="btn btn-outline-primary btn-block d-none d-lg-block"
                 type="button"
                 (click)="payAllTransactions()"
                 [disabled]="transactionsTotalAmount <= 0"


### PR DESCRIPTION
* Drop-down menu was displayed far away of the action button if a transaction was expanded.
  The menu is now displayed just below the transaction action button.
* As transaction event creation method susribed to `currentPatron$` observable, each time this
  observer emit content, a dummy transation event was created (with previously registered data event).
  This problem is now solved : the affected patron is now get from the parent transaction event.
* CSS buttons regarding UX chart

* Closes rero/rero-ils-ui#209

## How to test?

- Expand a patron transaction to display history. Click on 'action' button for this transaction. The drop-down menu should be display just below the action button.

- Register a payment for a pending transaction (full or partial).
- Navigate to another page using main menu (`~/records/patrons` is a good option)
- Return on the fee tab from the previous patron.
- The fee is not updated and you don't received any tostr message

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Extracted translations?
