### PR TITLE
ui: implement basic keyboard shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10802,6 +10802,14 @@
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
+    "ng-keyboard-shortcuts": {
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/ng-keyboard-shortcuts/-/ng-keyboard-shortcuts-7.1.15.tgz",
+      "integrity": "sha512-c5B/u8sAPwO1inTBc9FWGy/8y7/7x8iWgaPI8UM7l0vtUlyBHcwYU+Xso8Wya6Cf38r6f75aiyTHsWirpjJgBw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "ngx-bootstrap": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-5.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jquery": "^3.4.1",
     "lodash-es": "4.17.14",
     "moment": "^2.24.0",
+    "ng-keyboard-shortcuts": "^7.1.15",
     "ngx-bootstrap": "^5.6.2",
     "ngx-bootstrap-slider": "^1.8.0",
     "ngx-spinner": "^8.1.0",

--- a/projects/admin/src/app/app.component.html
+++ b/projects/admin/src/app/app.component.html
@@ -43,3 +43,12 @@
     {{ 'You do not have sufficient permissions to view this page' | translate }}
   </div>
 </ng-template>
+
+<ng-keyboard-shortcuts-help
+  [key]="'?'"
+  [keyLabel]="'Global shortcuts' | translate"
+  [keyDescription]="'Open/close the help panel' | translate"
+  [title]="'RERO ILS keyboard shortcuts' | translate"
+>
+</ng-keyboard-shortcuts-help>
+<admin-shortcuts></admin-shortcuts>

--- a/projects/admin/src/app/app.component.spec.ts
+++ b/projects/admin/src/app/app.component.spec.ts
@@ -17,6 +17,7 @@
 
 import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { KeyboardShortcutsModule } from 'ng-keyboard-shortcuts';
 import { AppComponent } from './app.component';
 import { MenuComponent } from './menu/menu.component';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
@@ -27,6 +28,7 @@ import { RecordModule } from '@rero/ng-core';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ShortcutsComponent } from './widgets/shortcuts/shortcuts.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -40,11 +42,13 @@ describe('AppComponent', () => {
         DatepickerModule.forRoot(),
         BsDropdownModule.forRoot(),
         TranslateModule.forRoot({}),
-        TypeaheadModule.forRoot()
+        TypeaheadModule.forRoot(),
+        KeyboardShortcutsModule.forRoot()
       ],
       declarations: [
         AppComponent,
-        MenuComponent
+        MenuComponent,
+        ShortcutsComponent
       ]
     }).compileComponents();
   }));

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyModule } from '@ngx-formly/core';
 import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { CoreConfigService, RecordModule, TranslateLoader, TranslateService } from '@rero/ng-core';
+import { KeyboardShortcutsModule } from 'ng-keyboard-shortcuts';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDatepickerModule, BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -116,6 +117,7 @@ import { MefTypeahead } from './class/mef-typeahead';
 import { DocumentsTypeahead } from './class/documents-typeahead';
 import { MainTitlePipe } from './pipe/main-title.pipe';
 import { AppInitService } from './service/app-init.service';
+import { ShortcutsComponent } from './widgets/shortcuts/shortcuts.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -195,7 +197,8 @@ export function appInitFactory(appInitService: AppInitService) {
     DefaultHoldingItemComponent,
     NotesFormatPipe,
     MarcPipe,
-    TabOrderDirective
+    TabOrderDirective,
+    ShortcutsComponent
   ],
   imports: [
     AppRoutingModule,
@@ -219,6 +222,7 @@ export function appInitFactory(appInitService: AppInitService) {
         useClass: TranslateLoader
       }
     }),
