### PR TITLE
authorization: limit roles management using API

### DIFF
--- a/projects/admin/src/app/routes/route-tool.service.ts
+++ b/projects/admin/src/app/routes/route-tool.service.ts
@@ -64,6 +64,13 @@ export class RouteToolService {
   }
 
   /**
+   * @return recordPermissionService
+   */
+  get recordPermissionService() {
+    return this._recordPermissionService;
+  }
+
+  /**
    * @return datePipe
    */
   get datePipe() {

--- a/projects/admin/src/app/service/record-permission.service.ts
+++ b/projects/admin/src/app/service/record-permission.service.ts
@@ -18,6 +18,8 @@ import { I18nPluralPipe, NgLocaleLocalization } from '@angular/common';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -52,6 +54,15 @@ export class RecordPermissionService {
       ? `/api/permissions/${resource}`
       : `/api/permissions/${resource}/${pid}`;
     return this._httpClient.get<RecordPermission>(url, this._httpOptions);
+  }
+
+
+  /**
+   * Get roles that the current user can manage
+   * @return an observable on allowed roles management
+   */
+  getRolesManagementPermissions(): Observable<any> {
+    return this._httpClient.get('api/patrons/roles_management_permissions', this._httpOptions);
   }
 
   /**


### PR DESCRIPTION
This commit restricts the role management for patrons using the role
management API. Depending of the API result, some roles could be
disabled into the role field.

- Closes rero/rero-ils#930

Co-authored_by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1523?kanban-status=1224894

## Dependencies

* rero/rero-ils#1043

## How to test?

- Logged as a `system_librarian`
- Go into the professional interface and try to edit a patron
- A system_librarian should be able to manage all roles, no role should be disabled.

- Logged as a `librarian`
- Go into the professional interface and try to edit a patron
- The `system_librarian` role should be displayed but disabled.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
