### PR TITLE
circulation infos refactoring 

### DIFF
--- a/projects/admin/src/app/circulation/checkin/checkin.component.html
+++ b/projects/admin/src/app/circulation/checkin/checkin.component.html
@@ -31,12 +31,6 @@
     </div>
   </div>
 
-  <div class="row" *ngIf="patronInfo | patronBlockedMessage as message">
-    <div class="col">
-        <div class="alert alert-danger" role="alert">{{ message }}</div>
-    </div>
-  </div>
-
   <div class="row">
     <div class="col-md-12">
       <admin-circulation-items-list

--- a/projects/admin/src/app/circulation/patron/card/card.component.html
+++ b/projects/admin/src/app/circulation/patron/card/card.component.html
@@ -15,55 +15,63 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<div m-0 *ngIf="patron && patron.patron" [ngClass]="{'text-muted': !patron.displayPatronMode}">
+<div class="m-0" *ngIf="patron && patron.patron" [ngClass]="{'text-muted': !patron.displayPatronMode}">
   <div class="row">
-    <div class="col-md-2 user-icon">
-      <i class="fa fa-user fa-5x" aria-hidden="true"></i>
-    </div>
-    <div class="col-md-10">
-      <div class="row">
-        <div class="col-md-10">
-          <h3>
-            <a [routerLink]="['/records', 'patrons','detail', patron.pid]">
-              <span id="patron-last-name" *ngIf="patron.last_name">{{ patron.last_name }}</span>
-              <span id="patron-first-name" *ngIf="patron.first_name">, {{ patron.first_name }} </span>
-            </a>
-          </h3>
-        </div>
-        <div *ngIf="patron.displayPatronMode" class="col-md-2">
-          <button id="clear-patron-button" type="button" class="btn btn-danger pull-right" (click)="clear()">
-            <i class="fa fa-close" aria-hidden="true"></i>
-          </button>
-        </div>
+    <div class="col row">
+      <div class="col-md-2 user-icon">
+        <i class="fa fa-user fa-5x" aria-hidden="true"></i>
       </div>
-      <div class="row">
-        <div class="col-md-6">
-          <div>
-            <span id="patron-birth-date"
-              *ngIf="patron.birth_date">{{ patron.birth_date | dateTranslate:'mediumDate' }}</span>
+      <div class="col-md-10">
+        <div class="row">
+          <div class="col-md-10">
+            <h3>
+              <a [routerLink]="['/records', 'patrons','detail', patron.pid]">
+                <span id="patron-last-name">{{ patron.last_name }}</span>
+                <span id="patron-first-name" *ngIf="patron.first_name">, {{ patron.first_name }}</span>
+              </a>
+            </h3>
           </div>
-          <div>
-            <span id="patron-city" *ngIf="patron.city">{{ patron.city}}</span>
+          <div *ngIf="patron.displayPatronMode" class="col-md-2">
+            <button id="clear-patron-button" type="button" class="btn btn-danger pull-right" (click)="clear()">
+              <i class="fa fa-close" aria-hidden="true"></i>
+            </button>
           </div>
         </div>
-        <div class="col-md-6">
-          <div>
-            <span id="patron-type" *ngIf="patronType$ | async as patronType">{{ patronType }}</span>
+        <div class="row">
+          <div class="col-md-6">
+            <div id="patron-birth-date">{{ patron.birth_date | dateTranslate:'mediumDate' }}</div>
+            <div id="patron-city">{{ patron.city }}</div>
           </div>
-          <div>
-            <span id="patron-barcode">
-              {{ patron.patron.barcode }}
-            </span>
+          <div class="col-md-6">
+            <div id="patron-type"
+                 *ngIf="patron.patron.type.pid | getRecord: 'patron_types': 'string':'name' | async as patronTypeName"
+            >
+              {{ patronTypeName }}
+            </div>
+            <div id="patron-barcode">{{ patron.patron.barcode }}</div>
           </div>
         </div>
       </div>
-    </div>
       <!-- NOTES-->
-      <div *ngIf="notes && notes.length > 0" class="col alert alert-warning" role="alert">
-        <ng-container *ngFor="let note of notes">
-          <strong class="alert-heading">{{ note.type | translate }}</strong>
-          <p class="mb-0" [innerHTML]="note.content"></p>
+      <div *ngIf="patron.notes" class="alert alert-warning" role="alert">
+        <ng-container *ngFor="let note of patron.notes">
+          <strong class="alert-heading" translate>{{ note.type.toString() }}</strong>
+          <p class="mb-0 ml-3" [innerHTML]="note.content | nl2br"></p>
         </ng-container>
       </div>
