### PR TITLE
search list: add extend link when no result has been found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7623,28 +7623,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -7655,14 +7655,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -7673,42 +7673,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -7718,28 +7718,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7749,14 +7749,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7773,7 +7773,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -7788,14 +7788,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -7805,7 +7805,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7815,7 +7815,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7826,21 +7826,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -7850,14 +7850,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -7867,14 +7867,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -7885,7 +7885,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -7895,7 +7895,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -7905,14 +7905,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -7924,7 +7924,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -7943,7 +7943,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7954,14 +7954,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -7972,7 +7972,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7985,21 +7985,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -8009,21 +8009,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -8034,21 +8034,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -8061,7 +8061,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -8070,7 +8070,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -8086,7 +8086,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -8096,49 +8096,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -8150,7 +8150,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8160,7 +8160,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -8170,14 +8170,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -8193,14 +8193,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -8210,14 +8210,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -119,6 +119,7 @@ import { PatronTypesDetailViewComponent } from './record/detail-view/patron-type
 import { PersonDetailViewComponent } from './record/detail-view/person-detail-view/person-detail-view.component';
 import { TemplateDetailViewComponent } from './record/detail-view/template-detail-view/template-detail-view.component';
 import { VendorDetailViewComponent } from './record/detail-view/vendor-detail-view/vendor-detail-view.component';
+import { DocumentRecordSearchComponent } from './record/document-record-search/document-record-search.component';
 import { ItemAvailabilityComponent } from './record/item-availability/item-availability.component';
 import { AppConfigService } from './service/app-config.service';
 import { AppInitService } from './service/app-init.service';
