### PR TITLE
template: adapt routes for templates

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { LOCALE_ID, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyModule } from '@ngx-formly/core';
 import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { CoreConfigService, RecordModule, TranslateLoader, TranslateService } from '@rero/ng-core';
+import { CoreConfigService, RecordModule, RemoteTypeaheadService, TranslateLoader, TranslateService } from '@rero/ng-core';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDatepickerModule, BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -33,13 +33,14 @@ import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { UiSwitchModule } from 'ngx-toggle-switch';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { MefTypeahead } from './class/mef-typeahead';
+import { TabOrderDirective } from './directives/tab-order.directive';
 import { ErrorPageComponent } from './error/error-page/error-page.component';
-import { FrontpageBoardComponent } from './widgets/frontpage/frontpage-board/frontpage-board.component';
-import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
 import { NoCacheHeaderInterceptor } from './interceptor/no-cache-header.interceptor';
 import { MenuComponent } from './menu/menu.component';
 import { BioInformationsPipe } from './pipe/bio-informations.pipe';
 import { BirthDatePipe } from './pipe/birth-date.pipe';
+import { MarcPipe } from './pipe/marc.pipe';
 import { MefTitlePipe } from './pipe/mef-title.pipe';
 import { NotesFormatPipe } from './pipe/notes-format.pipe';
 import { AcquisitionOrderBriefViewComponent } from './record/brief-view/acquisition-order-brief-view.component';
@@ -47,6 +48,7 @@ import { BudgetsBriefViewComponent } from './record/brief-view/budgets-brief-vie
 import { CircPoliciesBriefViewComponent } from './record/brief-view/circ-policies-brief-view.component';
 import { DocumentsBriefViewComponent } from './record/brief-view/documents-brief-view/documents-brief-view.component';
 import { ItemTypesBriefViewComponent } from './record/brief-view/item-types-brief-view.component';
+import { ItemsBriefViewComponent } from './record/brief-view/items-brief-view/items-brief-view.component';
 import { LibrariesBriefViewComponent } from './record/brief-view/libraries-brief-view.component';
 import { PatronTypesBriefViewComponent } from './record/brief-view/patron-types-brief-view.component';
 import { PatronsBriefViewComponent } from './record/brief-view/patrons-brief-view.component';
@@ -107,13 +109,10 @@ import { PersonDetailViewComponent } from './record/detail-view/person-detail-vi
 import { VendorDetailViewComponent } from './record/detail-view/vendor-detail-view/vendor-detail-view.component';
 import { ItemAvailabilityComponent } from './record/item-availability/item-availability.component';
 import { AppConfigService } from './service/app-config.service';
-import { SharedPipesModule } from './shared/shared-pipes.module';
-import { MarcPipe } from './pipe/marc.pipe';
-import { TabOrderDirective } from './directives/tab-order.directive';
-import { ItemsBriefViewComponent } from './record/brief-view/items-brief-view/items-brief-view.component';
 import { UiRemoteTypeaheadService } from './service/ui-remote-typeahead.service';
-import { RemoteTypeaheadService } from '@rero/ng-core';
-import { MefTypeahead } from './class/mef-typeahead';
+import { SharedPipesModule } from './shared/shared-pipes.module';
+import { FrontpageBoardComponent } from './widgets/frontpage/frontpage-board/frontpage-board.component';
+import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
 import { TemplatesBriefViewComponent } from './record/brief-view/templates-brief-view.component';
 import { TemplateDetailViewComponent } from './record/detail-view/template-detail-view/template-detail-view.component';
 import { DocumentsTypeahead } from './class/documents-typeahead';

--- a/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.ts
+++ b/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.ts
@@ -74,7 +74,7 @@ export class DocumentEditorComponent {
     if (value === false) {
       combineLatest([this._route.params, this._route.queryParams])
         .subscribe(([params, queryParams]) => {
-          if (queryParams.source != null && queryParams.pid != null) {
+          if (queryParams.source != null && queryParams.source !== 'templates' && queryParams.pid != null) {
             this.importFromExternalSource(queryParams.source, queryParams.pid);
           }
         });

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -51,7 +51,14 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
             key: this.name,
             label: 'Documents',
             showLabel: false,
-            editorLongMode: true,
+            editorSettings: {
+              longMode: true,
+              template: {
+                recordType: 'templates',
+                loadFromTemplate: true,
+                saveAsTemplate: true
+              }
+            },
             component: DocumentsBriefViewComponent,
             detailComponent: DocumentDetailViewComponent,
             canUpdate: (record: any) => this._routeToolService.canUpdate(record, this.recordType),

--- a/projects/admin/src/app/routes/holdings-route.ts
+++ b/projects/admin/src/app/routes/holdings-route.ts
@@ -50,6 +50,13 @@ export class HoldingsRoute extends BaseRoute implements RouteInterface {
           {
             key: this.name,
             label: 'Holdings',
+            editorSettings: {
+              template: {
+                recordType: 'templates',
+                loadFromTemplate: true,
+                saveAsTemplate: true
+              }
+            },
             detailComponent: HoldingDetailViewComponent,
             canUpdate: (record: any) => this._routeToolService.canUpdate(record, this.recordType),
             canDelete: (record: any) => this._routeToolService.canDelete(record, this.recordType),

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -56,6 +56,13 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
           {
             key: this.name,
             label: 'Items',
+            editorSettings: {
+              template: {
+                recordType: 'templates',
+                loadFromTemplate: true,
+                saveAsTemplate: true
+              }
+            },
             component: ItemsBriefViewComponent,
             detailComponent: ItemDetailViewComponent,
             canRead: (record: any) => this.canReadItem(record),

--- a/projects/admin/src/app/routes/patrons-route.ts
+++ b/projects/admin/src/app/routes/patrons-route.ts
@@ -50,6 +50,13 @@ export class PatronsRoute extends BaseRoute implements RouteInterface {
           {
             key: this.name,
             label: 'Patrons',
+            editorSettings: {
+              template: {
+                recordType: 'templates',
+                loadFromTemplate: true,
+                saveAsTemplate: true
+              }
+            },
             component: PatronsBriefViewComponent,
             detailComponent: PatronDetailViewComponent,
             canUpdate: (record: any) => this._routeToolService.canUpdate(record, this.recordType),

--- a/projects/admin/src/app/service/editor.service.ts
+++ b/projects/admin/src/app/service/editor.service.ts
@@ -22,7 +22,8 @@ export class EditorService {
 
   /**
    * Get record from rero-ils API
-   * @param ean EAN code
+   * @param source: the source where to find the data
+   * @param pid: the pid corresponding to the data to load
    * @returns observable of null if the record does not exists else an
    * observable containing the record
    */


### PR DESCRIPTION
* This commit introduces a new modal widget component able to list
  templates (filtered by resource type) and send, to the parent container
  (mainly editor), associated data. The parent container has
  responsibility to manage the data as it wants (fill the form, transform
  data, ...)
* Adapts `editorSettings` for several resources.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

* https://github.com/rero/rero-ils/pull/1199
* https://github.com/rero/ng-core/pull/246

## How to test?

- Try to create a new document using 'load template' button

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
