### PR TITLE
transactions: limit pay with 2 decimals

### DIFF
--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
@@ -86,9 +86,15 @@ export class PatronTransactionEventFormComponent implements OnInit {
         min: 0,
         max: this._computeTotalAmount(),
         step: 0.1,
+        pattern: '^\\d*(\\.\\d{0,2})?$',
         required: true,
         addonLeft: {
           text: getCurrencySymbol(this._organisationService.organisation.default_currency, 'wide')
+        }
+      },
+      validation: {
+        messages: {
+          pattern: (error, field: FormlyFieldConfig) => `Only 2 decimals are allowed`
         }
       },
       validators: {


### PR DESCRIPTION
Updates the transaction payment form to allow only 2 decimals.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
