### PR TITLE
document: clear '_draft' key when saving document.

### DIFF
--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -61,7 +61,9 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               simple: 1
             },
             preprocessRecordEditor: (record: any) => {
-              return this.removeKey(record, '_text');
+              record = this.removeKey(record, '_text');
+              record = this.removeKey(record, '_draft');
+              return record;
             },
             aggregations: (aggregations: any) => this._routeToolService
               .aggregationFilter(aggregations),


### PR DESCRIPTION
The `_draft` property is used to specify that the document is a draft and
should not be validated before saving into back-end. When a user click
on the document editor "save" button, this property shouldn't be present into the record, so the record can be validated by the backend API. 
This property could be set using the "save as template" functionality.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

Should be tested with https://github.com/rero/rero-ils/tree/US1546-marcxml-support

* Find a document with `_draft` property into backend
* go to the document editor for this pid
* save the document
* check the backend document data for this pid ; `_draft` key should be removed

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
