### PR TITLE
circulation: allow request for organisation items

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -30,23 +30,21 @@
     {{ callNumber }}
   </div>
   <div class="col-sm-4 text-right">
-    <ng-container *ngIf="isHoldingMatchUserLibraryPID">
-      <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
-              type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
+    <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
+            type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
+            title="{{ 'Item request' | translate}}"
+            name="request">
+      <i class="fa fa-shopping-basket" aria-hidden="true"></i>
+    </button>
+    <ng-template #notRequest>
+      <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
               title="{{ 'Item request' | translate}}"
+              [popover]="tolTemplate" triggers="mouseenter:mouseleave"
               name="request">
         <i class="fa fa-shopping-basket" aria-hidden="true"></i>
       </button>
-      <ng-template #notRequest>
-        <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
-                title="{{ 'Item request' | translate}}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
-                name="request">
-          <i class="fa fa-shopping-basket" aria-hidden="true"></i>
-        </button>
-        <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
-      </ng-template>
-    </ng-container>
+      <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
+    </ng-template>
     <button *ngIf="permissions.update && permissions.update.can"
             type="button" class="btn btn-sm btn-outline-primary ml-1"
             title="{{ 'Edit' | translate}}"

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
@@ -76,15 +76,6 @@ export class DefaultHoldingItemComponent implements OnInit {
     });
   }
 
-  /** Check if the holding owning library correspond to the current user library affiliation.
-   *
-   * Used to display the request button. A more advanced test is performed when the patron barcode is known.
-   * @returns - true if match
-   */
-  get isHoldingMatchUserLibraryPID(): boolean {
-    return this._userService.getCurrentUser().currentLibrary === this.holding.metadata.library.pid;
-  }
-
   /**
    * Get formatted call number
    *


### PR DESCRIPTION
The request document button was only available for the current library
items. This commit updates this behavior ; now all items of the current
logged user application can be requested.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

Closes rero/rero-ils#927

## How to test?

- Try to request a document for another library than the current logged user library (but in the same organisation)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
