### PR TITLE
circulation: add counter on tabs

### DIFF
--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -39,10 +39,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'loan']"
-          translate
-          >Checkin/Checkout</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'loan']">
+          {{ 'Checkin/Checkout' | translate }}
+          <span *ngIf="this.patronCirculationStatistics.loans > 0" class="badge badge-info font-weight-normal">
+            {{ this.patronCirculationStatistics.loans }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -50,10 +52,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pickup']"
-          translate
-          >To pick up</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pickup']">
+          {{ 'To pick up' | translate }}
+          <span *ngIf="this.patronCirculationStatistics.pickup > 0" class="badge badge-info font-weight-normal">
+            {{ this.patronCirculationStatistics.pickup }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -61,10 +65,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pending']"
-          translate
-          >Pending</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pending']">
+          {{ 'Pending' | translate }}
+          <span *ngIf="this.patronCirculationStatistics.pending > 0" class="badge badge-info font-weight-normal">
+            {{ this.patronCirculationStatistics.pending }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -84,7 +90,7 @@
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
           [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'fees']">
-          {{ 'Fees' }}
+          {{ 'Fees' | translate }}
           <span *ngIf="transactionsTotalAmount > 0" class="badge badge-warning font-weight-normal">
             {{ transactionsTotalAmount | currency: organisation.default_currency }}
           </span>

--- a/projects/admin/src/app/service/patron.service.ts
+++ b/projects/admin/src/app/service/patron.service.ts
@@ -169,6 +169,16 @@ export class PatronService {
   }
 
   /**
+   * Get circulation statistics about a patron
+   * @param patronPid - string : the patron pid to search
+   * @return Observable
+   */
+  getCirculationStats(patronPid: string): Observable<any> {
+    const url = `/api/patrons/${patronPid}/circulation_stats`;
+    return this._http.get(url);
+  }
+
+  /**
    * Get Loans by query
    * @param query - string : Query to execute to find loans
    * @param sort - string : Sorting criteria
@@ -182,4 +192,5 @@ export class PatronService {
       map(hits => this._recordService.totalHits(hits.total) === 0 ? [] : hits.hits)
     );
   }
+
 }


### PR DESCRIPTION
This commit adds some statistics on tabs into the patron circulation
detail page. Available statistics are for 'CI/CO', 'pickup' and
'pending' tabs.

Closes rero/rero-ils#1278
Closes rero/rero-ils#1281

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