-
+    </div>
+    <!-- Circulation message -->
+    <ng-container *ngIf="patron.circulation_informations">
+      <div class="col-sm-12 col-md-6">
+      <ul class="list-group">
+        <li *ngFor="let message of patron.circulation_informations.messages"
+            class="list-group-item list-group-item-{{ getBootstrapColor(message.type) }}"
+           [innerHTML]="message.content | nl2br"
+        ></li>
+      </ul>
+      </div>
+    </ng-container>
   </div>
+
+
+</div>

--- a/projects/admin/src/app/circulation/patron/card/card.component.ts
+++ b/projects/admin/src/app/circulation/patron/card/card.component.ts
@@ -15,56 +15,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { RecordService } from '@rero/ng-core';
-import { map } from 'rxjs/operators';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { User } from '../../../class/user';
+import { getBootstrapLevel } from '../../../utils/utils';
+
 
 @Component({
   selector: 'admin-circulation-patron-detailed',
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss']
 })
-export class CardComponent implements OnInit {
+export class CardComponent {
   @Input() patron: User;
+  @Input() circulationMessages = false;
   @Output() clearPatron = new EventEmitter<User>();
-  patronType$: any;
-
-  constructor(
-    private recordService: RecordService,
-    private _sanitizer: DomSanitizer
-  ) { }
-
-  ngOnInit() {
-    if (this.patron) {
-      this.patronType$ = this.recordService.getRecord('patron_types', this.patron.patron.type.pid).pipe(
-        map(patronType => patronType.metadata.name)
-      );
-    }
-  }
 
   clear() {
     if (this.patron) {
       this.clearPatron.emit(this.patron);
     }
   }
-  /**
-   * Get the patron notes.
-   *
-   * It replace a new line to the corresponding html code.
-   * Allows to render html.
-   */
-  get notes(): Array<{ type: string, content: SafeHtml }> {
-    if (!this.patron || !this.patron.notes || this.patron.notes.length < 1) {
-      return null;
-    }
-    return this.patron.notes.map((note: any) => {
-      return {
-        type: note.type,
-        content: this._sanitizer.bypassSecurityTrustHtml(
-          note.content.replace('\n', '<br>'))
-      };
-    });
+
+  getBootstrapColor(level: string): string {
+    return getBootstrapLevel(level);
   }
 }

--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -17,18 +17,11 @@
 
 <ng-container *ngIf="patron">
   <div class="col mb-4">
-    <div class="col-md-6">
-      <admin-circulation-patron-detailed
-        [patron]="patron"
-        (clearPatron)="clearPatron()"
-      ></admin-circulation-patron-detailed>
-    </div>
-  </div>
-
-  <div class="col mb-4" *ngIf="patron | patronBlockedMessage as message">
-      <div class="alert alert-danger" role="alert">
-      {{ message }}
-      </div>
+    <admin-circulation-patron-detailed
+      [patron]="patron"
+      [circulationMessages]="true"
+      (clearPatron)="clearPatron()"
+    ></admin-circulation-patron-detailed>
   </div>
 
   <div class="col">
@@ -39,10 +32,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'loan']"
-          translate
-          >Checkin/Checkout</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'loan']">
+          {{ 'Checkin/Checkout' | translate }}
+          <span *ngIf="getCirculationStatistics('loans') > 0" class="badge badge-info font-weight-normal">
+            {{ getCirculationStatistics('loans') }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -50,10 +45,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pickup']"
-          translate
-          >To pick up</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pickup']">
+          {{ 'To pick up' | translate }}
+          <span *ngIf="getCirculationStatistics('pickup') > 0" class="badge badge-info font-weight-normal">
+            {{ getCirculationStatistics('pickup') }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -61,10 +58,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pending']"
-          translate
-          >Pending</a
-        >
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pending']">
+          {{ 'Pending' | translate }}
+          <span *ngIf="getCirculationStatistics('pending') > 0 as stat" class="badge badge-info font-weight-normal">
+            {{ getCirculationStatistics('pending') }}
+          </span>
+        </a>
       </li>
       <li class="nav-item">
         <a
@@ -84,7 +83,7 @@
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
           [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'fees']">
-          {{ 'Fees' }}
+          {{ 'Fees' | translate }}
           <span *ngIf="transactionsTotalAmount > 0" class="badge badge-warning font-weight-normal">
             {{ transactionsTotalAmount | currency: organisation.default_currency }}
           </span>

--- a/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
@@ -53,7 +53,7 @@
         <div class="card-body" *ngIf="record.metadata.limits.checkout_limits">
           <dl class="row m-0">
             <dt class="offset-1 col-lg-2 col-sm-4 label-title" translate>General limit</dt>
-            <dd class="col">{{ record.metadata.limits.checkout_limits.general_limit }}</dd>
+            <dd class="col">{{ record.metadata.limits.checkout_limits.global_limit }}</dd>
             <dd class="w-100 m-0"></dd>
             <ng-container *ngIf="record.metadata.limits.checkout_limits.library_limit">
               <dt class="offset-1 col-lg-2 col-sm-4 label-title" translate>Library limit</dt>

--- a/projects/admin/src/app/record/detail-view/template-detail-view/template-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/template-detail-view/template-detail-view.component.html
@@ -29,9 +29,7 @@
             Description
           </span>
         </dt>
-        <dd id="template-description" [ngClass]="ddCssClass">
-          {{ record.metadata.description }}
-        </dd>
+        <dd id="template-description" [ngClass]="ddCssClass" [innerHTML]="record.metadata.description | nl2br"></dd>
       </ng-container>
       <!-- CREATOR -->
       <ng-container *ngIf="record.metadata.creator.pid | getRecord: 'patrons' | async as creator">
@@ -51,7 +49,7 @@
             Type
           </span>
         </dt>
-        <dd id="template-description" [ngClass]="ddCssClass">
+        <dd id="template-type" [ngClass]="ddCssClass">
           {{ record.metadata.template_type }}
         </dd>
       </ng-container>

--- a/projects/admin/src/app/service/patron.service.ts
+++ b/projects/admin/src/app/service/patron.service.ts
@@ -169,6 +169,16 @@ export class PatronService {
   }
 
   /**
+   * Get circulation statistics about a patron
+   * @param patronPid - string : the patron pid to search
+   * @return Observable
+   */
+  getCirculationInformations(patronPid: string): Observable<any> {
+    const url = [this._apiService.getEndpointByType('patrons'), patronPid, 'circulation_informations'].join('/');
+    return this._http.get(url);
+  }
+
+  /**
    * Get Loans by query
    * @param query - string : Query to execute to find loans
    * @param sort - string : Sorting criteria
@@ -182,4 +192,5 @@ export class PatronService {
       map(hits => this._recordService.totalHits(hits.total) === 0 ? [] : hits.hits)
     );
   }
+
 }

--- a/projects/admin/src/app/utils/utils.ts
+++ b/projects/admin/src/app/utils/utils.ts
@@ -1,0 +1,35 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ * Copyright (C) 2020 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** Convert a level string to boostrap level
+ *  See : https://getbootstrap.com/docs/4.5/components/alerts/
+ *  @param level - string: the level string to convert
+ *  @return the bootstrap level corresponding (info by default)
+ */
+export function getBootstrapLevel(level: string) {
+  switch (level) {
+    case 'error':
+      return 'danger';
+    case 'warning':
+      return 'warning';
+    case 'debug':
+      return 'dark';
+    default:
+      return 'info';
+  }
+}


### PR DESCRIPTION
The message return by the backend when a user is blocked has changed.
This commit adapts the UI to this change and display the error message
returned by the backend directly.
This commit also adds counter on tabs of the patron circulation detail
page. Available counter are for checkin/checkout, pickup and pending
tabs.

Small correction on the template detail view.

Closes rero/rero-ils#1278
Closes rero/rero-ils#1281

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

 * ng-core 0.13 (run `npm ci` the new version of ng-core should be installed)
 * https://github.com/rero/rero-ils/tree/US1643-borrow-limits

## How to test?

![image](https://user-images.githubusercontent.com/10031585/97463089-aeba2180-193f-11eb-87c8-bc90b218636a.png)

* Use the professional interface to block a user. 
* Go in the circulation interface for this patron ; you should see this message in red (see screenshot)
* Unblock the patron
* Define some (small) limits on a patron_type and assign this patron_type to this patron
* Do some checkout operation until the define limit is reached.
* Reload the circulation interface for this patron : you should see a message in red.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
