### PR TITLE
editor: fix patron editor

### DIFF
--- a/projects/admin/src/app/routes/patrons-route.ts
+++ b/projects/admin/src/app/routes/patrons-route.ts
@@ -78,6 +78,10 @@ export class PatronsRoute extends BaseRoute implements RouteInterface {
               if (record.blocked === false) {
                 delete record.blocked_note;
               }
+              // Clean-up 'patron' data from record if the patron doesn't have the 'patron' role
+              if (!record.roles.includes('patron') && 'patron' in record) {
+                delete record.patron;
+              }
               return record;
             },
             formFieldMap: (field: FormlyFieldConfig, jsonSchema: JSONSchema7): FormlyFieldConfig => {


### PR DESCRIPTION
In the patron editor, if the current edited patron doesn't have the
'patron' role, we need to remove all informations linked to this
profile (mainly the default expiration_date set in
`preprocessRecordEditor` function).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
