### PR TITLE
document: allow record duplication

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -16,11 +16,16 @@
 -->
 <!-- import button for external source importation such as BNF -->
 <div *ngIf="record && record.metadata && !record.metadata.pid && pid && source" class="float-right ml-4 mt-2 mb-4">
-  <a routerLink="/records/documents/new" [queryParams]="{source: source, pid: pid}" class="btn btn-sm btn-primary"
+  <a [routerLink]="['/records', 'documents', 'new']" [queryParams]="{source: source, pid: pid}" class="btn btn-sm btn-primary"
     translate>Import</a>
 </div>
+<!-- duplicate button -->
+<div *ngIf="record && record.metadata && record.metadata.pid" class="float-right mt-2 mb-4 btn-duplicate">
+  <a [routerLink]="['/records', 'documents', 'duplicate']" [queryParams]="{type: 'documents', pid: record.metadata.pid}" class="btn btn-sm btn-primary"
+    translate>Duplicate</a>
+</div>
 <ng-container *ngIf="record">
-  <!-- HEADER ----------------------------------------------------------------->
+  <!-- HEADER -->
   <header class="col-10 mt-3 mb-3">
     <!-- TYPE -->
     <ng-container *ngIf="record.metadata.type">
@@ -92,30 +97,30 @@
     </ng-container>
 
     <!-- IS PART OF -->
-      <ng-container *ngFor="let document of record.metadata.partOf; let i = index">
-        <ng-container *ngIf="document.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
-          <dl class="row mb-0">
-            <dt id="{{'doc-part-of-label-' + i}}" class="col-auto">
-              {{ getPartOfLabel(hostDocument) }}
-            </dt>
-            <dd class="col mb-0">
-              <div class="row">
-                <a id="{{'doc-part-of-' + i}}"[routerLink]="['/records', 'documents', 'detail', document.document.pid]">
-                  {{ getShortMainTitle(hostDocument.metadata.title) }}
-                </a>
-                <ng-container *ngIf="document.numbering">
-                  <span>;</span>
-                  <ul class="list-unstyled mb-0 ml-1">
-                    <li *ngFor="let numbering of document.numbering">
-                      <span id="{{'doc-part-of-numbering-' + i}}"*ngIf="formatNumbering(numbering) as num">{{ num }}</span>
-                    </li>
-                  </ul>
-                </ng-container>
-              </div>
-            </dd>
-          </dl>
-        </ng-container>
+    <ng-container *ngFor="let document of record.metadata.partOf; let i = index">
+      <ng-container *ngIf="document.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
+        <dl class="row mb-0">
+          <dt id="{{'doc-part-of-label-' + i}}" class="col-auto">
+            {{ getPartOfLabel(hostDocument) }}
+          </dt>
+          <dd class="col mb-0">
+            <div class="row">
+              <a id="{{'doc-part-of-' + i}}"[routerLink]="['/records', 'documents', 'detail', document.document.pid]">
+                {{ getShortMainTitle(hostDocument.metadata.title) }}
+              </a>
+              <ng-container *ngIf="document.numbering">
+                <span>;</span>
+                <ul class="list-unstyled mb-0 ml-1">
+                  <li *ngFor="let numbering of document.numbering">
+                    <span id="{{'doc-part-of-numbering-' + i}}" *ngIf="formatNumbering(numbering) as num">{{ num }}</span>
+                  </li>
+                </ul>
+              </ng-container>
+            </div>
+          </dd>
+        </dl>
       </ng-container>
+    </ng-container>
 
     <!-- ABSTRACT -->
     <ng-container *ngIf=" record.metadata.abstracts && record.metadata.abstracts.length > 0">

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.scss
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.scss
@@ -1,0 +1,20 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+.btn-duplicate {
+  z-index: 1000;
+  position: relative;
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
@@ -25,7 +25,7 @@ import { Observable, of, Subscription } from 'rxjs';
 @Component({
   selector: 'admin-document-detail-view',
   templateUrl: './document-detail-view.component.html',
-  styles: []
+  styleUrls: ['./document-detail-view.component.scss']
 })
 export class DocumentDetailViewComponent implements DetailRecord, OnInit, OnDestroy {
 

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -41,7 +41,8 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
         { path: '', component: RecordSearchComponent },
         { path: 'detail/:pid', component: DetailComponent },
         { path: 'edit/:pid', component: DocumentEditorComponent, canActivate: [ CanUpdateGuard ] },
-        { path: 'new', component: DocumentEditorComponent }
+        { path: 'new', component: DocumentEditorComponent },
+        { path: 'duplicate', component: DocumentEditorComponent }
       ],
       data: {
         linkPrefix: 'records',

--- a/projects/admin/src/app/service/editor.service.spec.ts
+++ b/projects/admin/src/app/service/editor.service.spec.ts
@@ -1,19 +1,56 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
 import { EditorService } from './editor.service';
 
-
 describe('EditorService', () => {
+  const record = {
+    metadata: {
+      pid: 1,
+      title: 'my title'
+    }
+  };
+  let editorService: EditorService;
+
+  const recordServiceSpy = jasmine.createSpyObj(
+    'recordService', ['getRecord']
+  );
+  recordServiceSpy.getRecord.and.returnValue(of(record));
+
   beforeEach(() => TestBed.configureTestingModule({
     imports: [
-      HttpClientTestingModule
+      HttpClientTestingModule,
+      TranslateModule.forRoot()
     ],
     providers: [
+      { provide: RecordService, useValue: recordServiceSpy },
     ]
   }));
 
+  beforeEach(() => {
+    editorService = TestBed.get(EditorService);
+  });
+
   it('should be created', () => {
-    const service: EditorService = TestBed.get(EditorService);
-    expect(service).toBeTruthy();
+    expect(editorService).toBeTruthy();
   });
 });

--- a/projects/admin/src/app/service/editor.service.ts
+++ b/projects/admin/src/app/service/editor.service.ts
@@ -1,23 +1,36 @@
-import { Injectable } from '@angular/core';
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { of, Observable } from 'rxjs';
 import { PredictionIssue } from './holdings.service';
 
 @Injectable({
   providedIn: 'root'
 })
-/**
- * Deliver piece of data for EditorComponent: Record from BNF (aka Bibliothèque Nationale de France).
- * Get Holding pattern preview examples.
- */
 export class EditorService {
   /**
    * Constructor
-   * @param http HttpClient
+   * @param _http - HttpClient
    */
   constructor(
-    private http: HttpClient,
+    private _http: HttpClient
   ) { }
 
   /**
@@ -26,8 +39,8 @@ export class EditorService {
    * @returns observable of null if the record does not exists else an
    * observable containing the record
    */
-  getRecordFromExternal(source, pid): Observable<any> {
-    return this.http.get<any>(`/api/import_${source}/${pid}`).pipe(
+  getRecordFromExternal(source: string, pid: string): Observable<any> {
+    return this._http.get<any>(`/api/import_${source}/${pid}`).pipe(
       catchError(e => {
         if (e.status === 404) {
           return of(null);
@@ -43,7 +56,7 @@ export class EditorService {
    * @returns an object with an issues property containing the list of samples
    */
   getHoldingPatternPreview(data: any, size = 10): Observable<PredictionIssue[]> {
-    return this.http.post<any>(`/api/holding/pattern/preview`, {
+    return this._http.post<any>(`/api/holding/pattern/preview`, {
       data: data.patterns,
       size
     }).pipe(


### PR DESCRIPTION
This feature allows you to duplicate a document by clicking on the duplicate button in the detailed view.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Select a document and click "duplicate" button.
- Modify data and save.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
