### PR TITLE
items: display items notes

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-item/holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-item/holding-item.component.html
@@ -19,6 +19,9 @@
     <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
       {{ item.metadata.barcode }}
     </a>
+    <span class="float-right text-warning small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
+      <i class="fa fa-sticky-note-o pr-1"></i>{{ item.metadata.notes.length }}
+    </span>
   </div>
   <div class="col-sm-2">
     {{ item.metadata.status | translate }}

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -68,6 +68,20 @@
     </dl>
   </section>
 
+  <section *ngIf="record.metadata.notes">
+    <div class="card item-notes">
+      <div class="card-header" translate>Notes</div>
+      <div class="card-body">
+        <div class="row mb-3" *ngFor="let note of record.metadata.notes">
+          <div class="col-12">
+            <strong translate>{{ note.type }}</strong>
+          </div>
+          <div class="offset-1 col-11 text-justify">{{ note.content }}</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- TRANSACTIONS -->
   <admin-item-transactions [item]="record"></admin-item-transactions>
 </ng-container>


### PR DESCRIPTION
Adapts the item detail view to display notes related to an item.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1352?milestone=266303

## How to test?

use https://github.com/rero/rero-ils/pull/1026 (backend) bootstrap + setup

- Log as a librarian
- Edit an item to add a note a each type
- Display the item detail view

![image](https://user-images.githubusercontent.com/10031585/83887030-2052c280-a748-11ea-8b9d-5811ff44bb11.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
