### PR TITLE
circulation: display pickup location name in patron profile

### DIFF
--- a/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.html
+++ b/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.html
@@ -15,22 +15,18 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="item && loan; else loading">
-  <!-- BARCODE -->
   <div class="col-sm-2">
     <a [routerLink]="['/records', 'items', 'detail', item.pid]">{{ item.barcode }}</a>
   </div>
-  <!-- TITLE -->
-  <div class="col-sm-5"><a [routerLink]="['/records', 'documents', 'detail', item.document.pid]"
-    *ngIf="item.document.title | mainTitle as title">
-    {{ title }}</a>
+  <div class="col-sm-5">
+    <a *ngIf="item.document.title | mainTitle as title" [routerLink]="['/records', 'documents', 'detail', item.document.pid]">
+      {{ title }}
+    </a>
   </div>
-  <!-- PICKUP LOCATION -->
   <div class="col-sm-3">
-    {{ loan.metadata.pickup_location_pid | getRecord: 'locations' : 'field' : 'name' | async }}
+    {{ loan.metadata.pickup_location_pid | getRecord: 'locations' : 'field' : 'pickup_name' | async }}
   </div>
-  <div class="col-sm-2">
-    &nbsp;
-  </div>
+  <div class="col"></div>
 </ng-container>
 
 <ng-template #loading>

--- a/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.ts
+++ b/projects/admin/src/app/circulation/patron/pickup/pickup-item/pickup-item.component.ts
@@ -24,14 +24,10 @@ import { PatronService } from '../../../../service/patron.service';
 })
 export class PickupItemComponent implements OnInit {
 
-  /**
-   * Loan
-   */
+  /** Loan */
   @Input() loan = undefined;
 
-  /**
-   * Item
-   */
+  /** Item */
   item = undefined;
 
   /**
@@ -49,8 +45,7 @@ export class PickupItemComponent implements OnInit {
    */
   ngOnInit() {
     if (this.loan) {
-      this._recordService.getRecord('items', this.loan.metadata.item_pid.value)
-      .subscribe(result => {
+      this._recordService.getRecord('items', this.loan.metadata.item_pid.value).subscribe(result => {
         this._patronService.getItem(result.metadata.barcode).subscribe(
           item => this.item = item
         );

--- a/projects/admin/src/app/circulation/patron/pickup/pickup.component.html
+++ b/projects/admin/src/app/circulation/patron/pickup/pickup.component.html
@@ -17,15 +17,13 @@
 <section *ngIf="isLoading; else loading" class="content">
   <div *ngIf="loans.length > 0; else noPickup">
     <!-- HEADER -->
-    <div class="row p-2 mb-1 bg-dark rounded text-light">
+    <div class="row p-2 mb-1 bg-dark rounded text-light row">
       <div class="col-sm-2" translate>Item</div>
       <div class="col-sm-5" translate>Title</div>
       <div class="col-sm-3" translate>Pickup location</div>
       <div class="col-sm-2">&nbsp;</div>
     </div>
-    <div *ngFor="let loan of loans">
-      <admin-pickup-item [loan]="loan" class="row p-2 mb-1 border rounded align-middle"></admin-pickup-item>
-    </div>
+    <admin-pickup-item *ngFor="let loan of loans" [loan]="loan" class="row p-2 mb-1 border rounded align-middle"></admin-pickup-item>
   </div>
 </section>
 


### PR DESCRIPTION
When a request is available for pickup, the location name was the short
name. This PR corrects this problem: now the label display is the
'pickup_name' field from location.

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

Closes rero/rero-ils#1300

## How to test?

Before
![image](https://user-images.githubusercontent.com/10031585/97575980-dcf63a80-19ed-11eb-83da-2f02df6fb80f.png)

After
![image](https://user-images.githubusercontent.com/10031585/97575943-cbad2e00-19ed-11eb-9c75-af3c029ec2d7.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
