### PR TITLE
editor: link persons to source instead of MEF

### DIFF
--- a/projects/admin/src/app/menu/menu.component.ts
+++ b/projects/admin/src/app/menu/menu.component.ts
@@ -232,7 +232,7 @@ export class MenuComponent implements OnInit {
   }
 
   private getPersonName(metadata) {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (metadata[source] && metadata[source].preferred_name_for_person) {
         return metadata[source].preferred_name_for_person;
       }

--- a/projects/admin/src/app/pipe/bio-informations.pipe.ts
+++ b/projects/admin/src/app/pipe/bio-informations.pipe.ts
@@ -23,7 +23,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class BioInformationsPipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].biographical_information) {
         return value[source].biographical_information;
       }

--- a/projects/admin/src/app/pipe/birth-date.pipe.ts
+++ b/projects/admin/src/app/pipe/birth-date.pipe.ts
@@ -23,7 +23,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class BirthDatePipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].date_of_birth) {
         return value[source].date_of_birth;
       }

--- a/projects/admin/src/app/pipe/mef-title.pipe.ts
+++ b/projects/admin/src/app/pipe/mef-title.pipe.ts
@@ -23,7 +23,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class MefTitlePipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].preferred_name_for_person) {
         return value[source].preferred_name_for_person;
       }

--- a/projects/admin/src/app/record/detail-view/person-detail-view/person-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/person-detail-view/person-detail-view.component.html
@@ -18,6 +18,7 @@
   <h1 class="mb-0">{{ record.metadata | mefTitle }}</h1>
   <small>{{ 'MEF ID' | translate }}: {{ record.metadata.pid }}</small>
 
+  <!-- TODO: custom ordering of sources -->
   <article class="card m-2" *ngFor="let source of record.metadata.sources">
     <a class="card-link" data-toggle="collapse" data-target="#collapse-rero" aria-expanded="true">
       <header class="card-header">
@@ -151,5 +152,3 @@
   </article>
   </ng-container>
 </ng-container>
-
-

--- a/projects/public-search/src/app/pipes/bio-informations.pipe.ts
+++ b/projects/public-search/src/app/pipes/bio-informations.pipe.ts
@@ -25,7 +25,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class BioInformationsPipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].biographical_information) {
         return value[source].biographical_information;
       }

--- a/projects/public-search/src/app/pipes/birth-date.pipe.ts
+++ b/projects/public-search/src/app/pipes/birth-date.pipe.ts
@@ -25,7 +25,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class BirthDatePipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].date_of_birth) {
         return value[source].date_of_birth;
       }

--- a/projects/public-search/src/app/pipes/mef-title.pipe.ts
+++ b/projects/public-search/src/app/pipes/mef-title.pipe.ts
@@ -25,7 +25,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class MefTitlePipe implements PipeTransform {
 
   transform(value: any): any {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (value[source] && value[source].preferred_name_for_person) {
         return value[source].preferred_name_for_person;
       }

--- a/projects/public-search/src/app/search-bar/search-bar.component.ts
+++ b/projects/public-search/src/app/search-bar/search-bar.component.ts
@@ -28,7 +28,7 @@ export class SearchBarComponent implements OnInit {
   recordTypes = [];
 
   static getPersonName(metadata) {
-    for (const source of ['rero', 'idref', 'bnf', 'gnd']) {
+    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
       if (metadata[source] && metadata[source].preferred_name_for_person) {
         return metadata[source].preferred_name_for_person;
       }


### PR DESCRIPTION
* Links documents to the source authority file, such as GND or IdRef,
  through the MEF server, instead of the MEF clusterized record. This
  is needed to provide a stable link to the authority.

My PR depends on the following `rero-ils`'s PR(s):

* rero/rero-ils#972

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/task/1464

## How to test?

- Try to edit an document and add an person

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
