### PR TITLE
search view: hide the add button for public views

### DIFF
--- a/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.spec.ts
@@ -45,8 +45,7 @@ const testingRoute = {
           key: 'documents',
         }
       ],
-      showSearchInput: true,
-      adminMode: true
+      showSearchInput: true
     }
   },
   queryParams: of({})

--- a/projects/admin/src/app/routes/organisations-route.ts
+++ b/projects/admin/src/app/routes/organisations-route.ts
@@ -18,6 +18,7 @@ import { BaseRoute } from './Base-route';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { OrganisationDetailViewComponent } from '../record/detail-view/organisation-detail-view/organisation-detail-view.component';
 import { RouteInterface, DetailComponent, EditorComponent } from '@rero/ng-core';
+import { of } from 'rxjs';
 
 export class OrganisationsRoute extends BaseRoute implements RouteInterface {
 
@@ -37,7 +38,10 @@ export class OrganisationsRoute extends BaseRoute implements RouteInterface {
       ],
       data: {
         linkPrefix: 'records',
-        adminMode: false,
+        adminMode: () => of({
+          can: false,
+          message: ''
+        }),
         types: [
           {
             key: this.name,

--- a/projects/admin/src/app/routes/persons-route.ts
+++ b/projects/admin/src/app/routes/persons-route.ts
@@ -18,6 +18,7 @@ import { RouteInterface, RecordSearchComponent, DetailComponent } from '@rero/ng
 import { PersonsBriefViewComponent } from '../record/brief-view/persons-brief-view.component';
 import { PersonDetailViewComponent } from '../record/detail-view/person-detail-view/person-detail-view.component';
 import { BaseRoute } from './Base-route';
+import { of } from 'rxjs';
 
 export class PersonsRoute extends BaseRoute implements RouteInterface {
 
@@ -37,7 +38,10 @@ export class PersonsRoute extends BaseRoute implements RouteInterface {
       ],
       data: {
         linkPrefix: 'records',
-        adminMode: false,
+        adminMode: () => of({
+          can: false,
+          message: ''
+        }),
         types: [
           {
             key: this.name,

--- a/projects/admin/src/app/service/main-title.service.spec.ts
+++ b/projects/admin/src/app/service/main-title.service.spec.ts
@@ -1,3 +1,20 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { TestBed } from '@angular/core/testing';
 
 import { MainTitleService } from './main-title.service';

--- a/projects/admin/src/app/service/main-title.service.ts
+++ b/projects/admin/src/app/service/main-title.service.ts
@@ -1,3 +1,20 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { Injectable } from '@angular/core';
 
 @Injectable({
@@ -13,6 +30,9 @@ export class MainTitleService {
    */
   getMainTitle(titleMetadata: any): string {
     let mainTitle: string = null;
+    if (titleMetadata == null) {
+      return;
+    }
     titleMetadata.forEach(metadata => {
       if (metadata.type === 'bf:Title') {
         mainTitle = metadata._text;

--- a/projects/public-search/src/app/service/routing-init.service.ts
+++ b/projects/public-search/src/app/service/routing-init.service.ts
@@ -16,13 +16,13 @@
  */
 import { Injectable } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
-
-import { RecordSearchComponent, DetailComponent } from '@rero/ng-core';
+import { TranslateService } from '@ngx-translate/core';
+import { DetailComponent, RecordSearchComponent } from '@rero/ng-core';
+import { Observable, of, Subscriber } from 'rxjs';
+import { AppConfigService } from '../app-config.service';
 import { DocumentBriefComponent } from '../document-brief/document-brief.component';
 import { PersonBriefComponent } from '../person-brief/person-brief.component';
-import { Observable, Subscriber } from 'rxjs';
-import { TranslateService } from '@ngx-translate/core';
-import { AppConfigService } from '../app-config.service';
+
 
 @Injectable({
   providedIn: 'root'
@@ -57,7 +57,10 @@ export class RoutingInitService {
       ],
       data: {
         showSearchInput: false,
-        adminMode: false,
+        adminMode: () => of({
+          can: false,
+          message: ''
+        }),
         detailUrl: `/${viewcode}/:type/:pid`,
         types: [
           {


### PR DESCRIPTION
* Adapts the configuration for the search views that disables administrative functionalities to be compatible with the new ng-core version. This removes all professional buttons from these search views.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To fix admin button on the public, organisation and person search views.

## How to test?

- Run the public view server and go to the public search views. The add button should not be present.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
