### PR TITLE
document: fix duplicate harvested document

### DIFF
--- a/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.ts
+++ b/projects/admin/src/app/record/custom-editor/document-editor/document-editor.component.ts
@@ -82,6 +82,7 @@ export class DocumentEditorComponent {
       record => {
         if (record) {
           delete (record.metadata.pid);
+          delete (record.metadata.harvested);
           this.model = record.metadata;
           this._toastrService.success('Document duplicated');
         } else {


### PR DESCRIPTION
When an harvested document is duplicate, then the `harvested` flag must
be removed.

Closes rero/rero-ils#1542

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
