### PR TITLE
document: adapt display of field "notes"

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { LOCALE_ID, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
@@ -42,6 +42,7 @@ import { MenuComponent } from './menu/menu.component';
 import { BioInformationsPipe } from './pipe/bio-informations.pipe';
 import { BirthDatePipe } from './pipe/birth-date.pipe';
 import { MefTitlePipe } from './pipe/mef-title.pipe';
+import { NotesFormatPipe } from './pipe/notes-format.pipe';
 import { AcquisitionOrderBriefViewComponent } from './record/brief-view/acquisition-order-brief-view.component';
 import { BudgetsBriefViewComponent } from './record/brief-view/budgets-brief-view.component';
 import { CircPoliciesBriefViewComponent } from './record/brief-view/circ-policies-brief-view.component';
@@ -184,7 +185,8 @@ import { SharedPipesModule } from './shared/shared-pipes.module';
     SerialHoldingItemComponent,
     SerialHoldingDetailViewComponent,
     HoldingDetailViewComponent,
-    DefaultHoldingItemComponent
+    DefaultHoldingItemComponent,
+    NotesFormatPipe
   ],
   imports: [
     AppRoutingModule,

--- a/projects/admin/src/app/pipe/notes-format.pipe.spec.ts
+++ b/projects/admin/src/app/pipe/notes-format.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { NotesFormatPipe } from './notes-format.pipe';
+
+describe('NotesFormatPipe', () => {
+  it('create an instance', () => {
+    const pipe = new NotesFormatPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/pipe/notes-format.pipe.ts
+++ b/projects/admin/src/app/pipe/notes-format.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'notesFormat'
+})
+export class NotesFormatPipe implements PipeTransform {
+
+  transform(notes: any): any {
+    if (notes) {
+      const notesText = {};
+      for (const note of notes) {
+        if (!(note.noteType in notesText)) {
+          notesText[note.noteType] = [note.label];
+        } else {
+          notesText[note.noteType].push(note.label);
+        }
+      }
+      return notesText;
+    }
+    return null;
+
+  }
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -201,41 +201,43 @@
             </ng-container>
 
             <!-- NOTES -->
-            <ng-container *ngIf="record.metadata.notes_text && record.metadata.notes_text.general">
+            <ng-container *ngIf="record.metadata.note && record.metadata.note.length > 0 && record.metadata.note | notesFormat as notes">
+              <ng-container *ngIf="notes.general">
                 <dt class="col-sm-4 offset-sm-2 offset-md-0" translate>
                   Note
                 </dt>
                 <dd [ngClass]="ddCssClass">
                   <ul class="list-unstyled mb-0">
                     <li
-                      *ngFor="let note of record.metadata.notes_text.general"
+                      *ngFor="let note of notes.general"
                     >{{ note }}</li>
                   </ul>
                 </dd>
-            </ng-container>
-            <ng-container *ngIf="record.metadata.notes_text && record.metadata.notes_text.otherPhysicalDetails">
-              <dt class="col-sm-4 offset-sm-2 offset-md-0" translate>
-                Physical details
-              </dt>
-              <dd [ngClass]="ddCssClass">
-                <ul class="list-unstyled mb-0">
-                  <li
-                    *ngFor="let note of record.metadata.notes_text.otherPhysicalDetails"
-                  >{{ note }}</li>
-                </ul>
-              </dd>
-            </ng-container>
-            <ng-container *ngIf="record.metadata.notes_text && record.metadata.notes_text.accompanyingMaterial">
-              <dt class="col-sm-4 offset-sm-2 offset-md-0" translate>
-                Accompanying material
-              </dt>
-              <dd [ngClass]="ddCssClass">
-                <ul class="list-unstyled mb-0">
-                  <li
-                    *ngFor="let note of record.metadata.notes_text.accompanyingMaterial"
-                  >{{ note }}</li>
-                </ul>
-              </dd>
+              </ng-container>
+              <ng-container *ngIf="notes.otherPhysicalDetails">
+                <dt class="col-sm-4 offset-sm-2 offset-md-0" translate>
+                  Physical details
+                </dt>
+                <dd [ngClass]="ddCssClass">
+                  <ul class="list-unstyled mb-0">
+                    <li
+                      *ngFor="let note of notes.otherPhysicalDetails"
+                    >{{ note }}</li>
+                  </ul>
+                </dd>
+              </ng-container>
+              <ng-container *ngIf="notes.accompanyingMaterial">
+                <dt class="col-sm-4 offset-sm-2 offset-md-0" translate>
+                  Accompanying material
+                </dt>
+                <dd [ngClass]="ddCssClass">
+                  <ul class="list-unstyled mb-0">
+                    <li
+                      *ngFor="let note of notes.accompanyingMaterial"
+                    >{{ note }}</li>
+                  </ul>
+                </dd>
+              </ng-container>
             </ng-container>
 
             <!-- SERIES -->


### PR DESCRIPTION
* Creates a pipe to display the field "notes".
* Corrects detail view accordingly.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To adapt the UI for the correction of the edition of a document with notes.

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* https://github.com/rero/rero-ils/pull/1062

## How to test?

Check the detail view of documents with notes.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
