### PR TITLE
item: update UI to manage 'new_acquisition' field

### DIFF
--- a/projects/admin/src/app/class/items.ts
+++ b/projects/admin/src/app/class/items.ts
@@ -154,6 +154,8 @@ export class Item {
   number_of_extensions: number;
   location: any;
   notes: ItemNote[];
+  acquisition_date: Moment;
+
 
   constructor(obj?: any) {
     Object.assign(this, obj);

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -72,6 +72,19 @@
       <dd class="col-sm-7 col-md-8 mb-0">
         <admin-item-availability [item]="record"></admin-item-availability>
       </dd>
+      <!-- ACQUISITION -->
+      <dt class="col-sm-3 offset-sm-2 offset-md-0">
+        {{ 'New acquisition' | translate }}:
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        <i class="fa"
+           [ngClass]="(record.metadata.acquisition_date) ? 'fa-check text-success' : 'fa-times text-danger'"
+           aria-hidden="true">
+        </i>
+        <span class="ml-1" *ngIf="record.metadata.acquisition_date">
+          ({{ record.metadata.acquisition_date | dateTranslate : 'shortDate' }})
+        </span>
+      </dd>
     </dl>
   </section>
 
@@ -95,8 +108,7 @@
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Regular issue</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
           <i class="fa"
-             [ngClass]="(record.metadata.issue.regular) ? 'fa-check' : 'fa-times'"
-             [ngStyle]="{'color': (record.metadata.issue.regular) ? 'green' : 'red'}"
+             [ngClass]="(record.metadata.issue.regular) ? 'fa-check text-success' : 'fa-times text-danger'"
              aria-hidden="true">
           </i>
         </dd>

--- a/projects/admin/src/app/routes/holdings-route.ts
+++ b/projects/admin/src/app/routes/holdings-route.ts
@@ -90,7 +90,7 @@ export class HoldingsRoute extends BaseRoute implements RouteInterface {
       const apiService = this._routeToolService.apiService;
       const libraryPid = user.currentLibrary;
       const query = `library.pid:${libraryPid}`;
-      field.templateOptions.options = recordService.getRecords(
+      recordService.getRecords(
         'locations',
         query, 1,
         RecordService.MAX_REST_RESULTS_SIZE,
@@ -111,7 +111,7 @@ export class HoldingsRoute extends BaseRoute implements RouteInterface {
             };
           });
         })
-      );
+      ).subscribe(options => field.templateOptions.options = options);
     }
     return field;
   }


### PR DESCRIPTION
This commit updates the item detail view to display a mention about new
acquisition. This commit also fixes a problem when 'location' select
field was populated to avoid a circular stringify error.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-Auhtored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
