### PR TITLE
ui: add `id=` HTML attributes on item lists

### DIFF
--- a/projects/admin/src/app/circulation/item/item.component.html
+++ b/projects/admin/src/app/circulation/item/item.component.html
@@ -28,7 +28,10 @@
       aria-controls="collapse">
       <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }" class="fa" aria-hidden="true"></i>
     </button>
-    <a [routerLink]="['/records','items','detail', item.pid]">{{ item.barcode }}</a>
+    <a [routerLink]="['/records','items','detail', item.pid]"
+       name="barcode">
+      {{ item.barcode }}
+    </a>
     <ng-container *ngIf="item.actionDone">
       <ng-container *ngIf="(item.actionDone === itemAction.checkin && item.getNote('checkin_note')) ||
                            (item.actionDone === itemAction.checkout && item.getNote('checkout_note'))">
@@ -38,7 +41,7 @@
   </div>
   <!-- TITLE -->
   <div class="col-lg-4">
-    <a [routerLink]="['/records','documents','detail', item.document.pid]" *ngIf="item.document.title | mainTitle as title ">
+    <a [routerLink]="['/records','documents','detail', item.document.pid]" *ngIf="item.document.title | mainTitle as title " name="title">
       {{ title | truncateText: 12 }}
     </a>
   </div>
@@ -46,17 +49,17 @@
   <div class="col-lg-3">
     <ul class="list-unstyled mb-0">
       <ng-container [ngSwitch]="item.status">
-        <li *ngSwitchCase="'on_loan'">{{ item.status | translate }} <i class="fa fa-arrow-right" aria-hidden="true"></i>
+        <li *ngSwitchCase="'on_loan'" name="status">{{ item.status | translate }} <i class="fa fa-arrow-right" aria-hidden="true"></i>
           {{ item.loan.dueDate | dateTranslate :'shortDate' }}</li>
-        <li *ngSwitchCase="'in_transit'">{{ item.status | translate }}
+        <li *ngSwitchCase="'in_transit'" name="status">{{ item.status | translate }}
           <ng-container *ngIf="getTransitLocationPid(item) | getRecord: 'locations' | async as location">
             ({{ 'to' | translate }}
             <ng-container *ngIf="item.loan && item.loan.state === 'ITEM_IN_TRANSIT_FOR_PICKUP'; else toHouse"> {{ location.metadata.pickup_name }})</ng-container>
             <ng-template #toHouse> {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }})</ng-template>
           </ng-container>
         </li>
-        <li *ngSwitchCase="'on_shelf'">{{ item.status | translate }}</li>
-        <li *ngSwitchDefault>{{ item.status | translate }}</li>
+        <li *ngSwitchCase="'on_shelf'" name="status">{{ item.status | translate }}</li>
+        <li *ngSwitchDefault name="status">{{ item.status | translate }}</li>
       </ng-container>
       <!-- RENEWALS, FEES, REQUESTS -->
       <li>
@@ -75,7 +78,7 @@
     </ul>
   </div>
   <!-- ACTION DONE -->
-  <div class="col-lg-2">
+  <div class="col-lg-2" name="action-done">
     <ng-container *ngIf="item.actionDone" [ngSwitch]="item.actionDone">
       <ng-container *ngSwitchCase="itemAction.checkin">
         <i class="fa fa-arrow-circle-o-down text-success align-baseline" aria-hidden="true"></i>
@@ -99,22 +102,22 @@
     <dl class="row">
       <ng-container *ngIf="item.loan && item.loan.pickup_location_pid">
         <dt class="col-sm-5 col-md-3 label-title" translate>Location</dt>
-        <dd class="col-sm-7 col-md-9">
+        <dd class="col-sm-7 col-md-9" name="location">
           {{ item.loan.pickup_location_pid | getRecord: 'locations' : 'field' : 'code' | async }} {{ item.location.name }}
         </dd>
       </ng-container>
       <ng-container *ngIf="item.loan && item.loan.extension_count">
         <dt class="col-sm-5 col-md-3 label-title" translate>Renewals</dt>
-        <dd class="col-sm-7 col-md-9">{{ item.loan.extension_count }}</dd>
+        <dd class="col-sm-7 col-md-9" name="renewals">{{ item.loan.extension_count }}</dd>
       </ng-container>
       <ng-container *ngIf="totalAmountOfFee > 0">
         <dt class="col-sm-5 col-md-3 label-title" translate>Fees</dt>
-        <dd class="col-sm-7 col-md-9">{{ totalAmountOfFee | currency: organisation.default_currency }}</dd>
+        <dd class="col-sm-7 col-md-9" name="fees">{{ totalAmountOfFee | currency: organisation.default_currency }}</dd>
       </ng-container>
       <ng-container *ngIf="notifications$ | async as notifications">
         <ng-container *ngIf="notifications.length > 0">
           <dt class="col-sm-5 col-md-3 label-title" translate>Notifications</dt>
