### PR TITLE
serials: new service to display late/claimed issues

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -54,6 +54,7 @@ import { CollectionBriefViewComponent } from './record/brief-view/collection-bri
 import { DocumentsBriefViewComponent } from './record/brief-view/documents-brief-view/documents-brief-view.component';
 import { ItemTypesBriefViewComponent } from './record/brief-view/item-types-brief-view.component';
 import { ItemsBriefViewComponent } from './record/brief-view/items-brief-view/items-brief-view.component';
+import { IssuesBriefViewComponent } from './record/brief-view/issues-brief-view/issues-brief-view.component';
 import { LibrariesBriefViewComponent } from './record/brief-view/libraries-brief-view.component';
 import { PatronTypesBriefViewComponent } from './record/brief-view/patron-types-brief-view.component';
 import { PatronsBriefViewComponent } from './record/brief-view/patrons-brief-view.component';
@@ -180,6 +181,7 @@ export function appInitFactory(appInitService: AppInitService) {
     ItemTransactionComponent,
     ItemTransactionsComponent,
     ItemsBriefViewComponent,
+    IssuesBriefViewComponent,
     PatronDetailViewComponent,
     VendorDetailViewComponent,
     VendorBriefViewComponent,
@@ -283,6 +285,7 @@ export function appInitFactory(appInitService: AppInitService) {
     ItemTypesBriefViewComponent,
     ItemTypeDetailViewComponent,
     ItemsBriefViewComponent,
+    IssuesBriefViewComponent,
     LibrariesBriefViewComponent,
     PatronsBriefViewComponent,
     PatronTypesDetailViewComponent,

--- a/projects/admin/src/app/class/items.ts
+++ b/projects/admin/src/app/class/items.ts
@@ -51,7 +51,8 @@ export enum ItemNoteType {
 export enum IssueItemStatus {
   RECEIVED = _('received'),
   CLAIMED = _('claimed'),
-  DELETED = _('deleted')
+  DELETED = _('deleted'),
+  LATE = _('late')
 }
 
 export enum LoanState {

--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
@@ -1,0 +1,81 @@
+<!--
+ RERO ILS UI
+  Copyright (C) 2019 RERO
+  Copyright (C) 2020 UCLouvain
+ 
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+ 
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+ 
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<h5 class="mb-0 card-title">
+    <a [routerLink]="[detailUrl.link]">
+        {{ record.metadata.ui_title_text }}
+    </a>
+  </h5>
+  <ng-container class="card-text">
+    <dl class="row mb-0 ml-1">
+      <!-- CALL NUMBER -->
+      <ng-container *ngIf="record.metadata.call_number">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.call_number }}
+        </dd>
+      </ng-container>
+      <ng-container *ngIf="record.metadata.barcode">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Barcode</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.barcode }}
+        </dd>
+      </ng-container>
+      <!-- ENUMERATION AND CHRONOLOGY -->
+      <ng-container *ngIf="record.metadata.enumerationAndChronology">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Numbering</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.enumerationAndChronology }}
+        </dd>
+      </ng-container>
+      <!-- EXPECTED DATE -->
+      <ng-container *ngIf="record.metadata.issue.expected_date">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Expected date</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.issue.expected_date | dateTranslate }}
+        </dd>
+      </ng-container>
+      <!-- NUMBER OF CLAIMS SENT -->
+      <ng-container *ngIf="record.metadata.issue.claims_count">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Claims sent</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.issue.claims_count }}
+        </dd>
+      </ng-container>
+      <!-- VENDOR -->
+      <ng-container *ngIf="record.metadata.vendor">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Vendor</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.vendor.pid | getRecord: 'vendors': 'field': 'name' | async }}
+        </dd>
+      </ng-container>
+      <!-- ISSUE STATUS AND DATE-->
+      <ng-container *ngIf="record.metadata.issue.status as status">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Issue status</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          <i class="fa text-warning" [ngClass]="{ 
+            'fa-envelope': status == issueItemStatus.CLAIMED,
+            'fa-envelope-open-o': status == issueItemStatus.LATE 
+          }"
+          ></i>
+        {{ status | translate }} [{{ record.metadata.issue.status_date | dateTranslate}}]
+        </dd>
+      </ng-container>
+    </dl>
+  </ng-container>
+  

