### PR TITLE
items: display second call number field.

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -27,7 +27,7 @@
     {{ item.metadata.status | translate }}
   </div>
   <div class="col-sm-2">
-    {{ item.metadata.call_number }}
+    {{ callNumber }}
   </div>
   <div class="col-sm-4 text-right">
     <ng-container *ngIf="isHoldingMatchUserLibraryPID">

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
@@ -86,6 +86,19 @@ export class DefaultHoldingItemComponent implements OnInit {
   }
 
   /**
+   * Get formatted call number
+   *
+   * Join call number and second call number separate by ` - `
+   * @returns - formatted string
+   */
+  get callNumber(): string {
+    if (this.item.metadata.second_call_number) {
+      return this.item.metadata.call_number + ' | ' + this.item.metadata.second_call_number;
+    }
+    return this.item.metadata.call_number;
+  }
+
+  /**
    * Add request on item and refresh permissions
    * @param itemPid - string
    */

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -27,7 +27,7 @@
     {{ item.metadata.issue.display_text }}
   </div>
   <div class="col-sm-2">
-    {{ item.metadata.call_number }}
+    {{ callNumber }}
   </div>
   <div class="col-sm-2 text-right">
     <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -31,6 +31,13 @@
           <span class="no-data">({{ 'no data' | translate }})</span>
         </ng-template>
       </dd>
+      <!-- SECOND CALL NUMBER -->
+      <ng-container *ngIf="record.metadata.second_call_number">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Second call number</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+            {{ record.metadata.second_call_number }}
+        </dd>
+      </ng-container>
       <!-- ITEM TYPE -->
       <dt class="col-sm-3 offset-sm-2 offset-md-0">
         {{ 'Type' | translate }}:


### PR DESCRIPTION
Implements new item field 'second_call_number' in professional views.

* Adapts holding-item brief view.
* Adapts item detail view to add second call number field.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
https://tree.taiga.io/project/rero21-reroils/task/1577

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#1082

## How to test?

- Go to the professional view.
- Create (or edit) an item
- Add a second call number.
- Check if the second call number appears in item detail view.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