-          <dd class="col-sm-7 col-md-9">
+          <dd class="col-sm-7 col-md-9" name="notifications">
             <ul class="list-unstyled pl-2 mb-0">
               <li *ngFor="let notification of notifications">
                 {{ notification.metadata.process_date | dateTranslate :'shortDate' }}:
@@ -126,17 +129,17 @@
       </ng-container>
       <ng-container *ngIf="item.pending_loans">
         <dt class="col-sm-5 col-md-3 label-title" translate>Requests</dt>
-        <dd class="col-sm-7 col-md-9">{{ item.pending_loans.length }}</dd>
+        <dd class="col-sm-7 col-md-9" name="requests">{{ item.pending_loans.length }}</dd>
         <dt class="col-sm-5 col-md-3 label-title" translate="">For</dt>
-        <dd class="col-sm-7 col-md-9">{{ item.pending_loans[0].patron.name }}</dd>
+        <dd class="col-sm-7 col-md-9" name="request-for">{{ item.pending_loans[0].patron.name }}</dd>
       </ng-container>
       <ng-container *ngIf="item.actionDone && item.actionDone === itemAction.checkin && item.getNote('checkin_note') as note">
         <dt class="col-sm-5 col-md-3 label-title" translate>{{ note.type }}</dt>
-        <dd class="col-sm-7 col-md-9 text-justify">{{ note.content }}</dd>
+        <dd class="col-sm-7 col-md-9 text-justify" name="checkin-note">{{ note.content }}</dd>
       </ng-container>
       <ng-container *ngIf="item.actionDone && item.actionDone === itemAction.checkout && item.getNote('checkout_note') as note">
         <dt class="col-sm-5 col-md-3 label-title" translate>{{ note.type }}</dt>
-        <dd class="col-sm-7 col-md-9 text-justify">{{ note.content }}</dd>
+        <dd class="col-sm-7 col-md-9 text-justify" name="checkout-note">{{ note.content }}</dd>
       </ng-container>
     </dl>
   </div>

--- a/projects/admin/src/app/circulation/items-list/items-list.component.html
+++ b/projects/admin/src/app/circulation/items-list/items-list.component.html
@@ -35,6 +35,7 @@
         <button class="btn btn-primary d-none d-lg-block"
         (click)="extendAllLoansClick()"
         [disabled]="loansToExtend.length < 1"
+        id="renew-all-button"
         translate>Renew all</button>
       </div>
     </div>
@@ -43,15 +44,16 @@
   <div class="row align-items-start" *ngFor="let item of checkedOutItems">
     <!-- CONTENT -->
     <div class="col mr-1">
-      <admin-item [patron]="patron" [item]="item">
+      <admin-item [patron]="patron" [item]="item" [attr.id]="item.barcode | idAttribute:{prefix: 'item'}">
       </admin-item>
     </div>
     <!-- ACTIONS -->
     <div *ngIf="patron" class="col-md-2 text-left pl-0 mb-2">
       <!-- extend loan action -->
-      <button id="button-basic" type="button"
+      <button type="button"
               class="btn btn-outline-secondary mr-1 d-md-block"
               [disabled]="!item.actions.includes(extendLoan)"
+              [attr.id]="item.barcode | idAttribute:{prefix: 'item', suffix: 'renew-button'}"
               (click)="extendLoanClick($event, item)" translate>
         Renew
       </button>
@@ -61,7 +63,8 @@
   <!--   Callout border for [TRANSIT|REQUEST|FEE] -->
   <div class="row align-items-start" *ngFor="let item of checkedInItems">
     <div class="col mr-1">
-      <admin-item [patron]="patron" [item]="item" (hasFeesEmitter)="hasFees($event)"></admin-item>
+      <admin-item [patron]="patron" [item]="item" (hasFeesEmitter)="hasFees($event)" [attr.id]="item.barcode | idAttribute:{prefix: 'item'}">
+      </admin-item>
     </div>
     <div *ngIf="patron" class="col-md-2 pl-0 mb-2">
       <!-- No actions -->

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -16,30 +16,32 @@
 -->
 <ng-container *ngIf="item && permissions">
   <div class="offset-sm-1 col-sm-3">
-    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
+    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
       {{ item.metadata.barcode }}
     </a>
     <span class="float-right text-warning small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
       <i class="fa fa-sticky-note-o pr-1"></i>{{ item.metadata.notes.length }}
     </span>
   </div>
-  <div class="col-sm-2">
+  <div class="col-sm-2" name="status">
     {{ item.metadata.status | translate }}
   </div>
-  <div class="col-sm-2">
+  <div class="col-sm-2" name="call-number">
     {{ callNumber }}
   </div>
   <div class="col-sm-4 text-right">
     <ng-container *ngIf="isHoldingMatchUserLibraryPID">
       <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
               type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
-              title="{{ 'Item request' | translate}}">
+              title="{{ 'Item request' | translate}}"
+              name="request">
         <i class="fa fa-shopping-basket" aria-hidden="true"></i>
       </button>
       <ng-template #notRequest>
         <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
                 title="{{ 'Item request' | translate}}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave">