@@ -212,7 +213,8 @@ export function appInitFactory(appInitService: AppInitService) {
     CollectionBriefViewComponent,
     CollectionDetailViewComponent,
     CollectionItemsComponent,
-    HoldingItemInCollectionComponent
+    HoldingItemInCollectionComponent,
+    DocumentRecordSearchComponent
   ],
   imports: [
     AppRoutingModule,
@@ -311,7 +313,8 @@ export function appInitFactory(appInitService: AppInitService) {
     TemplateDetailViewComponent,
     CollectionBriefViewComponent,
     CollectionDetailViewComponent,
-    HoldingItemInCollectionComponent
+    HoldingItemInCollectionComponent,
+    DocumentRecordSearchComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/admin/src/app/record/brief-view/documents-brief-view/documents-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/documents-brief-view/documents-brief-view.component.html
@@ -15,36 +15,38 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<h5 class="mb-0 card-title">
-  <a name="document-title" [routerLink]="[detailUrl.link]">
-    <ng-container *ngIf="record.metadata.ui_title_text else mainTitle">
-      {{ record.metadata.ui_title_text }}
-    </ng-container>
-    <ng-template #mainTitle>
-      {{ record.metadata.title | mainTitle }}
-    </ng-template>
-  </a>
-<small> &ndash; {{ record.metadata.type | translate }}</small></h5>
-<ng-container class="card-text">
-  <!-- contribution -->
-  <ul class="list-inline mb-0" *ngIf="record.metadata.contribution && record.metadata.contribution.length > 0">
-    <li
-      class="list-inline-item"
-      *ngFor="let contribution of record.metadata.contribution.slice(0,3); let last = last; let i = index"
-    >
-      <span *ngIf="!contribution.agent.pid">
-        {{ contribution | contributionFormat }}
-      </span>
-      <a *ngIf="contribution.agent.pid" [routerLink]="['/records', 'persons', 'detail', contribution.agent.pid]">
-        {{ contribution | contributionFormat }}
-      </a>
-      {{ last ? '' : '; ' }}
-      {{ last && record.metadata.contribution.length > 3 ? '; …' : '' }}
-    </li>
-  </ul>
+<ng-container *ngIf="record">
+  <h5 class="mb-0 card-title">
+    <a name="document-title" [routerLink]="[detailUrl.link]">
+      <ng-container *ngIf="record.metadata.ui_title_text else mainTitle">
+        {{ record.metadata.ui_title_text }}
+      </ng-container>
+      <ng-template #mainTitle>
+        {{ record.metadata.title | mainTitle }}
+      </ng-template>
+    </a>
+  <small> &ndash; {{ record.metadata.type | translate }}</small></h5>
+  <ng-container class="card-text">
+    <!-- contribution -->
+    <ul class="list-inline mb-0" *ngIf="record.metadata.contribution && record.metadata.contribution.length > 0">
+      <li
+        class="list-inline-item"
+        *ngFor="let contribution of record.metadata.contribution.slice(0,3); let last = last; let i = index"
+      >
+        <span *ngIf="!contribution.agent.pid">
+          {{ contribution | contributionFormat }}
+        </span>
+        <a *ngIf="contribution.agent.pid" [routerLink]="['/records', 'persons', 'detail', contribution.agent.pid]">
+          {{ contribution | contributionFormat }}
+        </a>
+        {{ last ? '' : '; ' }}
+        {{ last && record.metadata.contribution.length > 3 ? '; …' : '' }}
+      </li>
+    </ul>
 
-  <!-- provision activity publications -->
-  <ul class="list-unstyled" *ngIf="provisionActivityPublications.length > 0">
-    <li *ngFor="let publication of provisionActivityPublications">{{ publication.value }}</li>
-  </ul>
+    <!-- provision activity publications -->
+    <ul class="list-unstyled" *ngIf="provisionActivityPublications.length > 0">
+      <li *ngFor="let publication of provisionActivityPublications">{{ publication.value }}</li>
+    </ul>
+  </ng-container>
 </ng-container>

--- a/projects/admin/src/app/record/custom-editor/holding-editor/holding-editor.component.spec.ts.disabled
+++ b/projects/admin/src/app/record/custom-editor/holding-editor/holding-editor.component.spec.ts.disabled
@@ -30,7 +30,7 @@ import { HoldingEditorComponent } from './holding-editor.component';
 describe('HoldingEditorComponent', () => {
   let component: HoldingEditorComponent;
   let fixture: ComponentFixture<HoldingEditorComponent>;
-  const recordService = jasmine.createSpyObj('RecordService', ['getSchemaForm']);
+  const recordService = jasmine.createSpyObj('RecordService', ['getSchemaForm', 'getRecord']);
   recordService.getSchemaForm.and.returnValue(of({
     schema: {
       type: 'object',
@@ -38,11 +38,11 @@ describe('HoldingEditorComponent', () => {
       properties: {}
     }
   }));
+  recordService.getRecord.and.returnValue(of({metadata: { pid: '1' }}));
   const route = {
+    params: of({ type: 'holdings', pid: 1 }),
     snapshot: {
-      paramMap: convertToParamMap({
-        type: 'holdings', pid: '1'
-      }),
+      params: { type: 'holdings', pid: 1 },
       data: {
         types: [
           {
@@ -50,10 +50,12 @@ describe('HoldingEditorComponent', () => {
           }
         ],
         showSearchInput: true,
-        adminMode: true
+        adminMode: of({ message: '', can: true })
       }
-    }
+    },
+    queryParams: of({})
   };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/projects/admin/src/app/record/document-record-search/document-record-search.component.html
+++ b/projects/admin/src/app/record/document-record-search/document-record-search.component.html
@@ -1,0 +1,27 @@
+<!--
+  RERO ILS UI
+   Copyright (C) 2019 RERO
+  
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, version 3 of the License.
+  
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Affero General Public License for more details.
+  
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-core-record-search [adminMode]="adminMode" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
+  [showSearchInput]="showSearchInput" [q]="q" [page]="page" [size]="size" [sort]="sort"
+  (parametersChanged)="updateUrl($event)" (recordsSearched)="recordsSearched($event)"
+>
+  <div class="my-4" *ngIf="currentType === 'documents' && showLink">
+    <a href="#" (click)="linkToGlobalDocuments($event)" translate>
+      Expand to all organisations
+    </a>
+  </div>
+</ng-core-record-search>

--- a/projects/admin/src/app/record/document-record-search/document-record-search.component.spec.ts
+++ b/projects/admin/src/app/record/document-record-search/document-record-search.component.spec.ts
@@ -1,0 +1,140 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, convertToParamMap, Router, UrlSegment } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { DialogComponent, DialogService, RecordModule, RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+import { ContributionFormatPipe } from '../../pipe/contribution-format.pipe';
+import { DocumentRecordSearchComponent } from './document-record-search.component';
+
+
+describe('RecordSearchComponent', () => {
+  let component: DocumentRecordSearchComponent;
+  let fixture: ComponentFixture<DocumentRecordSearchComponent>;
+
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate', 'parseUrl']);
+  routerSpy.url = '';
+  routerSpy.parseUrl.and.returnValue({
+    root: {
+      children: {
+        primary: {
+          segments: [
+            new UrlSegment('records', {}),
+            new UrlSegment('documents', {}),
+          ]
+        }
+      }
+    }
+  });
+
+  const emptyRecords = {
+    aggregations: {},
+    hits: {
+      total: {
+        relation: 'eq',
+        value: 0
+      },
+      hits: []
+    },
+    links: {}
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecords', 'delete', 'totalHits']);
+  recordServiceSpy.getRecords.and.returnValue(of(emptyRecords));
+  recordServiceSpy.delete.and.returnValue(of({}));
+  recordServiceSpy.totalHits.and.returnValue(0);
+
+  const dialogServiceSpy = jasmine.createSpyObj('DialogService', ['show']);
+  dialogServiceSpy.show.and.returnValue(of(true));
+
+  const route = {
+    snapshot: {
+      data: {
+        detailUrl: '/custom/url/for/detail/:type/:pid',
+        types: [
+          {
+            key: 'documents'
+          },
+          {
+            key: 'organisations'
+          }
+        ],
+        showSearchInput: true,
+        adminMode: () => of({
+          can: false,
+          message: ''
+        })
+      },
+      queryParams: { organisation: 1 },
+      params: { type: 'documents' }
+    },
+    queryParamMap: of(convertToParamMap({
+      q: '',
+      page: 1,
+      size: 10,
+      author: ['Filippini, Massimo']
+    })),
+    paramMap: of(convertToParamMap({ type: 'documents' })),
+    queryParams: of({})
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        DocumentRecordSearchComponent,
+        ContributionFormatPipe
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        RecordModule,
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
+        })
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: route },
+        { provide: DialogService, useValue: dialogServiceSpy }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .overrideModule(BrowserDynamicTestingModule, {
+        set: {
+          entryComponents: [DialogComponent]
+        }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocumentRecordSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/document-record-search/document-record-search.component.ts
+++ b/projects/admin/src/app/record/document-record-search/document-record-search.component.ts
@@ -1,0 +1,107 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { SearchResult, RecordSearchComponent, RecordSearchService, RecordService } from '@rero/ng-core';
+
+@Component({
+  selector: 'admin-document-record-search',
+  templateUrl: './document-record-search.component.html'
+})
+export class DocumentRecordSearchComponent extends RecordSearchComponent implements OnInit {
+
+  /** Base url */
+  private _baseUrl: string;
+
+  /** Result of Elasticsearch */
+  private _searchResult: SearchResult;
+
+  /** Resource type */
+  private _documentType = 'documents';
+
+  /**
+   * Show link for no result
+   * @return boolean
+   */
+  get showLink(): boolean {
+    return this.total === 0
+      && ('organisation' in this._route.snapshot.queryParams);
+  }
+
+  /**
+   * Total number of records
+   * @return null or number
+   */
+  get total(): null | number {
+    if (this._searchResult) {
+      return this._recordService.totalHits(
+        this._searchResult.records.hits.total
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Constructor
+   * @param _route - ActivatedRoute
+   * @param _router - Router
+   * @param _recordSearchService - RecordSearchService
+   * @param _recordService - RecordService
+   */
+  constructor(
+    protected _route: ActivatedRoute,
+    protected _router: Router,
+    protected _recordSearchService: RecordSearchService,
+    private _recordService: RecordService
+  ) {
+    super(_route, _router, _recordSearchService);
+  }
+
+  /** Init */
+  ngOnInit() {
+    super.ngOnInit();
+    this._baseUrl = super.getCurrentUrl(this._documentType);
+  }
+
+  /**
+   * Result of search with type and records (Elasticsearch)
+   * @param event - SearchResult
+   */
+  recordsSearched(event: SearchResult) {
+    if (event && event.type === this._documentType) {
+      this._searchResult = event;
+    }
+  }
+
+  /**
+   * Launches a new documents search on all records
+   * @param event - Click on link
+   */
+  linkToGlobalDocuments(event: any) {
+    event.preventDefault();
+    const queryParams = this._route.snapshot.queryParams;
+    this._router.navigate(
+      [this._baseUrl],
+      { relativeTo: this._route, queryParams: {
+        q: queryParams.q || '',
+        page: 1,
+        size: queryParams.size || 10
+      }}
+    );
+  }
+}

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -15,11 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DetailComponent, RecordSearchComponent, RouteInterface } from '@rero/ng-core';
+import { DetailComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { DocumentsBriefViewComponent } from '../record/brief-view/documents-brief-view/documents-brief-view.component';
 import { DocumentEditorComponent } from '../record/custom-editor/document-editor/document-editor.component';
 import { DocumentDetailViewComponent } from '../record/detail-view/document-detail-view/document-detail-view.component';
+import { DocumentRecordSearchComponent } from '../record/document-record-search/document-record-search.component';
 import { BaseRoute } from './base-route';
 
 export class DocumentsRoute extends BaseRoute implements RouteInterface {
@@ -38,7 +39,7 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
     return {
       matcher: (url: any) => this.routeMatcher(url, this.name),
       children: [
-        { path: '', component: RecordSearchComponent },
+        { path: '', component: DocumentRecordSearchComponent },
         { path: 'detail/:pid', component: DetailComponent },
         { path: 'edit/:pid', component: DocumentEditorComponent, canActivate: [ CanUpdateGuard ] },
         { path: 'new', component: DocumentEditorComponent },

--- a/projects/public-search/src/app/app.module.ts
+++ b/projects/public-search/src/app/app.module.ts
@@ -26,23 +26,26 @@ import { BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { SharedPipesModule } from 'projects/admin/src/app/shared/shared-pipes.module';
 import { AppConfigService } from './app-config.service';
+import { AppInitializerService } from './app-initializer.service';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CollectionBriefComponent } from './collection-brief/collection-brief.component';
 import { DocumentBriefComponent } from './document-brief/document-brief.component';
+import { DocumentRecordSearchComponent } from './document-record-search/document-record-search.component';
+import { ErrorPageComponent } from './error/error-page.component';
 import { MainComponent } from './main/main.component';
 import { PersonBriefComponent } from './person-brief/person-brief.component';
 import { BioInformationsPipe } from './pipes/bio-informations.pipe';
 import { BirthDatePipe } from './pipes/birth-date.pipe';
 import { MefTitlePipe } from './pipes/mef-title.pipe';
 import { SearchBarComponent } from './search-bar/search-bar.component';
-import { AppInitializerService } from './app-initializer.service';
-import { ErrorPageComponent } from './error/error-page.component';
+
 
 /** function to instantiate the application  */
 export function appInitFactory(appInitializerService: AppInitializerService) {
   return () => appInitializerService.load();
 }
+
 
 @NgModule({
   declarations: [
@@ -55,7 +58,8 @@ export function appInitFactory(appInitializerService: AppInitializerService) {
     SearchBarComponent,
     MainComponent,
     CollectionBriefComponent,
-    ErrorPageComponent
+    ErrorPageComponent,
+    DocumentRecordSearchComponent
   ],
   imports: [
     BrowserModule,
@@ -88,7 +92,8 @@ export function appInitFactory(appInitializerService: AppInitializerService) {
     PersonBriefComponent,
     SearchBarComponent,
     CollectionBriefComponent,
-    ErrorPageComponent
+    ErrorPageComponent,
+    DocumentRecordSearchComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/public-search/src/app/document-record-search/document-record-search.component.html
+++ b/projects/public-search/src/app/document-record-search/document-record-search.component.html
@@ -1,0 +1,27 @@
+<!--
+  RERO ILS UI
+   Copyright (C) 2020 RERO
+  
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, version 3 of the License.
+  
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Affero General Public License for more details.
+  
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-core-record-search [adminMode]="adminMode" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
+  [showSearchInput]="showSearchInput" [q]="q" [page]="page" [size]="size" [sort]="sort"
+  (parametersChanged)="updateUrl($event)" (recordsSearched)="recordsSearched($event)"
+>
+  <div class="my-4" *ngIf="currentType === 'documents' && showLink">
+    <a href="#" (click)="linkToGlobalDocuments($event)" translate>
+      Expand to all RERO ILS
+    </a>
+  </div>
+</ng-core-record-search>

--- a/projects/public-search/src/app/document-record-search/document-record-search.component.spec.ts
+++ b/projects/public-search/src/app/document-record-search/document-record-search.component.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, convertToParamMap, Router, UrlSegment } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RecordModule, RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+import { DocumentRecordSearchComponent } from './document-record-search.component';
+
+describe('DocumentRecordSearchComponent', () => {
+  let component: DocumentRecordSearchComponent;
+  let fixture: ComponentFixture<DocumentRecordSearchComponent>;
+
+  const emptyRecords = {
+    aggregations: {},
+    hits: {
+      total: {
+        relation: 'eq',
+        value: 0
+      },
+      hits: []
+    },
+    links: {}
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecords', 'totalHits']);
+  recordServiceSpy.getRecords.and.returnValue(of(emptyRecords));
+  recordServiceSpy.totalHits.and.returnValue(0);
+
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate', 'parseUrl']);
+  routerSpy.navigate.and.returnValue(of(false));
+  routerSpy.url = '';
+  routerSpy.parseUrl.and.returnValue({
+    root: {
+      children: {
+        primary: {
+          segments: [
+            new UrlSegment('aoste', {}),
+            new UrlSegment('search', {}),
+            new UrlSegment('documents', {}),
+          ]
+        }
+      }
+    }
+  });
+
+  const route = {
+    snapshot: {
+      data: {
+        detailUrl: '/custom/url/for/detail/:type/:pid',
+        types: [
+          {
+            key: 'documents'
+          }
+        ],
+        showSearchInput: true,
+        // TODO: if can is setted true, this test failed.
+        adminMode: () => of({
+          can: false,
+          message: ''
+        })
+      },
+      queryParams: { q: '', page: 1, size: 10 },
+      params: { type: 'documents' }
+    },
+    queryParamMap: of(convertToParamMap({
+      q: '',
+      page: 1,
+      size: 10
+    })),
+    paramMap: of(convertToParamMap({ type: 'documents' })),
+    queryParams: of({})
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RecordModule,
+        BrowserAnimationsModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot()
+      ],
+      declarations: [
+        DocumentRecordSearchComponent
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy },
+        { provide: ActivatedRoute, useValue: route },
+        { provide: Router, useValue: routerSpy }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocumentRecordSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/public-search/src/app/document-record-search/document-record-search.component.ts
+++ b/projects/public-search/src/app/document-record-search/document-record-search.component.ts
@@ -1,0 +1,129 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RecordSearchComponent, RecordSearchService, RecordService, SearchResult } from '@rero/ng-core';
+import { AppConfigService } from '../app-config.service';
+import { RouteFactoryService } from '../routes/route-factory.service';
+
+@Component({
+  selector: 'public-search-document-record-search',
+  templateUrl: './document-record-search.component.html'
+})
+export class DocumentRecordSearchComponent extends RecordSearchComponent implements OnInit {
+
+  /** Base url */
+  private _baseUrl: string;
+
+  /** View code */
+  private _viewCode: string;
+
+  /** Result of Elasticsearch */
+  private _searchResult: SearchResult;
+
+  /** Resource type */
+  private _documentType = 'documents';
+
+  /**
+   * Show link for no result
+   * @return boolean
+   */
+  get showLink(): boolean {
+    return this.total === 0
+      && (this._appConfigService.globalViewName !== this._viewCode);
+  }
+
+  /**
+   * Total number of records
+   * @return null or number
+   */
+  get total(): null | number {
+    if (this._searchResult) {
+      return this._recordService.totalHits(
+        this._searchResult.records.hits.total
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Constructor
+   * @param _route - ActivatedRoute
+   * @param _router - Router
+   * @param _recordSearchService - RecordSearchService
+   * @param _recordService - RecordService
+   * @param _appConfigService - AppConfigService
+   * @param _routeFactoryService - RouteFactoryService
+   */
+  constructor(
+    protected _route: ActivatedRoute,
+    protected _router: Router,
+    protected _recordSearchService: RecordSearchService,
+    private _recordService: RecordService,
+    private _appConfigService: AppConfigService,
+    private _routeFactoryService: RouteFactoryService
+  ) {
+    super(_route, _router, _recordSearchService);
+  }
+
+  /** Init */
+  ngOnInit() {
+    super.ngOnInit();
+    this._convertUrlForGlobalView();
+  }
+
+  /**
+   * Result of search with type and records (Elasticsearch)
+   * @param event - SearchResult
+   */
+  recordsSearched(event: SearchResult) {
+    if (event && event.type === this._documentType) {
+      this._searchResult = event;
+    }
+  }
+
+  /**
+   * Launches a new documents search on all records
+   * @param event - Click on link
+   */
+  linkToGlobalDocuments(event: any) {
+    event.preventDefault();
+    this._routeFactoryService.createRouteByRecourceNameAndView(
+      'documents', 'global'
+    );
+    const queryParams = this._route.snapshot.queryParams;
+    this._router.navigate(
+      [this._baseUrl], {
+        relativeTo: this._route,
+        queryParams: {
+        q: queryParams.q || '',
+        page: 1,
+        size: queryParams.size || 10
+      }}
+    );
+  }
+
+  /** Convert url for global view redirect */
+  private _convertUrlForGlobalView() {
+    const segments = this._router.parseUrl(this._router.url)
+      .root.children.primary.segments.map(it => it.path);
+    this._viewCode = segments[0];
+    segments[0] = this._appConfigService.globalViewName;
+    this._baseUrl = '/' + segments.join('/');
+  }
+}

--- a/projects/public-search/src/app/routes/base-route.ts
+++ b/projects/public-search/src/app/routes/base-route.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { UrlSegment } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscriber } from 'rxjs';
 
@@ -28,35 +27,6 @@ export class BaseRoute {
   protected constructor(
     protected _translateService: TranslateService
   ) {}
-
-  /**
-   * Route matcher
-   * @param url - any
-   * @param types - array of string
-   */
-  protected routeMatcher(url: any, types: Array<string>) {
-    const urlType = url.slice(-1).pop();
-    if (types.some(x => x === urlType.path)) {
-      return this.matchedUrl(url);
-    }
-    return null;
-  }
-
-  /**
-   * Matched url
-   * @param url - array of UrlSegment
-   */
-  private matchedUrl(url: UrlSegment[]) {
-    const segments = [
-      new UrlSegment(url[0].path, {}),
-      new UrlSegment(url[1].path, {}),
-      new UrlSegment(url[2].path, {})
-    ];
-    return {
-      consumed: segments,
-      posParams: { type: new UrlSegment(url[2].path, {}) }
-    };
-  }
 
   /**
    * Filter aggregations

--- a/projects/public-search/src/app/routes/collections-route.service.ts
+++ b/projects/public-search/src/app/routes/collections-route.service.ts
@@ -61,7 +61,7 @@ export class CollectionsRouteService extends BaseRoute implements ResourceRouteI
       this.availableConfig.push(viewcode);
 
       return {
-        matcher: (url: any) => this.routeMatcher(url, ['collections']),
+        path: `${viewcode}/search/:type`,
         children: [
           { path: '', component: RecordSearchComponent, canActivate: [CollectionAccessGuard] }
         ],
@@ -70,7 +70,7 @@ export class CollectionsRouteService extends BaseRoute implements ResourceRouteI
             can: false,
             message: ''
           }),
-          detailUrl: `/${viewcode}/:type/:pid`,
+          detailUrl: `/${viewcode}/collections/:pid`,
           types: [
             {
               key: this.getName(),

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -18,10 +18,10 @@
 import { Injectable } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
-import { RecordSearchComponent } from '@rero/ng-core';
 import { of } from 'rxjs';
 import { AppConfigService } from '../app-config.service';
 import { DocumentBriefComponent } from '../document-brief/document-brief.component';
+import { DocumentRecordSearchComponent } from '../document-record-search/document-record-search.component';
 import { PersonBriefComponent } from '../person-brief/person-brief.component';
 import { BaseRoute } from './base-route';
 import { ResourceRouteInterface } from './resource-route-interface';
@@ -66,9 +66,9 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
       this.availableConfig.push(viewcode);
 
       return {
-        matcher: (url: any) => this.routeMatcher(url, ['documents', 'persons']),
+        path: `${viewcode}/search/:type`,
         children: [
-          { path: '', component: RecordSearchComponent },
+          { path: '', component: DocumentRecordSearchComponent },
         ],
         data: {
           showSearchInput: false,

--- a/projects/public-search/src/app/routes/route-factory.service.ts
+++ b/projects/public-search/src/app/routes/route-factory.service.ts
@@ -42,9 +42,11 @@ export class RouteFactoryService {
    */
   createRouteByRecourceNameAndView(resource: string, view: string) {
     const service = this._routeCollectionService.getRouteByResourceName(resource);
-    const routeConfig = service.create(view);
-    if (routeConfig) {
-      this._router.config.push(routeConfig);
+    if (service) {
+      const routeConfig = service.create(view);
+      if (routeConfig) {
+        this._router.config.push(routeConfig);
+      }
     }
   }
 }


### PR DESCRIPTION
* Adds a link to extend the search to all documents (public and admin).
* Adds a control on document brief view if the document exists.
* Changes boolean to new observable on adminMode configuration.
* Improves dynamic routing system.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Dependencies

* rero/ng-core#278

## How to test?

- Search for a term that does not exist in the results (Ex: Cheval)
- See if the extend link is present
- Click on the link and see if the url has changed and if you have results.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
