### PR TITLE
item: conditional renewal badges.

### DIFF
--- a/projects/admin/src/app/circulation/item/item.component.html
+++ b/projects/admin/src/app/circulation/item/item.component.html
@@ -64,7 +64,7 @@
       <!-- RENEWALS, FEES, REQUESTS -->
       <li>
         <span title="{{ 'Renewals' | translate }}" class="badge badge-secondary font-weight-normal mr-1"
-              *ngIf="item.loan && item.loan.extension_count">
+              *ngIf="item.loan && item.loan.extension_count && (!item.actionDone || item.actionDone !== itemAction.checkin)">
           {{ item.loan.extension_count }} <i class="fa fa-refresh"></i>
         </span>
         <span title="{{ 'Fees' | translate }}" class="badge badge-warning font-weight-normal mr-1"


### PR DESCRIPTION
The renewal badges should not be displayed when a checkin action in done
on the corresponding item. This commit change the behavior of this badge
to be conditional depending if a 'checkin' action is done on the item.

Closes rero/rero-ils#797


## How to test?

Test procedure describes a https://github.com/rero/rero-ils/issues/797

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
