### PR TITLE
users: display keep_history for patron

### DIFF
--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -89,7 +89,7 @@
           </span>
         </a>
       </li>
-      <li class="nav-item">
+      <li *ngIf="patron.patron.keep_history" class="nav-item">
         <a
           id="history-tab"
           class="nav-link"

--- a/projects/admin/src/app/circulation/patron/profile/profile.component.html
+++ b/projects/admin/src/app/circulation/patron/profile/profile.component.html
@@ -117,6 +117,15 @@
         {{ patron.patron.type.pid | getRecord: 'patron_types' : 'field' : 'name' | async }}
       </dd>
     </dl>
+    <!-- KEEP HISTORY -->
+    <dl class="row mb-0">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Keep history</dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        <i class="fa" [ngClass]="patron.patron.keep_history ? 'fa-check text-success' : 'fa-times text-danger'"
+          aria-hidden="true">
+        </i>
+      </dd>
+    </dl>
     <!-- ACCOUNT EXPIRATION -->
     <dl class="row mb-0">
       <dt class="col-sm-3 offset-sm-2 offset-md-0">
@@ -125,12 +134,14 @@
       <dd class="col-sm-7 col-md-8 mb-0">
         {{ patron.patron.expiration_date | dateTranslate:'mediumDate' }}
       </dd>
+    </dl>
+    <dl *ngIf="patron.patron.libraries && patron.patron.libraries.length > 0" class="row mb-0">
       <dt class="col-sm-3 offset-sm-2 offset-md-0">
         {{ 'Affiliation libraries' | translate }}:
       </dt>
-      <dd *ngIf="patron.patron.libraries && patron.patron.libraries.length > 0" class="col-sm-7 col-md-8 mb-0">
+      <dd class="col-sm-7 col-md-8 mb-0">
         <div *ngFor="let library of patron.patron.libraries">
-          {{library.pid | getRecord: 'libraries' : 'field' : 'name' | async}}
+          {{ library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}
         </div>
       </dd>
     </dl>

--- a/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail-view.component.html
@@ -135,6 +135,16 @@
           {{ patron.patron.type.pid | getRecord: 'patron_types' : 'field' : 'name' | async }}
         </dd>
       </dl>
+      <!-- KEEP HISTORY -->
+      <dl class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Keep history</dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          <i class="fa"
+             [ngClass]="patron.patron.keep_history ? 'fa-check text-success' : 'fa-times text-danger'"
+             aria-hidden="true">
+          </i>
+        </dd>
+      </dl>
       <!-- ACCOUNT EXPIRATION -->
       <dl class="row mb-0">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
@@ -143,14 +153,18 @@
         <dd class="col-sm-7 col-md-8 mb-0">
           {{ patron.patron.expiration_date | dateTranslate:'mediumDate' }}
         </dd>
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
-          Affiliation libraries
+      </dl>
+      <dl *ngIf="patron.patron.libraries && patron.patron.libraries.length > 0" class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0">
+          {{ 'Affiliation libraries' | translate }}:
         </dt>
-        <dd *ngIf="patron.patron.libraries && patron.patron.libraries.length > 0" class="col-sm-7 col-md-8 mb-0">
+        <dd class="col-sm-7 col-md-8 mb-0">
           <div *ngFor="let library of patron.patron.libraries">
-            {{ library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}</div>
+            {{ library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}
+          </div>
         </dd>
       </dl>
+  
     </section>
   </article>
 </ng-container>

--- a/projects/shared/src/lib/class/user.ts
+++ b/projects/shared/src/lib/class/user.ts
@@ -46,6 +46,7 @@ export class User {
     communication_channel: string,
     communication_language: string,
     expiration_date: string,
+    keep_history: boolean,
     libraries?: Array<Library>,
     // When patron is blocked, add 'blocked' and 'blocked_note' fields.
     blocked?: false,


### PR DESCRIPTION
In the patron detailed view, the new field
keep_history is displayed.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/us/1422?milestone=277700

## Dependencies

https://github.com/rero/invenio-userprofiles/pull/2
https://github.com/rero/rero-ils/pull/1512

## How to test?

Case 1:
- Login as system_librarian.
- Find any patron with completed circ transactions
- Edit the patron record and disable the `keep_history` field if enabled. (Note: if disabled already, then enable it and then disable it).
- Go back the patron page, you will not find the the circ history. they are anonymized (not visible anymore)

Case 2:
- Login as patron (simonetta or other).
- Make sure you have completed circ transactions in the history tab.
- Take a look at the `Personal data` tab (re-organiszed) and the new `edit` button to take you to the RERO_ID editor.
- disable the `keep_history` field if enabled. (Note: if disabled already, then enable it and then disable it).
- Go back the history tab, you will not find the the circ history. they are anonymized (not visible anymore)

Case 3:
- repeat any of the above cases for a completed circulation transaction that has still `fees` to pay.
- The transaction will not be anonymized
- Pay the fees and the transaction will be anonymized with the execution of the daily job @7h00

Case 4:
- Patron has the `keep_history` enabled.  transaction older than 6 months will be anonymized

Case 5:
- Patron has `keep_history` disabled and no transactions are visiable.
- Patron enables the `keep_history` . The anonymized transactions will still be not visible.


<img width="1431" alt="Screenshot 2020-11-30 at 14 09 26" src="https://user-images.githubusercontent.com/26998238/100614019-c22d2380-3315-11eb-98b1-1cf55c269a6c.png">
<img width="1306" alt="Screenshot 2020-11-30 at 14 08 08" src="https://user-images.githubusercontent.com/26998238/100614021-c2c5ba00-3315-11eb-8d0a-686d6492241e.png">
<img width="1094" alt="Screenshot 2020-11-30 at 14 07 31" src="https://user-images.githubusercontent.com/26998238/100614026-c48f7d80-3315-11eb-821e-8e4fd6c02887.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