--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.ts
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.ts
@@ -1,0 +1,43 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, Input } from '@angular/core';
+import { ResultItem } from '@rero/ng-core';
+import { IssueItemStatus } from '../../../class/items';
+
+@Component({
+  selector: 'admin-inventory-brief-view',
+  templateUrl: './issues-brief-view.component.html'
+})
+export class IssuesBriefViewComponent implements ResultItem {
+
+  /** reference to IssueItemStatus */
+  issueItemStatus = IssueItemStatus;
+
+  /** Record */
+  @Input()
+  record: any;
+
+  /** Type of record */
+  @Input()
+  type: string;
+
+  /** Detail Url */
+  @Input()
+  detailUrl: { link: string, external: boolean };
+
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
@@ -140,7 +140,7 @@ export class HoldingComponent implements OnInit, OnDestroy {
     let query = `holding.pid:${this.holding.metadata.pid}`;
     let sort = '';
     if (this.holding.metadata.holdings_type === 'serial') {
-      query += ' AND -issue.status:(claimed OR deleted)';
+      query += ' AND -issue.status:(claimed OR deleted OR late)';
       sort = '-issue_expected_date';
     }
     this.itemsRef = this._recordService

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -104,12 +104,8 @@
         <span class="badge badge-pill badge-info pl-2" *ngIf="item.new_issue" translate>New</span>
       </div>
       <div class="col-sm-1 text-center">
-        <i class="fa fa-circle" title="{{ item.metadata.issue.status | translate }}"
-           [ngClass]="{
-             'text-success': item.metadata.issue.status == issueItemStatus.RECEIVED,
-             'text-danger': item.metadata.issue.status == issueItemStatus.DELETED,
-             'text-warning': item.metadata.issue.status == issueItemStatus.CLAIMED
-           }"
+        <i class="fa" title="{{ item.metadata.issue.status | translate }}"
+           [ngClass]="getIcon(item.metadata.issue.status)"
         ></i>
       </div>
       <div class="col-sm-2 text">{{ item.metadata.call_number }}</div>

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.ts
@@ -197,4 +197,14 @@ export class SerialHoldingDetailViewComponent implements OnInit {
       }
     );
   }
+
+  /**
+   * Make the method getIcon from holdingService available
+   * @param status: the item status
+   *  @return: the font-awsome icon to use
+   */
+  getIcon(status: IssueItemStatus): string {
+    return this._holdingService.getIcon(status);
+  }
 }
+

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -121,12 +121,8 @@
         <!-- issue status -->
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Status</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          <i class="fa fa-circle" [ngClass]="{
-              'text-success': record.metadata.issue.status == issueItemStatus.RECEIVED,
-              'text-danger': record.metadata.issue.status == issueItemStatus.DELETED,
-              'text-warning': record.metadata.issue.status == issueItemStatus.CLAIMED
-          }"></i>
-          {{ record.metadata.issue.status | translate }}
+          <i class="fa" [ngClass]="getIcon(record.metadata.issue.status)"></i>
+          {{ record.metadata.issue.status | translate }} [{{ record.metadata.issue.status_date | dateTranslate}}]
         </dd>
       </dl>
     </section>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -19,6 +19,7 @@ import { RecordService } from '@rero/ng-core';
 import { DetailRecord } from '@rero/ng-core/lib/record/detail/view/detail-record';
 import { Observable, Subscription } from 'rxjs';
 import { IssueItemStatus, Item, ItemNote } from '../../../class/items';
+import { HoldingsService } from '../../../service/holdings.service';
 
 @Component({
   selector: 'admin-item-detail-view',
@@ -48,9 +49,11 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
   /**
    * Constructor
    * @param _recordService - RecordService
+   * @param _holdingService - HoldingsService
    */
   constructor(
-    private _recordService: RecordService
+    private _recordService: RecordService,
+    private _holdingService: HoldingsService,
   ) {}
 
   ngOnInit() {
@@ -77,4 +80,12 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
       this.record.metadata.available = item.metadata.available;
     });
   }
+
+  /**
+   * Make the method getIcon available here
+   */
+  getIcon(status: IssueItemStatus): string {
+    return this._holdingService.getIcon(status);
+  }
+
 }

--- a/projects/admin/src/app/routes/issues-route.ts
+++ b/projects/admin/src/app/routes/issues-route.ts
@@ -1,0 +1,82 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { RecordSearchComponent, RouteInterface } from '@rero/ng-core';
+import { of } from 'rxjs';
+import { IssuesBriefViewComponent } from '../record/brief-view/issues-brief-view/issues-brief-view.component';
+import { BaseRoute } from './base-route';
+import { IssueItemStatus } from '../class/items';
+
+export class IssuesRoute extends BaseRoute implements RouteInterface {
+
+  /** Route name */
+  readonly name = 'issues';
+
+  /** Record type */
+  readonly recordType = 'items';
+
+  /**
+   * Get Configuration
+   * @return Object
+   */
+  getConfiguration() {
+    return {
+      matcher: (url: any) => this.routeMatcher(url, this.name),
+      children: [
+        { path: '', component: RecordSearchComponent }
+      ],
+      data: {
+        adminMode: () => of({
+          can: false,
+          message: ''
+        }),
+        detailUrl: '/records/items/detail/:pid',
+        types: [
+          {
+            key: this.name,
+            label: 'Issues',
+            index: 'items',
+            component: IssuesBriefViewComponent,
+            permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),
+            // use simple query for UI search
+            preFilters: {
+                simple: 1,
+                or_issue_status: [IssueItemStatus.LATE, IssueItemStatus.CLAIMED]
+              },
+            aggregationsBucketSize: 10,
+            aggregationsOrder: [
+              'library',
+              'location',
+              'item_type',
+              'vendor',
+              'issue_status'
+            ],
+            aggregationsExpand: ['library', 'issue_status'],
+            listHeaders: {
+              Accept: 'application/rero+json, application/json'
+            },
+            exportFormats: [
+              {
+                label: 'CSV',
+                format: 'csv'
+              }
+            ],
+          }
+        ],
+      }
+    };
+  }
+}

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -65,7 +65,6 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
             },
             component: ItemsBriefViewComponent,
             detailComponent: ItemDetailViewComponent,
