### PR TITLE
autocomplete: fix author wrong date

### DIFF
--- a/projects/admin/src/app/record/editor/remote-autocomplete/remote-autocomplete.component.ts
+++ b/projects/admin/src/app/record/editor/remote-autocomplete/remote-autocomplete.component.ts
@@ -134,50 +134,10 @@ export class RemoteAutocompleteInputTypeComponent extends FieldType implements O
    */
   getNameSource(sourceData) {
     if (sourceData) {
-      const data = sourceData;
-      let name = data.preferred_name_for_person;
-      if (data.date_of_birth || data.date_of_death) {
-        name += ', ';
-        if (data.date_of_birth) {
-          name += this.extractDate(data.date_of_birth);
-        }
-        name += ' - ';
-        if (data.date_of_death) {
-          name += this.extractDate(data.date_of_death);
-        }
-      }
-      return name;
+      return sourceData.authorized_access_point_representing_a_person;
     }
   }
 
-  getName(metadata) {
-    for (const source of ['idref', 'gnd', 'bnf', 'rero']) {
-      if (metadata[source]) {
-        const data = metadata[source];
-        let name = source.toUpperCase( );
-        name += ': ' + data.preferred_name_for_person;
-        if (data.date_of_birth || data.date_of_death) {
-          name += ', ';
-          if (data.date_of_birth) {
-            name += this.extractDate(data.date_of_birth);
-          }
-          name += ' - ';
-          if (data.date_of_death) {
-            name += this.extractDate(data.date_of_death);
-          }
-        }
-        return name;
-      }
-    }
-  }
-
-  extractDate(date) {
-    const mDate = moment(date, ['YYYY', 'YYYY-MM', 'YYYY-MM-DD']);
-    if (mDate.isValid()) {
-      return mDate.format('YYYY');
-    }
-    return date;
-  }
 
   changeTypeaheadLoading(e: boolean): void {
     this.typeaheadLoading = e;


### PR DESCRIPTION
* Fixes display of wrong dates for autocomplete in form editor.
  The function with the problem of caculation the dates for authors
  was replaced by using `authorized_access_point_representing_a_person`.
  The function was handling the dates in the form like `19..` wrongly.
* closes rero/rero-ils#1038

Co-Authored-by: Peter Weber <peter.weber@rero.ch>

## Why are you opening this PR?

- https://github.com/rero/rero-ils/issues/1038

## How to test?

- In the documents editor add an author and verify correct dates.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