+    KeyboardShortcutsModule.forRoot(),
     TypeaheadModule
   ],
   providers: [

--- a/projects/admin/src/app/class/user.ts
+++ b/projects/admin/src/app/class/user.ts
@@ -123,6 +123,7 @@ export class User {
 
 export interface Organisation {
   pid: string;
+  code?: string;
 }
 
 export interface Library {

--- a/projects/admin/src/app/widgets/shortcuts/shortcuts.component.spec.ts
+++ b/projects/admin/src/app/widgets/shortcuts/shortcuts.component.spec.ts
@@ -1,0 +1,32 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { AppModule } from '../../app.module';
+
+import { ShortcutsComponent } from './shortcuts.component';
+
+describe('ShortcutsComponent', () => {
+  let component: ShortcutsComponent;
+  let fixture: ComponentFixture<ShortcutsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        AppModule,
+        TranslateModule.forRoot(),
+        RouterTestingModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShortcutsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/widgets/shortcuts/shortcuts.component.ts
+++ b/projects/admin/src/app/widgets/shortcuts/shortcuts.component.ts
@@ -1,0 +1,109 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ * Copyright (C) 2020 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { AfterViewInit, Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { AllowIn, ShortcutEventOutput, ShortcutInput } from 'ng-keyboard-shortcuts';
+import { User } from '../../class/user';
+import { UserService } from '../../service/user.service';
+
+@Component({
+  selector: 'admin-shortcuts',
+  template: `<ng-keyboard-shortcuts [shortcuts]="shortcuts"></ng-keyboard-shortcuts>`
+})
+export class ShortcutsComponent implements OnInit, AfterViewInit {
+
+  /** the current logged user */
+  currentUser: User;
+
+  /** shortcuts list */
+  shortcuts: ShortcutInput[] = [];
+
+  /** Constructor
+   *  @param _router: Router
+   *  @param _translateService: TranslateService
+   *  @param _userService: UserService
+   */
+  constructor(
+    private _router: Router,
+    private _translateService: TranslateService,
+    private _userService: UserService
+  ) { }
+
+  /** Hook OnInit */
+  ngOnInit() {
+    this._userService.onUserLoaded$.subscribe(() => this.currentUser = this._userService.getCurrentUser());
+  }
+
+  /** Hook AfterViewInit */
+  ngAfterViewInit(): void {
+    this.shortcuts.push(
+      {
+        key: ['escape'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Lose focus on the current field'),
+        allowIn: [AllowIn.Select, AllowIn.Input, AllowIn.Textarea],
+        preventDefault: true,
+        command: (output: ShortcutEventOutput) => (output.event.target as HTMLElement).blur()
+      }, {
+        key: ['/'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Set focus on the header search input'),
+        preventDefault: true,
+        command: () => {
+          const autocompleteElement = document.getElementsByClassName('rero-ils-autocomplete')[0];
+          const inputField = autocompleteElement.getElementsByTagName('input')[0];
+          inputField.focus();
+        }
+      }, {
+        key: ['h'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Open the global help page'),
+        preventDefault: true,
+        command: () => window.open('https://ils.test.rero.ch/help', 'rero-ils-help')
+      }, {
+        key: ['s'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Switch to public interface'),
+        command: () => {
+          if (this.currentUser != null) {
+            window.location.href = `/${this.currentUser.library.organisation.code}`;
+          }
+        }
+      }, {
+        key: ['p'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Open the patron search page'),
+        preventDefault: true,
+        command: () => this._router.navigate(['/records', 'patrons'])
+      }, {
+        key: ['c'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Open the circulation checkin interface'),
+        preventDefault: false,
+        command: () => this._router.navigate(['/circulation', 'checkout'])
+      }, {
+        key: ['r'],
+        label: this._translateService.instant('Global shortcuts'),
+        description: this._translateService.instant('Open the requests page'),
+        preventDefault: true,
+        command: () => this._router.navigate(['/circulation', 'requests'])
+      }
+    );
+  }
+}


### PR DESCRIPTION
his commit adds keyboard shortcut functionality into the professional
interface. When the focus are not set into an input element, if user
press on some keyboard key (or keys combination) an action is done
(redirection, set focus, ...).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1488?milestone=268117

## Dependencies

Need to install `ng-keyboard-shortcuts` packages (https://www.npmjs.com/package/ng-keyboard-shortcuts)

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
