### PR TITLE
editor: define custom documents typeahead type

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -114,6 +114,8 @@ import { ItemsBriefViewComponent } from './record/brief-view/items-brief-view/it
 import { UiRemoteTypeaheadService } from './service/ui-remote-typeahead.service';
 import { RemoteTypeaheadService } from '@rero/ng-core';
 import { MefTypeahead } from './class/mef-typeahead';
+import { DocumentsTypeahead } from './class/documents-typeahead';
+import { MainTitlePipe } from './pipe/main-title.pipe';
 
 @NgModule({
   declarations: [
@@ -235,7 +237,9 @@ import { MefTypeahead } from './class/mef-typeahead';
       deps: [TranslateService]
     },
     BsLocaleService,
-    MefTypeahead
+    MefTypeahead,
+    DocumentsTypeahead,
+    MainTitlePipe
   ],
   entryComponents: [
     CircPoliciesBriefViewComponent,

--- a/projects/admin/src/app/class/documents-typeahead.ts
+++ b/projects/admin/src/app/class/documents-typeahead.ts
@@ -1,0 +1,122 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ * Copyright (C) 2020 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { ApiService, RecordService, SuggestionMetadata } from '@rero/ng-core';
+import { of, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MainTitlePipe } from '../pipe/main-title.pipe';
+
+/**
+ * Escape string using regular expression.
+ */
+function escapeRegExp(data) {
+  return data.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+@Injectable()
+export class DocumentsTypeahead {
+
+  /** Maximum length of the suggestion */
+  maxLengthSuggestion = 100;
+
+  /**
+   * Constructor
+   * @param _apiService - ApiService
+   * @param _recordService - RecordService
+   * @param _translateService - TranslateService
+   */
+  constructor(
+    @Inject(ApiService) private _apiService: ApiService,
+    @Inject(RecordService) private _recordService: RecordService,
+    @Inject(MainTitlePipe) private _mainTitlePipe: MainTitlePipe
+  ) { }
+
+  /**
+   * Convert the input value (i.e. $ref url) into a template html code.
+   * @param options - remote typeahead options
+   * @param value - formControl value i.e. $ref value
+   * @returns Observable of string - html template representation of the value.
+   */
+  getValueAsHTML(options: any, value: string): Observable<string> {
+    const url = value.split('/');
+    const pid = url.pop();
+
+    return this._recordService
+      .getRecord(options.type, pid, 1)
+      .pipe(
+        map((data: any) =>
+          `<span class="bg-light p-2"><strong>${this._mainTitlePipe.transform(data.metadata.title)}</strong></span>`
+        )
+      );
+  }
+
+  /**
+   * Get the suggestions list given a search query.
+   * @param options - remote typeahead options
+   * @param query - search query to retrieve the suggestions list
+   * @param numberOfSuggestions - the max number of suggestion to return
+   * @returns - an observable of the list of suggestions.
+   */
+  getSuggestions(options: any, query: string, numberOfSuggestions: number): Observable<Array<SuggestionMetadata>> {
+    if (!query) {
+      return of([]);
+    }
+    return this._recordService
+      .getRecords(
+        'documents',
+        `autocomplete_title:'${query}'`,
+        1,
+        numberOfSuggestions
+      ).pipe(
+        map((results: any) => {
+          const documemts = [];
+          if (!results) {
+            return [];
+          }
+          results.hits.hits.map((hit: any) => {
+            documemts.push(this._getDocumentRef(hit.metadata, query));
+          });
+          return documemts;
+        })
+      );
+  }
+
+  /**
+   * Returns label and $ref.
+   *
+   * @param metadata - the meta data.
+   * @param query - search query term.
+   * @return Metadata - the label, $ref.
+   */
+  private _getDocumentRef(metadata: any, query: string): SuggestionMetadata {
+    let text = this._mainTitlePipe.transform(metadata.title);
+    let truncate = false;
+    if (text.length > this.maxLengthSuggestion) {
+      truncate = true;
+      text = this._mainTitlePipe.transform(metadata.title).substr(0, this.maxLengthSuggestion);
+    }
+    text = text.replace(new RegExp(escapeRegExp(query), 'gi'), `<b>${query}</b>`);
+    if (truncate) {
+      text = text + ' ...';
+    }
+    return {
+      label: text,
+      value: this._apiService.getRefEndpoint('documents', metadata.pid)
+    };
+  }
+}

--- a/projects/admin/src/app/service/ui-remote-typeahead.service.spec.ts
+++ b/projects/admin/src/app/service/ui-remote-typeahead.service.spec.ts
@@ -20,6 +20,8 @@ import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-tran
 import { RecordModule } from '@rero/ng-core';
 import { MefTypeahead } from '../class/mef-typeahead';
 import { UiRemoteTypeaheadService } from './ui-remote-typeahead.service';
+import { DocumentsTypeahead } from '../class/documents-typeahead';
+import { MainTitlePipe } from '../pipe/main-title.pipe';
 
 describe('UiRemoteTypeaheadService', () => {
   beforeEach(() => TestBed.configureTestingModule({
@@ -31,7 +33,9 @@ describe('UiRemoteTypeaheadService', () => {
     })
     ],
     providers: [
-      MefTypeahead
+      MefTypeahead,
+      DocumentsTypeahead,
+      MainTitlePipe
     ]
   }));
 

--- a/projects/admin/src/app/service/ui-remote-typeahead.service.ts
+++ b/projects/admin/src/app/service/ui-remote-typeahead.service.ts
@@ -18,6 +18,7 @@ import { Injectable, Injector } from '@angular/core';
 import { RemoteTypeaheadService, RecordService, ApiService, SuggestionMetadata } from '@rero/ng-core';
 import { Observable } from 'rxjs';
 import { MefTypeahead } from '../class/mef-typeahead';
+import { DocumentsTypeahead } from '../class/documents-typeahead';
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +27,8 @@ export class UiRemoteTypeaheadService extends RemoteTypeaheadService {
 
   /** Custom typeahead Type */
   private _typeaheadTypes = {
-    mef: this._injector.get(MefTypeahead)
+    mef: this._injector.get(MefTypeahead),
+    documents: this._injector.get(DocumentsTypeahead)
   };
 
   /**


### PR DESCRIPTION
Extends remote typeahead component to be able to search list
of suggestion of documents.

* Adds a new class for custom documents typeahead.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
