### PR TITLE
circulation: fix patron info in loan view

### DIFF
--- a/projects/admin/src/app/circulation/checkin/checkin.component.ts
+++ b/projects/admin/src/app/circulation/checkin/checkin.component.ts
@@ -157,14 +157,20 @@ export class CheckinComponent implements OnInit {
       this.isLoading = true;
       this._patronService
         .getPatron(barcode)
-        .pipe(map(patron => (patron.displayPatronMode = false)))
-        .subscribe(
-          () => (this.isLoading = false),
-          error =>
+        .pipe(map(patron => {
+          if (patron) {
+            patron.displayPatronMode = false;
+          }
+        }))
+        .subscribe(() => {
+            this.isLoading = false;
+          },
+          error => {
             this._toastService.error(
               error.message,
               this._translate.instant('Checkin')
-            ),
+            );
+          },
           () => console.log('patron by pid success')
         );
     } else {

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -80,6 +80,7 @@ export class LoanComponent implements OnInit {
       this.patron = patron;
       if (patron) {
         this.isLoading = true;
+        this.patron.displayPatronMode = true;
         this._patronService.getItems(patron.pid).subscribe(items => {
           this.checkedOutItems = items;
           this.isLoading = false;


### PR DESCRIPTION
* Fixes patron info in loan view: it couldn't be removed in order to go
to checkin view (displayPatronMode is setted to false in checkin view
and not updated when going to loan view).
* Fixes the display of a flash error message saying 'patron is
undefined' when going to loan view after a checkin in checkin view.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

![circ](https://user-images.githubusercontent.com/28982829/91144003-ae897580-e6b3-11ea-8d4d-af6b11990d71.png)

![checkin](https://user-images.githubusercontent.com/28982829/91144091-d082f800-e6b3-11ea-99a0-6464ad55dfdb.png)

## Why are you opening this PR?
Task 1693 of US1665

## Dependencies

N/A

## How to test?

Do a checkin or a receive in checkin view (User services > Circulation).
Then type a patron barcode to go to patron loan view. A red button should be displayed in order to remove patron info and go back to checkin view.
No error flash message saying `patron is undefined` should be displayed.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
