### PR TITLE
circulation: replace pickup location name by library name

### DIFF
--- a/projects/admin/src/app/circulation/item/item.component.html
+++ b/projects/admin/src/app/circulation/item/item.component.html
@@ -100,10 +100,10 @@
   <!-- COLLAPSED DETAILS -->
   <div class="col-sm-12 mt-2" *ngIf="!isCollapsed">
     <dl class="row">
-      <ng-container *ngIf="item.loan && item.loan.pickup_location_pid">
+      <ng-container *ngIf="item.location.pid | getRecord: 'locations' | async as location">
         <dt class="col-sm-5 col-md-3 label-title" translate>Location</dt>
         <dd class="col-sm-7 col-md-9" name="location">
-          {{ item.loan.pickup_location_pid | getRecord: 'locations' : 'field' : 'code' | async }} {{ item.location.name }}
+          {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}: {{ item.location.name }}
         </dd>
       </ng-container>
       <ng-container *ngIf="item.loan && item.loan.extension_count">


### PR DESCRIPTION
* Replaces the item pickup location name by the item library name in
collapsed details.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

This is the issue nb 4 reported by Nicolas during the tests of new circulation ui:

Scenario C: after CHECKIN_3.2.2.2
When I expand the loan in the checkin interface, the location displayed is the pickup location name (see screenshot).
Expected: the item location should be displayed, as for a standard checkin.

## Dependencies

My PR depends on:

* rero/rero-ils US1394 branch

## How to test?

Login as (system) librarian and go to a patron circulation view.
Uncollapse the details in the items of the list and check the location name.
Should be:
`Location:        library name: item location name`

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