-            canRead: (record: any) => this.canReadItem(record),
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),
             preprocessRecordEditor: (record: any) => {
               // If we found an `holding` parameter into the query string then we need to pre-populated

--- a/projects/admin/src/app/routes/route.service.ts
+++ b/projects/admin/src/app/routes/route.service.ts
@@ -16,6 +16,7 @@
  */
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 import { RouteCollectionService } from '@rero/ng-core';
 import { ErrorPageComponent } from '../error/error-page/error-page.component';
 import { AcquisitionAccountsRoute } from './acquisition-accounts-route';
@@ -23,8 +24,11 @@ import { AcquisitionOrderLinesRoute } from './acquisition-order-lines-route';
 import { AcquisitionOrdersRoute } from './acquisition-orders-route';
 import { BudgetsRoute } from './budgets-route';
 import { CirculationPoliciesRoute } from './circulation-policies-route';
+import { CollectionsRoute } from './collections-route';
 import { DocumentsRoute } from './documents-route';
 import { HoldingsRoute } from './holdings-route';
+import { ImportDocumentsRoute } from './import-documents-route';
+import { IssuesRoute } from './issues-route';
 import { ItemTypesRoute } from './item-types-route';
 import { ItemsRoute } from './items-route';
 import { LibrariesRoute } from './libraries-route';
@@ -36,9 +40,6 @@ import { PersonsRoute } from './persons-route';
 import { RouteToolService } from './route-tool.service';
 import { TemplatesRoute } from './templates-route';
 import { VendorsRoute } from './vendors-route';
-import { ImportDocumentsRoute } from './import-documents-route';
-import { TranslateService } from '@ngx-translate/core';
-import { CollectionsRoute } from './collections-route';
 
 @Injectable({
   providedIn: 'root'
@@ -72,6 +73,7 @@ export class RouteService {
       .addRoute(new DocumentsRoute(this._routeToolService))
       .addRoute(new HoldingsRoute(this._routeToolService))
       .addRoute(new ItemsRoute(this._routeToolService))
+      .addRoute(new IssuesRoute(this._routeToolService))
       .addRoute(new ItemTypesRoute(this._routeToolService))
       .addRoute(new LibrariesRoute(this._routeToolService))
       .addRoute(new LocationsRoute(this._routeToolService))

--- a/projects/admin/src/app/service/holdings.service.ts
+++ b/projects/admin/src/app/service/holdings.service.ts
@@ -19,6 +19,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { IssueItemStatus } from '../class/items';
 
 /**
  * Prediction issue structure
@@ -76,6 +77,19 @@ export class HoldingsService {
       }
     }
     return this._http.post<any>(url, data);
+  }
+
+  /**
+   * This function return issue icon based on its status
+   */
+  getIcon(status: IssueItemStatus): string {
+    switch (status) {
+      case IssueItemStatus.DELETED: return 'fa-circle text-danger';
+      case IssueItemStatus.CLAIMED: return 'fa-envelope text-warning';
+      case IssueItemStatus.RECEIVED: return 'fa-circle text-success';
+      case IssueItemStatus.LATE: return 'fa-envelope-open-o text-warning';
+      default: return 'fa-circle text-dark';
+    }
   }
 
 }

--- a/projects/admin/src/app/service/menu.service.ts
+++ b/projects/admin/src/app/service/menu.service.ts
@@ -100,6 +100,11 @@ export class MenuService {
           routerLink: '/records/budgets',
           iconCssClass: 'fa fa-money',
           id: 'budgets-menu'
+        }, {
+          name: this._translateService.instant('Late issues'),
+          routerLink: '/records/issues',
+          iconCssClass: 'fa fa-envelope-open-o',
+          id: 'late-issues-menu'
         }]
       }, {
         name: this._translateService.instant('Reports & monitoring'),


### PR DESCRIPTION
A new item "Late issues" in the Acquisition menu is added
to display late and claimed issues filtered by library and
location and issue status.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1544?milestone=275632

## Dependencies

* https://github.com/rero/rero-ils/pull/1415
* https://github.com/rero/ng-core/pull/299

## How to test?

Full information about the implementation is documented here https://tree.taiga.io/project/rero21-reroils/us/1544?milestone=275632

* login to your organisation as system_librarian (either Irma or Astrid)
* Go to the `Acquisition Menu` and select the item `Late issues`
* you will have a list of `claimed` and `late` issues.
* you can filter by library, location, vendor and issue status
* you can also visit the holdings record to check the new `claims` fields.
* the `claimed`, `late`, `received` icons are harmonized in the pro interface
* in the public interface, you can see that the claimed and late issues are not displayed

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
