### PR TITLE
items: fix display notes content.

### DIFF
--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -143,6 +143,7 @@
             ></i>
             <strong translate>{{ note.type }}</strong>
           </dt>
+          <dd class="col-9 text-justify" [innerHTML]="note.content | nl2br"></dd>
         </div>
       </div>
       <div class="card-footer text-muted small">


### PR DESCRIPTION
Fix the display note content. The item detail view shows all item notes
type but no content was displayed.

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- display the item detail view for any item with some notes.
- check if notes content are displayed

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
