### PR TITLE
item: add item note categories

### DIFF
--- a/projects/admin/src/app/class/items.ts
+++ b/projects/admin/src/app/class/items.ts
@@ -37,10 +37,15 @@ export enum ItemStatus {
 }
 
 export enum ItemNoteType {
-  PUBLIC = _('public_note'),
+  GENERAL = _('general_note'),
   STAFF = _('staff_note'),
   CHECKIN = _('checkin_note'),
-  CHECKOUT = _('checkout_note')
+  CHECKOUT = _('checkout_note'),
+  BINDING = _('binding_note'),
+  PROVENANCE = _('provenance_note'),
+  CONDITION = _('condition_note'),
+  PATRIMONIAL = _('patrimonial_note'),
+  ACQUISITION = _('acquisition_note'),
 }
 
 export enum IssueItemStatus {
@@ -149,6 +154,15 @@ export class ItemNote {
 }
 
 export class Item {
+
+  static PUBLIC_NOTE_TYPES: ItemNoteType[] = [
+    ItemNoteType.GENERAL,
+    ItemNoteType.BINDING,
+    ItemNoteType.PROVENANCE,
+    ItemNoteType.CONDITION,
+    ItemNoteType.PATRIMONIAL
+  ]
+
   available: boolean;
   barcode: string;
   call_number: string;
@@ -167,6 +181,7 @@ export class Item {
   location: any;
   notes: ItemNote[];
   acquisition_date: Moment;
+  enumerationAndChronology: string;
 
 
   constructor(obj?: any) {

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -15,22 +15,24 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="item && permissions">
-  <div class="offset-sm-1 col-sm-3">
+  <div class="col-sm-3">
+    <span class="badge badge-secondary float-right small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
+      <i class="fa fa-sticky-note-o"></i> {{ item.metadata.notes.length }}
+    </span>
     <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
       {{ item.metadata.barcode }}
     </a>
-    <admin-holding-item-in-collection [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
-    <span class="float-right text-warning small pt-1" *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
-      <i class="fa fa-sticky-note-o pr-1"></i>{{ item.metadata.notes.length }}
-    </span>
   </div>
   <div class="col-sm-2" name="status">
     {{ item.metadata.status | translate }}
   </div>
+  <div class="col-sm-3" name="issue">
+    {{ item.metadata.enumerationAndChronology }}
+  </div>
   <div class="col-sm-2" name="call-number">
     {{ callNumber }}
   </div>
-  <div class="col-sm-4 text-right" name="buttons">
+  <div class="col-sm-2 text-right" name="buttons">
     <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
             type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
             title="{{ 'Item request' | translate}}"
@@ -70,6 +72,7 @@
       <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
     </ng-template>
   </div>
+  <admin-holding-item-in-collection [itemPid]="item.metadata.pid" [class]="'col-sm-12'"></admin-holding-item-in-collection>
 </ng-container>
 
 

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-in-collection/holding-item-in-collection.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-in-collection/holding-item-in-collection.component.html
@@ -16,7 +16,8 @@
 -->
 <ng-container *ngIf="collections">
   <div [class]="class" *ngIf="collections.length > 0">
-    <span class="font-weight-bold" translate>In</span>
+    <i class="fa fa-long-arrow-right pl-4 pr-1"></i>
+    <span class="label-title" translate>Temporary location</span>
     <ng-container *ngFor="let collection of collections; let last=last">
       <a [routerLink]="['/records', 'collections', 'detail', collection.metadata.pid]">
         {{ collection.metadata.title }}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -74,6 +74,7 @@
             </div>
             <admin-serial-holding-item
                 *ngFor="let item of items | slice:0: displayItemsCounter"
+                class="row mt-1 mb-2"
                 [holding]="holding"
                 [item]="item"
                 (deleteItem)="deleteItem($event)"
@@ -98,13 +99,14 @@
         <ng-container *ngSwitchDefault>
           <ng-container *ngIf="items && items.length > 0">
             <div class="row font-weight-bold">
-              <div class="offset-sm-1 col-sm-3" translate>Barcode</div>
+              <div class="col-sm-3" translate>Barcode</div>
               <div class="col-sm-2" translate>Status</div>
+              <div class="col-sm-3" translate>Unit</div>
               <div class="col-sm-2" translate>Call number</div>
             </div>
             <admin-default-holding-item
                 *ngFor="let item of items | slice:0: displayItemsCounter"
-                class="row mt-1"
+                class="row mt-1 mb-2"
                 [holding]="holding"
                 [item]="item"
                 (deleteItem)="deleteItem($event)"

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="row mt-1" *ngIf="item && permissions && item.metadata.issue.status !== itemIssueStatus.DELETED">
+<ng-container *ngIf="item && permissions && item.metadata.issue.status !== itemIssueStatus.DELETED">
   <div class="col-sm-3">
     <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
       {{ item.metadata.barcode }}
@@ -24,7 +24,7 @@
     {{ item.metadata.status }}
   </div>
   <div class="col-sm-3" name="issue">
-    {{ item.metadata.issue.display_text }}
+    {{ item.metadata.enumerationAndChronology }}
   </div>
   <div class="col-sm-2" name="call-number">
     {{ callNumber }}
@@ -69,7 +69,5 @@
       <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
     </ng-template>
   </div>
-  <admin-holding-item-in-collection class="col-sm-12" [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
-</div>
-
-
+  <admin-holding-item-in-collection [class]="'col-sm-12'" [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
+</ng-container>

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -88,7 +88,7 @@
                 [queryParams]="{
                     'holding': holding.id,
                     'redirectTo': 'records/holdings/detail/' + holding.id,
-                    'display_text': prediction.issue,
+                    'enumerationAndChronology': prediction.issue,
                     'expected_date': prediction.expected_date
                 }">
           <i class="fa fa-pencil"></i>
@@ -100,7 +100,7 @@
          *ngFor="let item of this.receivedItems"
          [ngClass]="{'deleted-status': item.metadata.issue.status == 'deleted'}">
       <div class="col-sm-4 text">
-        {{ item.metadata.issue.display_text }}
+        {{ item.metadata.enumerationAndChronology }}
         <span class="badge badge-pill badge-info pl-2" *ngIf="item.new_issue" translate>New</span>
       </div>
       <div class="col-sm-1 text-center">

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -35,6 +35,13 @@
             {{ record.metadata.second_call_number }}
         </dd>
       </ng-container>
+      <!-- ENUMERATION AND CHRONOLOGY / UNIT -->
+      <ng-container *ngIf="record.metadata.enumerationAndChronology">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Unit</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.enumerationAndChronology }}
+        </dd>
+      </ng-container>
       <!-- ITEM TYPE -->
       <dt class="col-sm-3 offset-sm-2 offset-md-0">
         {{ 'Type' | translate }}:
@@ -95,9 +102,6 @@
     </header>
     <section class="mb-4">
       <dl class="row mb-0">
-        <!-- numbering -->
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Numbering</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">{{ record.metadata.issue.display_text }}</dd>
         <!-- received date -->
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Received date</dt>
         <dd class="col-sm-7 col-md-8 mb-0">{{ record.metadata.issue.received_date | dateTranslate }}</dd>
@@ -126,16 +130,27 @@
     </section>
   </section>
 
+  <!-- NOTES -->
   <section *ngIf="record.metadata.notes">
     <div class="card item-notes">
       <div class="card-header" translate>Notes</div>
       <div class="card-body">
-        <div class="row mb-3" *ngFor="let note of record.metadata.notes">
-          <div class="col-12">
+        <div class="row mb-2" *ngFor="let note of record.metadata.notes">
+          <dt class="col-3 label-title">
+            <i class="fa mr-4 small"
+               [ngClass]="{
+                  'fa-eye text-success': isPublicNote(note),
+                  'fa-eye-slash text-secondary': !isPublicNote(note)
+               }"
+            ></i>
             <strong translate>{{ note.type }}</strong>
-          </div>
-          <div class="offset-1 col-11 text-justify">{{ note.content }}</div>
+          </dt>
+          <dd class="col-9 text-justify" [innerHTML]="note.content | nl2br"></dd>
         </div>
+      </div>
+      <div class="card-footer text-muted small">
+        <i class="fa fa-eye text-success"></i> {{ 'Public notes' | translate }}
+        <i class="fa fa-eye-slash text-secondary ml-4"></i> {{ 'Staff notes' | translate }}
       </div>
     </div>
   </section>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -18,7 +18,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { extractIdOnRef, RecordService } from '@rero/ng-core';
 import { DetailRecord } from '@rero/ng-core/lib/record/detail/view/detail-record';
 import { forkJoin, Observable, Subscription } from 'rxjs';
-import { IssueItemStatus } from '../../../class/items';
+import { IssueItemStatus, Item, ItemNote, ItemNoteType } from '../../../class/items';
 import { LoanService } from '../../../service/loan.service';
 
 @Component({
@@ -81,5 +81,9 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
 
   ngOnDestroy() {
     this._recordObs.unsubscribe();
+  }
+
+  isPublicNote(note: ItemNote): boolean {
+    return Item.PUBLIC_NOTE_TYPES.includes(note.type);
   }
 }

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -248,7 +248,7 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
     } catch (e) { }
     // setting other issue attributes from url parameters
     const today = this._routeToolService.datePipe.transform(Date.now(), 'yyyy-MM-dd');
-    record.issue.display_text = this._routeToolService.getRouteQueryParam('display_text', '');
+    record.enumerationAndChronology = this._routeToolService.getRouteQueryParam('enumerationAndChronology', '');
     record.issue.expected_date = this._routeToolService.getRouteQueryParam('expected_date', today);
     record.issue.received_date = this._routeToolService.getRouteQueryParam('received_date', today);
 

--- a/projects/admin/src/app/service/holdings.service.ts
+++ b/projects/admin/src/app/service/holdings.service.ts
@@ -69,7 +69,7 @@ export class HoldingsService {
     if (displayText || receivedDate) {
       data.issue = {};
       if (displayText) {
-        data.issue.display_text = displayText;
+        data.enumerationAndChronology = displayText;
       }
       if (receivedDate) {
         data.issue.received_date = receivedDate;


### PR DESCRIPTION
Updates code to reflect new item note categories (binding, provenance,
condition, patrimonial, acquisition). Adds an icon related to each
note in the item detail view to know if the note is public or not.

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

https://github.com/rero/rero-ils/pull/1310

## How to test?

- edit the item to add multiples notes with html inside and new_line.
- see result in item detail view

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
