### PR TITLE
request: allow cancellation when item is at desk

### DIFF
--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -157,5 +157,8 @@
   </section>
 
   <!-- TRANSACTIONS -->
-  <admin-item-transactions [item]="record"></admin-item-transactions>
+  <admin-item-transactions
+    [item]="record"
+    (cancelRequestEvent)="updateItemStatus()"
+  ></admin-item-transactions>
 </ng-container>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -50,11 +50,11 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
    * @param _recordService - RecordService
    */
   constructor(
-    private _recordService: RecordService,
+    private _recordService: RecordService
   ) {}
 
   ngOnInit() {
-    this._recordObs = this.record$.subscribe( record => {
+    this._recordObs = this.record$.subscribe(record => {
       this.record = record;
       this._recordService.getRecord('locations', record.metadata.location.pid, 1).subscribe(data => this.location = data);
     });
@@ -66,5 +66,15 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
 
   isPublicNote(note: ItemNote): boolean {
     return Item.PUBLIC_NOTE_TYPES.includes(note.type);
+  }
+
+  /**
+   * Update item status
+   */
+  updateItemStatus() {
+    this._recordService.getRecord('items', this.record.metadata.pid).subscribe((item: any) => {
+      this.record.metadata.status = item.metadata.status;
+      this.record.metadata.available = item.metadata.available;
+    });
   }
 }

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
@@ -43,7 +43,7 @@
             </button>
             <ul id="dropdown-animated" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="dropdown-animated">
               <li role="menuitem" *ngFor="let pickup of pickupLocations; let i = index">
-                <a class="dropdown-item" (click)="updateRequest(pickup.value)">{{ pickup.label }}</a>
+                <a class="dropdown-item" (click)="emitUpdatePickupLocation(pickup.value)">{{ pickup.label }}</a>
               </li>
             </ul>
           </div>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-transactions/item-transactions.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-transactions/item-transactions.component.html
@@ -50,7 +50,8 @@
           type="loan_request"
           [transaction]="request"
           [itemPid]="item.metadata.pid"
-          (removeRequest)="deleteRequest(request)"
+          (cancelRequestEvent)="cancelRequest($event)"
+          (updatePickupLocationEvent)="updateRequestPickupLocation($event)"
         ></admin-item-transaction>
       </div>
     </ng-container>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-transactions/item-transactions.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-transactions/item-transactions.component.ts
@@ -14,10 +14,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { BsModalService } from 'ngx-bootstrap/modal';
+import { ToastrService } from 'ngx-toastr';
 import { LoanService } from 'projects/admin/src/app/service/loan.service';
 import { forkJoin } from 'rxjs';
+import { UserService } from 'projects/admin/src/app/service/user.service';
+import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { ItemRequestComponent } from '../../document-detail-view/item-request/item-request.component';
 
@@ -31,6 +35,11 @@ export class ItemTransactionsComponent implements OnInit {
   /** Item record */
   @Input() item: any;
 
+  /**
+   * Informs parent component that a request has been cancelled
+   */
+  @Output() cancelRequestEvent = new EventEmitter<any>();
+
   /** Borrowed loan */
   borrowedBy: Array<any> = [];
 
@@ -38,19 +47,31 @@ export class ItemTransactionsComponent implements OnInit {
   requestedBy: Array<any> = [];
 
   /**
+   * Current user
+   */
+  private _currentUser: any;
+
+  /**
    * Constructor
    * @param _loanService - LoanService
    * @param _modalService - BsModalService
+   * @param _toastrService - ToastrService
+   * @param _translateService - TranslateService
+   * @param _userService - UserService
    */
   constructor(
     private _loanService: LoanService,
-    private _modalService: BsModalService
+    private _modalService: BsModalService,
+    private _toastrService: ToastrService,
+    private _translateService: TranslateService,
+    private _userService: UserService
   ) { }
 
   /**
    * On init hook
    */
   ngOnInit() {
+    this._currentUser = this._userService.getCurrentUser();
     const borrowedBy$ = this._loanService.borrowedBy$(this.item.metadata.pid);
     const requestedBy$ = this._loanService.requestedBy$(this.item.metadata.pid);
     forkJoin([borrowedBy$, requestedBy$]).subscribe(
@@ -79,5 +100,56 @@ export class ItemTransactionsComponent implements OnInit {
     modalRef.content.onSubmit.pipe(first()).subscribe(value => {
       this._loanService.requestedBy$(this.item.metadata.pid).subscribe(data => this.requestedBy = data);
     });
+  }
+
+  /**
+   * Cancel request
+   * @param transaction - request to cancel
+   */
+  cancelRequest(transaction: any) {
+    this._loanService
+      .cancelLoan(
+        this.item.pid,
+        transaction.metadata.pid,
+        this._currentUser.currentLibrary
+      )
+      .subscribe((itemData: any) => {
+        const status = itemData.status;
+        this._toastrService.warning(
+          this._translateService.instant('The item is ' + status),
+          // this._translateService.instant('The item is {{ status }}', { status }),
+          this._translateService.instant('Request')
+        );
+        this.cancelRequestEvent.emit();
+        this.updateRequestList();
+      });
+  }
+
+  /**
+   * Update request pickup location
+   * @param pickupLocationPid - pickup location pid to change
+   */
+  updateRequestPickupLocation(data: any) {
+    this._loanService
+      .updateLoanPickupLocation(
+        data.transaction.metadata.pid,
+        data.pickupLocationPid
+      )
+      .subscribe((response: any) => {
+        this._toastrService.success(
+          this._translateService.instant('The pickup location has been changed.'),
+          this._translateService.instant('Request')
+        );
+        this.updateRequestList();
+      });
+  }
+
+  /**
+   * Update request list
+   */
+  updateRequestList() {
+    this._loanService.requestedBy$(this.item.metadata.pid).subscribe(requestedLoans =>
+      this.requestedBy = requestedLoans
+    );
   }
 }


### PR DESCRIPTION
* Updates 'cancel request' permissions to allow the cancellation of an
item 'at desk'.
* Adds a method to update the item detailed view after a cancel request.
* Adds a flash message to inform the user about the item status.
* Moves 'cancel' and 'update' logic from the item-transaction component (list item) to
the item-transactions (list) component for a better understanding and to clean the code.
* Closes rero/rero-ils#1293.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?
Task 1784 of US1762 Issue fixing

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

N/A

## How to test?

See issue description.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
