### PR TITLE
locations: hide action buttons depending of parent permissions

### DIFF
--- a/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.html
@@ -84,7 +84,7 @@
     <article class="card-body collapsed show">
       <ul class="list-group list-group-flush" *ngIf="locations; else no_locations">
         <li *ngFor="let location of locations" class="list-group-item p-1">
-          <admin-location [location]="location" class="col-12" (deleteLocation)="deleteLocation($event)"></admin-location>
+          <admin-location [location]="location" [library]="record" class="col-12" (deleteLocation)="deleteLocation($event)"></admin-location>
         </li>
       </ul>
       <ng-template #no_locations><p translate>no location</p></ng-template>

--- a/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.html
@@ -16,7 +16,7 @@
 -->
 
 <a [routerLink]="['/records/locations/detail', location.metadata.pid]">{{ location.metadata.name }}</a>
-<div class="float-right ml-2">
+<div class="float-right ml-2" *ngIf="!library.permissions.cannot_update">
   <a *ngIf="!location.permissions.cannot_update" class="btn btn-link p-0 ml-2 text-primary"
     [routerLink]="['/records', 'locations', 'edit', location.metadata.pid]">
     <i class="fa fa-pencil"></i>

--- a/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.ts
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.ts
@@ -11,6 +11,9 @@ export class LocationComponent {
   /** The location whose details are displayed */
   @Input() location: any;
 
+  /** The parent library of the location */
+  @Input() library: any;
+
   /** Delete location event emitter */
   @Output() deleteLocation = new EventEmitter();
 


### PR DESCRIPTION
When you display a library detail, locations action buttons are displayed even if
current logged user doesn't have permissions to update the library.
This PR fixes this problem.

Ca-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Login as Jean (Librarian)
- Display the detail of library 1 : `~/records/libraries/detail/1`
- No actions should be available for any locations
- Display the detail of Jean's library : `~/records/libraries/detail/2`
- You should view the "add", "delete" and "edit" action buttons for locations

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
