### PR TITLE
templates: add 'use it' functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,9 +3178,9 @@
       }
     },
     "@rero/ng-core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.10.0.tgz",
-      "integrity": "sha512-TXJwAdZOmSvq+RQzIzdA/CHDa+F+9W0XYvYlooOixy48IpiRb6FcVShylB1oqPtQpP8iysAsyc2mP8bgrNhrrQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.11.1.tgz",
+      "integrity": "sha512-O88ltXdjSEsh4tpsEparZZBoNwhTC6e3NH8fcQtYoUadnhQqcoaTcFtjQv4MO6jSrRfBJfgdKY5ZTMTUPiqFEQ==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@ngx-formly/bootstrap": "^5.9.1",
     "@ngx-formly/core": "^5.9.1",
     "@ngx-translate/core": "^12.1.1",
-    "@rero/ng-core": "^0.10.0",
+    "@rero/ng-core": "^0.11.1",
     "bootstrap": "^4.3.1",
     "crypto-js": "^3.1.9-1",
     "document-register-element": "^1.7.2",

--- a/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.spec.ts
@@ -17,6 +17,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
  */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormlyModule } from '@ngx-formly/core';
@@ -78,7 +79,8 @@ describe('DocumentEditorComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         FormlyModule.forRoot({}),
-        RecordModule
+        RecordModule,
+        BrowserAnimationsModule,
       ],
       providers: [
         EditorService,

--- a/projects/admin/src/app/record/custom-editor/holding-editor/holding-editor.component.spec.ts.disabled
+++ b/projects/admin/src/app/record/custom-editor/holding-editor/holding-editor.component.spec.ts.disabled
@@ -7,7 +7,9 @@ import { TranslateService, TranslateModule, TranslateLoader, TranslateFakeLoader
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+// FIX THIS TEST
 describe('HoldingEditorComponent', () => {
   let component: HoldingEditorComponent;
   let fixture: ComponentFixture<HoldingEditorComponent>;
@@ -43,7 +45,8 @@ describe('HoldingEditorComponent', () => {
         }),
         RecordModule,
         HttpClientTestingModule,
-        RouterTestingModule
+        RouterTestingModule,
+        BrowserAnimationsModule,
       ],
       declarations: [ HoldingEditorComponent ],
       providers: [

--- a/projects/admin/src/app/routes/route-tool.service.ts
+++ b/projects/admin/src/app/routes/route-tool.service.ts
@@ -16,7 +16,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router, UrlSerializer } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { ActionStatus, ApiService, RecordService } from '@rero/ng-core';
 import { Observable, of, Subscriber } from 'rxjs';
@@ -78,6 +78,20 @@ export class RouteToolService {
   }
 
   /**
+   * @return router
+   */
+  get router() {
+    return this._router;
+  }
+
+  /**
+   * @return urlSerializer
+   */
+  get urlSerializer() {
+    return this._urlSerializer;
+  }
+
+  /**
    * Constructor
    *
    * @param _translateService - TranslateService
@@ -86,7 +100,9 @@ export class RouteToolService {
    * @param _activatedRoute - ActivatedRoute
    * @param _recordService - RecordService
    * @param _recordPermissionService - RecordPermissionService
-   * @param _datePipe - DatePipe
+   * @param _datePipe - DatePipe,
+   * @param _router - Router
+   * @param _urlSerializer - UrlSerializer
    */
   constructor(
     private _translateService: TranslateService,
@@ -95,7 +111,9 @@ export class RouteToolService {
     private _activatedRoute: ActivatedRoute,
     private _recordService: RecordService,
     private _recordPermissionService: RecordPermissionService,
-    private _datePipe: DatePipe
+    private _datePipe: DatePipe,
+    private _router: Router,
+    private _urlSerializer: UrlSerializer
   ) { }
 
   /**
@@ -170,6 +188,26 @@ export class RouteToolService {
                 : this._recordPermissionService.generateDeleteMessage(permission.delete.reasons)
             });
           });
+    });
+  }
+
+
+  /**
+   * Check if a record can be read
+   *
+   * @param record - Object: the resource object to check
+   * @param recordType - String: the record type
+   * @return Observable providing object with 2 attributes :
+   *     - 'can' - Boolean: to know if the resource could be deleted
+   *     - 'message' - String: the message to display if the record cannot be deleted
+   */
+  canRead(record: any, recordType: string): Observable<ActionStatus> {
+    return new Observable((observer: Subscriber<any>): void => {
+      this._recordPermissionService
+        .getPermission(recordType, record.metadata.pid)
+        .subscribe((permission: RecordPermission) => {
+          observer.next({can: permission.read.can, message: ''});
+        });
     });
   }
 

--- a/projects/admin/src/app/service/record-permission.service.ts
+++ b/projects/admin/src/app/service/record-permission.service.ts
@@ -217,6 +217,9 @@ export class RecordPermissionService {
  * Permission response structure
  */
 export interface RecordPermission {
+  read: {
+    can: boolean
+  };
   update: {
     can: boolean
   };


### PR DESCRIPTION
This commit implements the 'canUse' permission function allowing to use
a template as a skeleton for a new resource.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## Dependencies

* https://github.com/rero/ng-core/pull/250

## How to test?

- List template ; for each one, a new button should be available to use it in the related editor.
- Into a template detail page : a new button "Use" is also available

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
