### PR TITLE
search: fix contribution link

### DIFF
--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -41,7 +41,7 @@
             <span *ngIf="!contribution.agent.pid">
               {{ contribution | contributionFormat }}
             </span>
-            <a *ngIf="contribution.agent.pid" [routerLink]="['/records', 'persons', 'detail', contribution.agent.pid]">
+            <a *ngIf="contribution.agent.pid" [href]="getPersonLink(contribution.agent.pid)">
               {{ contribution | contributionFormat }}
             </a>
             {{ last ? '' : '; ' }}

--- a/projects/public-search/src/app/document-brief/document-brief.component.ts
+++ b/projects/public-search/src/app/document-brief/document-brief.component.ts
@@ -73,14 +73,25 @@ export class DocumentBriefComponent {
     private localRecordService: LocalRecordService
   ) {  }
 
-    /**
-     * Load cover image
-     */
+  /**
+   * Load cover image
+   * @param isbn - isbn of the document
+   * @returns string - url of the cover if cover exists.
+   */
   getCover(isbn: string) {
     this.localRecordService.getCover(isbn).subscribe(result => {
       if (result.success) {
         this.coverUrl = result.image;
       }
     });
+  }
+
+  /**
+   * Get link to MEF person
+   * @param pid - a MEF PID
+   * @returns string - link to MEF person.
+   */
+  getPersonLink(pid: string) {
+    return `/${this.viewcode}/persons/${pid}`;
   }
 }


### PR DESCRIPTION
Fixes wrong link to MEF person in the document brief view of the public interface.

*  Adds function to get MEF Person link.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
