### PR TITLE
document: improve translated aggregations

### DIFF
--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -69,10 +69,7 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               .aggregationFilter(aggregations),
             aggregationsOrder: [
               'document_type',
-              'contribution__fr',
-              'contribution__en',
-              'contribution__de',
-              'contribution__it',
+              'author',
               'organisation',
               'language',
               'subject',

--- a/projects/public-search/src/app/manual_translations.ts
+++ b/projects/public-search/src/app/manual_translations.ts
@@ -18,8 +18,6 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
 // _('Your string');
-// Facets
-_('author');
 
 // Document type
 _('other');

--- a/projects/public-search/src/app/service/routing-init.service.ts
+++ b/projects/public-search/src/app/service/routing-init.service.ts
@@ -108,10 +108,7 @@ export class RoutingInitService {
     if (this._appConfigService.globalViewName === viewcode) {
       return [
         _('document_type'),
-        _('contribution__fr'),
-        _('contribution__en'),
-        _('contribution__de'),
-        _('contribution__it'),
+        _('author'),
         _('organisation'),
         _('language'),
         _('subject'),
@@ -120,10 +117,7 @@ export class RoutingInitService {
     } else {
       return [
         _('document_type'),
-        _('contribution__fr'),
-        _('contribution__en'),
-        _('contribution__de'),
-        _('contribution__it'),
+        _('author'),
         _('library'),
         _('language'),
         _('subject'),


### PR DESCRIPTION
The current language used to retrieve only nested i18n aggregation.

* Renames contribution facet to author.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#1195

## How to test?

- Check author facet in public search and admin search

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
