### PR TITLE
ui: select holding item barcode through IDs

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -16,7 +16,7 @@
 -->
 <ng-container *ngIf="item && permissions">
   <div class="offset-sm-1 col-sm-3">
-    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
+    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" [attr.id]="getId(item.metadata, '-item')">
       {{ item.metadata.barcode }}
     </a>
     <span class="float-right text-warning small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
@@ -54,7 +54,8 @@
     <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
             type="button" class="btn btn-outline-danger btn-sm ml-1"
             title="{{ 'Delete' | translate}}"
-            (click)="delete(item.metadata.pid)">
+            (click)="delete(item.metadata.pid)"
+            [attr.id]="getId(item.metadata, '-delete')">
         <i class="fa fa-trash" ></i>
     </button>
     <ng-template #deleteInfo>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
@@ -120,4 +120,20 @@ export class DefaultHoldingItemComponent implements OnInit {
     return this._recordPermissionService.generateTooltipMessage(this.permissions.canRequest.reasons, 'request');
   }
 
+  /**
+   * Get item ID (barcode) and add optional suffix on it
+   * @param item metadata from item
+   * @param suffix suffix to add after item ID (barcode)
+   * @return a string
+   */
+  getId(item: any, suffix?: string): string {
+    if (item.barcode !== null) {
+      let res = item.barcode;
+      if (suffix !== null) {
+        res += suffix;
+      }
+      return res;
+    }
+  }
+
 }


### PR DESCRIPTION
* Adds `id=` attribute on holding item barcode link
* Adds `id=` attribute on holding item deletion button link

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

Enhance UI view by using ID on item barcode (for holding item detailed view) and deletion button.

## How to test?

* start RERO ILS server (port 5000)
* launch `npm run start-admin-proxy`
* Go to a document detailed view
* Check that each item barcode have an attribute `id=`. For example: `id="10000003-item"`.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
