### PR TITLE
ui: better way to select menu items by Cypress

### DIFF
--- a/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
+++ b/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
@@ -22,7 +22,7 @@
   </div>
   <ul class="list-group list-group-flush" *ngIf="item.entries">
     <li class="list-group-item p-0" *ngFor="let entry of item.entries">
-      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink" [queryParams]="entry.queryParams"><i *ngIf="entry.iconCssClass"
+      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink" [queryParams]="entry.queryParams" [attr.id]="getId(entry, '-frontpage')"><i *ngIf="entry.iconCssClass"
         [ngClass]="entry.iconCssClass" aria-hidden="true"></i> {{ entry.name | translate }}</a>
     </li>
   </ul>

--- a/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.ts
+++ b/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.ts
@@ -25,4 +25,20 @@ export class FrontpageBoardComponent {
 
   /** List of items to display */
   @Input() item: any;
+
+  /**
+   * Get item ID and add optional suffix on it
+   * @param item menu item
+   * @param suffix suffix to add after item id
+   * @return a string
+   */
+  getId(item: any, suffix?: string): string {
+    if (item.id !== null) {
+      let res = item.id;
+      if (suffix !== null) {
+        res += suffix;
+      }
+      return res;
+    }
+  }
 }

--- a/projects/admin/src/app/menu/menu.component.ts
+++ b/projects/admin/src/app/menu/menu.component.ts
@@ -87,15 +87,18 @@ export class MenuComponent implements OnInit {
     this.userMenu.entries.push({
       name: `${currentUser.first_name[0]}${currentUser.last_name[0]}`,
       iconCssClass: 'fa fa-user',
+      id: 'my-account-menu',
       entries: [
         {
           name: this._translateService.instant('Public interface'),
           href: '/',
-          iconCssClass: 'fa fa-television'
+          iconCssClass: 'fa fa-television',
+          id: 'public-interface-menu'
         }, {
           name: this._translateService.instant('Logout'),
           href: `/logout`,
-          iconCssClass: 'fa fa-sign-out'
+          iconCssClass: 'fa fa-sign-out',
+          id: 'logout-menu'
         }
       ]
     });
@@ -133,16 +136,18 @@ export class MenuComponent implements OnInit {
       entries: [{
         name: this._translateService.instant('Menu'),
         iconCssClass: 'fa fa-bars',
+        id: 'language-menu',
         entries: [{
           name: this._translateService.instant('Help'),
           iconCssClass: 'fa fa-info',
-          href: 'https://ils.test.rero.ch/help'
+          href: 'https://ils.test.rero.ch/help',
+          id: 'help-menu',
         }]
       }]
     };
     const languages = this._configService.languages;
     // divider
-    languagesMenu.entries[0].entries.splice(0, 0, {name: null, iconCssClass: null, href: null});
+    languagesMenu.entries[0].entries.splice(0, 0, {name: null, iconCssClass: null, href: null, id: null});
     for (const lang of languages) {
       if (lang !== this._appTranslateService.currentLanguage) {
         const data: any = {
@@ -150,6 +155,7 @@ export class MenuComponent implements OnInit {
           name: `ui_language_${lang}`,
           code: lang,
           iconCssClass: 'fa fa-language',
+          id: `language-menu-${lang}`,
         };
         languagesMenu.entries[0].entries.splice(0, 0, data);
       }

--- a/projects/admin/src/app/service/menu.service.ts
+++ b/projects/admin/src/app/service/menu.service.ts
@@ -16,83 +16,103 @@ export class MenuService {
       {
         name: this._translateService.instant('User services'),
         iconCssClass: 'fa fa-users',
+        id: 'user-services-menu',
         entries: [{
           name: this._translateService.instant('Circulation'),
           routerLink: '/circulation',
-          iconCssClass: 'fa fa-exchange'
+          iconCssClass: 'fa fa-exchange',
+          id: 'circulation-menu'
         }, {
           name: this._translateService.instant('Requests'),
           routerLink: '/circulation/requests',
-          iconCssClass: 'fa fa-shopping-basket'
+          iconCssClass: 'fa fa-shopping-basket',
+          id: 'requests-menu'
         }, {
           name: this._translateService.instant('Patrons'),
           routerLink: '/records/patrons',
-          iconCssClass: 'fa fa-users'
+          iconCssClass: 'fa fa-users',
+          id: 'patrons-menu'
         }]
       }, {
         name: this._translateService.instant('Catalog'),
         iconCssClass: 'fa fa-file-o',
+        id: 'catalog-menu',
         entries: [{
           name: this._translateService.instant('Documents'),
           routerLink: '/records/documents',
           queryParams: this._myDocumentsQueryParams(),
-          iconCssClass: 'fa fa-file-o'
+          iconCssClass: 'fa fa-file-o',
+          id: 'documents-menu'
         }, {
           name: this._translateService.instant('Create a bibliographic record'),
           routerLink: '/records/documents/new',
-          iconCssClass: 'fa fa-file-o'
+          iconCssClass: 'fa fa-file-o',
+          id: 'create-bibliographic-record-menu'
         }, {
           name: this._translateService.instant('Import from the web'),
           routerLink: '/records/import_bnf',
-          iconCssClass: 'fa fa-file-o'
+          iconCssClass: 'fa fa-file-o',
+          id: 'import-menu'
         }, {
           name: this._translateService.instant('Persons'),
           routerLink: '/records/persons',
-          iconCssClass: 'fa fa-user'
+          iconCssClass: 'fa fa-user',
+          id: 'persons-menu'
         }]
       }, {
         name: this._translateService.instant('Acquisitions'),
         iconCssClass: 'fa fa-university',
+        id: 'acquisitions-menu',
         entries: [{
           name: this._translateService.instant('Vendors'),
           routerLink: '/records/vendors',
-          iconCssClass: 'fa fa-briefcase'
+          iconCssClass: 'fa fa-briefcase',
+          id: 'vendors-menu'
         }, {
           name: this._translateService.instant('Orders'),
           routerLink: '/records/acq_orders',
-          iconCssClass: 'fa fa-shopping-cart'
+          iconCssClass: 'fa fa-shopping-cart',
+          id: 'orders-menu'
         }, {
           name: this._translateService.instant('Budgets'),
           routerLink: '/records/budgets',
-          iconCssClass: 'fa fa-money'
+          iconCssClass: 'fa fa-money',
+          id: 'budgets-menu'
         }]
       }, {
         name: this._translateService.instant('Admin & Monitoring'),
         iconCssClass: 'fa fa-cogs',
+        id: 'admin-and-monitoring-menu',
         entries: [{
           name: this._translateService.instant('Circulation policies'),
           routerLink: '/records/circ_policies',
-          iconCssClass: 'fa fa-exchange'
+          iconCssClass: 'fa fa-exchange',
+          id: 'circulation-policies-menu'
         }, {
           name: this._translateService.instant('Item types'),
           routerLink: '/records/item_types',
-          iconCssClass: 'fa fa-file-o'
+          iconCssClass: 'fa fa-file-o',
+          id: 'item-types-menu'
         }, {
           name: this._translateService.instant('Patron types'),
           routerLink: '/records/patron_types',
-          iconCssClass: 'fa fa-users'
+          iconCssClass: 'fa fa-users',
+          id: 'patron-types-menu'
         }, {
           name: this._translateService.instant('My organisation'),
           routerLink: this._myOrganisationRouterLink(),
-          iconCssClass: 'fa fa-university'
+          iconCssClass: 'fa fa-university',
+          id: 'my-organisation-menu'
         }, {
           name: this._translateService.instant('My library'),
           routerLink: this._myLibraryRouterLink(),
-          iconCssClass: 'fa fa-university'
+          iconCssClass: 'fa fa-university',
+          id: 'my-library-menu'
         }, {
           name: this._translateService.instant('Libraries'),
           routerLink: '/records/libraries',
-          iconCssClass: 'fa fa-university'
+          iconCssClass: 'fa fa-university',
+          id: 'libraries-menu'
         }]
       }
     ]


### PR DESCRIPTION
In Cypress it's difficult to choose a specific item in the menu if you
don't know in which language you are. Each element can be in French,
English, etc.
To facilitate this work we can add `id=` on each element on the menu.
With a specific word. This way you don't need to know in which language
you are.

* Adds Id on all menus ('My Account' menu, languages menu, help menu,
logout, etc.) for testing purposes.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `ng-core/dev#`.

## How to test?

```
* clone ng-core
* do `npm i && npm ci && npm run pack`
* clone this repository (rero-ils-ui)
* do `npm i && npm i ../ng-core/rero-ng-core-0.5.0.tgz`
* launch rero-ils server `cd rero-ils && poetry run server`
* launch rero-ils-ui: `cd rero-ils-ui && npm run start-admin-proxy`
* Use your browser debugger to check that menu items have `id=`. For example Help menu have `id=help-menu`
```

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