+                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+                name="request">
           <i class="fa fa-shopping-basket" aria-hidden="true"></i>
         </button>
         <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
@@ -48,20 +50,22 @@
     <button *ngIf="permissions.update && permissions.update.can"
             type="button" class="btn btn-sm btn-outline-primary ml-1"
             title="{{ 'Edit' | translate}}"
-            [routerLink]="['/records', 'items', 'edit', item.metadata.pid]">
+            [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
+            name="edit">
       <i class="fa fa-pencil"></i>
     </button>
     <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
             type="button" class="btn btn-outline-danger btn-sm ml-1"
             title="{{ 'Delete' | translate}}"
             (click)="delete(item.metadata.pid)"
-            [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item', suffix: 'delete'}">
+            name="delete">
         <i class="fa fa-trash" ></i>
     </button>
     <ng-template #deleteInfo>
       <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
               title="{{ 'Delete' | translate}}"
-              [popover]="tolTemplate" triggers="mouseenter:mouseleave">
+              [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+              name="delete">
         <i class="fa fa-trash"></i>
       </button>
       <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -74,10 +74,11 @@
                 *ngFor="let item of items | slice:0: displayItemsCounter"
                 [holding]="holding"
                 [item]="item"
-                (deleteItem)="deleteItem($event)">
+                (deleteItem)="deleteItem($event)"
+                [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
             ></admin-serial-holding-item>
             <div class="row pl-3" *ngIf="displayItemsCounter < totalItemsCounter">
-              <a [routerLink]="" (click)="showMore(5)">
+              <a [routerLink]="" (click)="showMore(5)" [attr.id]="holding.metadata.pid | idAttribute:{prefix: 'holding', suffix: 'show-more-button'}">
                 <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
                 {{ 'Show more' | translate }} ...
               </a>
@@ -104,10 +105,11 @@
                 class="row mt-1"
                 [holding]="holding"
                 [item]="item"
-                (deleteItem)="deleteItem($event)">
+                (deleteItem)="deleteItem($event)"
+                [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
             </admin-default-holding-item>
             <div class="row pl-3" *ngIf="displayItemsCounter < totalItemsCounter">
-              <a [routerLink]="" (click)="showMore(5)">
+              <a [routerLink]="" (click)="showMore(5)" [attr.id]="holding.metadata.pid | idAttribute:{prefix: 'holding', suffix: 'show-more-button'}">
                 <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
                 {{ 'Show more' | translate }} ...
               </a>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -16,29 +16,31 @@
 -->
 <div class="row mt-1" *ngIf="item && permissions && item.metadata.issue.status !== itemIssueStatus.DELETED">
   <div class="col-sm-3">
-    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]">
+    <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
       {{ item.metadata.barcode }}
     </a>
   </div>
-  <div class="col-sm-2" translate>
+  <div class="col-sm-2" translate name="status">
     {{ item.metadata.status }}
   </div>
-  <div class="col-sm-3">
+  <div class="col-sm-3" name="issue">
     {{ item.metadata.issue.display_text }}
   </div>
-  <div class="col-sm-2">
+  <div class="col-sm-2" name="call-number">
     {{ callNumber }}
   </div>
   <div class="col-sm-2 text-right">
     <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
             type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
-            title="{{ 'Item request' | translate}}">
+            title="{{ 'Item request' | translate}}"
+            name="request">
       <i class="fa fa-shopping-basket" aria-hidden="true"></i>
     </button>
     <ng-template #notRequest>
       <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
               title="{{ 'Item request' | translate}}"
-              [popover]="tolTemplate" triggers="mouseenter:mouseleave">
+              [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+              name="request">
         <i class="fa fa-shopping-basket" aria-hidden="true"></i>
       </button>
       <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
@@ -46,19 +48,22 @@
     <button *ngIf="permissions.update && permissions.update.can"
             type="button" class="btn btn-sm btn-outline-primary ml-1"
             title="{{ 'Edit' | translate}}"
-            [routerLink]="['/records', 'items', 'edit', item.metadata.pid]">
+            [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
+            name="edit">
       <i class="fa fa-pencil"></i>
     </button>
     <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
             type="button" class="btn btn-outline-danger btn-sm ml-1"
             title="{{ 'Delete' | translate}}"
-            (click)="delete(item.metadata.pid)">
+            (click)="delete(item.metadata.pid)"
+            name="delete">
       <i class="fa fa-trash" ></i>
     </button>
     <ng-template #deleteInfo>
       <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
               title="{{ 'Delete' | translate}}"
-              [popover]="tolTemplate" triggers="mouseenter:mouseleave">
+              [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+              name="delete">
         <i class="fa fa-trash"></i>
       </button>
       <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>


### PR DESCRIPTION
* Adds `id=` HTML attributes on each item on item list (from
holding/serials)
* Adds `id=` HTML attributes on item request button
* Adds `id=` HTML attributes on item edit button
* Adds `id=` HTML attributes on item delete button
* Adds `id=` HTML attributes on `Show more` link on serials/holding

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
