### PR TITLE
holding: fix holding display problem.

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -101,7 +101,7 @@
               <div class="col-sm-2" translate>Call number</div>
             </div>
             <admin-default-holding-item
-                *ngFor="let item of items"
+                *ngFor="let item of items | slice:0: displayItemsCounter"
                 class="row mt-1"
                 [holding]="holding"
                 [item]="item"

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
@@ -30,8 +30,8 @@ export class HoldingComponent implements OnInit, OnDestroy {
   /** Holding record */
   @Input() holding: any;
 
-  /** Document harvested */
-  @Input() holdingType: 'electronic' | 'serial' | 'standard';
+  /** shortcut for holding type */
+  holdingType: 'electronic' | 'serial' | 'standard';
 
   /** Items */
   items: any = null;
@@ -70,6 +70,7 @@ export class HoldingComponent implements OnInit, OnDestroy {
 
   /** Init */
   ngOnInit() {
+    this.holdingType = this.holding.metadata.holdings_type;
     if (this.holdingType !== 'electronic') {
       this._loadItems();
     }

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
@@ -15,21 +15,20 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-  <div class="row" *ngIf="canAdd">
-    <div class="col" [ngSwitch]="holdingType">
-      <a *ngSwitchCase="'standard'" class="btn btn-sm btn-outline-primary mt-2 float-right"
-        [routerLink]="['/', 'records', 'items', 'new']" [queryParams]="{ document: documentPid }">
-        <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
-      </a>
-      <a *ngSwitchCase="'serial'" class="btn btn-sm btn-outline-primary float-right"
-        [routerLink]="['/', 'records', 'holdings', 'new']" [queryParams]="{ document: documentPid }">
-        <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
-      </a>
-    </div>
+<div class="row" *ngIf="canAdd">
+  <div class="col" [ngSwitch]="holdingType">
+    <a *ngSwitchCase="'standard'" class="btn btn-sm btn-outline-primary mt-2 float-right"
+      [routerLink]="['/', 'records', 'items', 'new']" [queryParams]="{ document: documentPid }">
+      <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
+    </a>
+    <a *ngSwitchCase="'serial'" class="btn btn-sm btn-outline-primary float-right"
+      [routerLink]="['/', 'records', 'holdings', 'new']" [queryParams]="{ document: documentPid }">
+      <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
+    </a>
   </div>
+</div>
 
 <ng-container *ngIf="holdings">
-  <admin-document-holding *ngFor="let holding of holdings" [holding]="holding" [holdingType]="holdingType"
-    (deleteHolding)="deleteHolding($event)">
+  <admin-document-holding *ngFor="let holding of holdings" [holding]="holding" (deleteHolding)="deleteHolding($event)">
   </admin-document-holding>
 </ng-container>


### PR DESCRIPTION
If a document is a serial or electronic, all linked holdings was force
to be displayed as serial/electronic. This PR fix this problem ; despite
of the document metadata, the holding is display depending of the
holding_type metadata from the holding.

Closes rero/rero-ils#1252

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

https://github.com/rero/rero-ils/issues/1252

## How to test?

- display "serial/electronic" documents detailed view and check holdings display. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
