### PR TITLE
circulation: adds a counter on history tab

### DIFF
--- a/projects/admin/src/app/circulation/patron/history/history.component.ts
+++ b/projects/admin/src/app/circulation/patron/history/history.component.ts
@@ -26,7 +26,6 @@ export class HistoryComponent implements OnInit {
 
   /** history Loans */
   loans = [];
-
   /** is loading */
   isLoading = false;
 
@@ -40,20 +39,14 @@ export class HistoryComponent implements OnInit {
 
   /**
    * Component initialization.
-   * Load current parton loans history.
+   * Load current patron loans history.
    */
   ngOnInit() {
     this._patronService.currentPatron$.subscribe(patron => {
       if (patron) {
         this._patronService.getHistory(patron.pid).subscribe(
           (loans) => {
-            // Despite `getHistory` should be sort by loan 'end_date' property, it seems not to be :(
-            // So use a simple javascript sort function
-            this.loans = loans.sort((a, b): number => {
-              if (a.metadata.end_date > b.metadata.end_date) { return -1; }
-              if (a.metadata.end_date < b.metadata.end_date) { return 1; }
-              return 0;
-            });
+            this.loans = loans;
             this.isLoading = true;
           });
       }

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -213,6 +213,7 @@ export class LoanComponent implements OnInit, OnDestroy {
                 );
               }
               this.patron.decrementCirculationStatistic('loans');
+              this.patron.incrementCirculationStatistic('history');
               break;
             }
             case ItemAction.checkout: {

--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -95,8 +95,12 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'history']"
-          translate>History</a>
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'history']">
+          {{ 'History' | translate }}
+          <span *ngIf="getCirculationStatistics('history') > 0" class="badge badge-info font-weight-normal">
+            {{ getCirculationStatistics('history') }}
+          </span>
+        </a>
       </li>
     </ul>
     <div class="mt-4">

--- a/projects/admin/src/app/circulation/patron/main/main.component.ts
+++ b/projects/admin/src/app/circulation/patron/main/main.component.ts
@@ -210,6 +210,11 @@ export class MainComponent implements OnInit, OnDestroy {
         case LoanState[LoanState.ITEM_ON_LOAN]:
           this.patron.incrementCirculationStatistic('loans',  Number(data[key]));
           break;
+        case LoanState[LoanState.CANCELLED]:
+        case LoanState[LoanState.ITEM_IN_TRANSIT_TO_HOUSE]:
+        case LoanState[LoanState.ITEM_RETURNED]:
+          this.patron.incrementCirculationStatistic('history',  Number(data[key]));
+          break;
       }
     }
   }

--- a/projects/admin/src/app/service/patron.service.ts
+++ b/projects/admin/src/app/service/patron.service.ts
@@ -174,7 +174,7 @@ export class PatronService {
     ];
     const statesQuery = states.map(state => `state:${state}`).join(' OR ');
     const query = `patron_pid:${patronPid} AND (${statesQuery}) end_date:[now-${fromLimit}d/d TO now-${toLimit}d/d]`;
-    return this.getLoans(query, '-end_date');
+    return this.getLoans(query, 'duedate');
   }
 
   /**


### PR DESCRIPTION
Adds a counter for the patron circulation history tab. This counter is
dynamically update when a checkin operation is done for the patron.

Closes rero/rero-ils#1515

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
