### PR TITLE
ui: replace getId() by idAttribute Pipe

### DIFF
--- a/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
+++ b/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.html
@@ -22,7 +22,7 @@
   </div>
   <ul class="list-group list-group-flush" *ngIf="item.entries">
     <li class="list-group-item p-0" *ngFor="let entry of item.entries">
-      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink" [queryParams]="entry.queryParams" [attr.id]="getId(entry, '-frontpage')"><i *ngIf="entry.iconCssClass"
+      <a class="list-group-item btn btn-light text-left text-wrap" [routerLink]="entry.routerLink" [queryParams]="entry.queryParams" [attr.id]="entry.id | idAttribute:{suffix: 'frontpage'}"><i *ngIf="entry.iconCssClass"
         [ngClass]="entry.iconCssClass" aria-hidden="true"></i> {{ entry.name | translate }}</a>
     </li>
   </ul>

--- a/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.ts
+++ b/projects/admin/src/app/frontpage/frontpage-board/frontpage-board.component.ts
@@ -26,19 +26,4 @@ export class FrontpageBoardComponent {
   /** List of items to display */
   @Input() item: any;
 
-  /**
-   * Get item ID and add optional suffix on it
-   * @param item menu item
-   * @param suffix suffix to add after item id
-   * @return a string
-   */
-  getId(item: any, suffix?: string): string {
-    if (item.id !== null) {
-      let res = item.id;
-      if (suffix !== null) {
-        res += suffix;
-      }
-      return res;
-    }
-  }
 }

--- a/projects/admin/src/app/pipe/id-attribute.pipe.spec.ts
+++ b/projects/admin/src/app/pipe/id-attribute.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { IdAttributePipe } from './id-attribute.pipe';
+
+describe('IdAttributePipe', () => {
+  it('create an instance', () => {
+    const pipe = new IdAttributePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/pipe/id-attribute.pipe.ts
+++ b/projects/admin/src/app/pipe/id-attribute.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'idAttribute'
+})
+
+export class IdAttributePipe implements PipeTransform {
+
+  transform(value: any, options?: {prefix?: string|null, suffix?: string|null}, ...args: any[]): any {
+    // If no options, return only value
+    if (!options) {
+      return value;
+    }
+
+    let parts = [options.prefix || null, value, options.suffix || null];
+    parts = parts.filter(v => v !== null);
+    return parts.join('-');
+  }
+
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -16,7 +16,7 @@
 -->
 <ng-container *ngIf="item && permissions">
   <div class="offset-sm-1 col-sm-3">
-    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
+    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
       {{ item.metadata.barcode }}
     </a>
     <span class="float-right text-warning small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
@@ -54,7 +54,8 @@
     <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
             type="button" class="btn btn-outline-danger btn-sm ml-1"
             title="{{ 'Delete' | translate}}"
-            (click)="delete(item.metadata.pid)">
+            (click)="delete(item.metadata.pid)"
+            [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item', suffix: 'delete'}">
         <i class="fa fa-trash" ></i>
     </button>
     <ng-template #deleteInfo>

--- a/projects/admin/src/app/shared/shared-pipes.module.ts
+++ b/projects/admin/src/app/shared/shared-pipes.module.ts
@@ -21,16 +21,19 @@ import { AuthorNameTranslatePipe } from '../pipe/author-name-translate.pipe';
 import { MainTitlePipe } from '../pipe/main-title.pipe';
 import { ProvisionActivityPipe } from '../pipe/provision-activity.pipe';
 import { PatronBlockedMessagePipe } from '../pipe/patron-blocked-message.pipe';
+import { IdAttributePipe } from '../pipe/id-attribute.pipe';
 
 @NgModule({
   declarations: [
     AuthorNameTranslatePipe,
+    IdAttributePipe,
     MainTitlePipe,
     ProvisionActivityPipe,
     PatronBlockedMessagePipe
   ],
   exports: [
     AuthorNameTranslatePipe,
+    IdAttributePipe,
     MainTitlePipe,
     ProvisionActivityPipe,
     PatronBlockedMessagePipe

--- a/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
+++ b/projects/public-search/src/app/person-brief/person-brief.component.spec.ts
@@ -27,6 +27,7 @@ import { BioInformationsPipe } from '../pipes/bio-informations.pipe';
 import { BirthDatePipe } from '../pipes/birth-date.pipe';
 import { MefTitlePipe } from '../pipes/mef-title.pipe';
 import { PersonBriefComponent } from './person-brief.component';
+import { IdAttributePipe } from 'projects/admin/src/app/pipe/id-attribute.pipe';
 
 
 describe('PersonBriefComponent', () => {
@@ -40,6 +41,7 @@ describe('PersonBriefComponent', () => {
         MefTitlePipe,
         BirthDatePipe,
         BioInformationsPipe,
+        IdAttributePipe,
         FrontpageComponent,
         FrontpageBoardComponent
       ],


### PR DESCRIPTION
Cypress needs to use `id=` attributes in HTML tags to target elements.
At the moment a getId() method is used in each component. But the need
is global. It's probably better to use a Pipe element (from Angular) to
format `id=` attributes content.

* Adds a new idAttribute Pipe component in Angular application
* Changes document detail view to:
  * add `id=` on barcode link
  * add `id=` on deletion button link

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

To improve way we generates `id=` attributes in professional view interface.

## How to test?

Just start a rero-ils instance on port 5000 (Cf. https://localhost:5000).
Then launch `npm run start-admin-proxy`, then go to https://localhost:4200 and check with your developer debug toolbar (in your browser) that main menu have `id=help-menu` (for help menu i.e), that frontpage dashboard have some `id=documents-menu-frontpage`.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
