### PR TITLE
items: inherit holdings first call_number

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -27,7 +27,7 @@ import {
   CoreConfigService, LocalStorageService, RecordModule, RemoteTypeaheadService,
   TranslateLoader, TranslateService, TruncateTextPipe
 } from '@rero/ng-core';
-import { LoggedUserService, MainTitlePipe, SharedConfigService, SharedModule, UserService } from '@rero/shared';
+import { ItemHoldingsCallNumberPipe, LoggedUserService, MainTitlePipe, SharedConfigService, SharedModule, UserService } from '@rero/shared';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDatepickerModule, BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -323,7 +323,8 @@ export function appInitFactory(appInitService: AppInitService) {
       provide: HotkeysService,
       useClass: HotkeysService
     },
-    MainTitlePipe
+    MainTitlePipe,
+    ItemHoldingsCallNumberPipe
   ],
   entryComponents: [
     IllRequestsBriefViewComponent,

--- a/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
+++ b/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
@@ -59,7 +59,9 @@
       </ul>
     </ng-container>
   </div>
-  <div name="call-number" class="col-2"> {{ item.call_number }}</div>
+  <div name="call-number" class="col-2">
+    <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
+  </div>
   <div name="transaction-date" class="col-2">{{ item.loan.transaction_date | dateTranslate :'medium' }}</div>
   <!-- NEXT-ROWS :: request detail -->
   <div class="col-12 mt-2" *ngIf="!isCollapsed">

--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
@@ -23,13 +23,15 @@
   </h5>
   <ng-container class="card-text">
     <dl class="row mb-0 ml-1">
-      <!-- CALL NUMBER -->
-      <ng-container *ngIf="record.metadata.call_number">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.call_number }}
-        </dd>
-      </ng-container>
+
+    <!-- INHERITED CALL NUMBER -->
+    <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
+      </dd>
+    </ng-container>
+
       <ng-container *ngIf="record.metadata.barcode">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Barcode</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
@@ -68,9 +70,9 @@
       <ng-container *ngIf="record.metadata.issue.status as status">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Issue status</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          <i class="fa text-warning" [ngClass]="{ 
+          <i class="fa text-warning" [ngClass]="{
             'fa-envelope': status == issueItemStatus.CLAIMED,
-            'fa-envelope-open-o': status == issueItemStatus.LATE 
+            'fa-envelope-open-o': status == issueItemStatus.LATE
           }"
           ></i>
         {{ status | translate }} [{{ record.metadata.issue.status_date | dateTranslate}}]
@@ -78,4 +80,3 @@
       </ng-container>
     </dl>
   </ng-container>
-  

--- a/projects/admin/src/app/record/brief-view/items-brief-view/items-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/items-brief-view/items-brief-view.component.html
@@ -23,11 +23,11 @@
 </h5>
 <ng-container class="card-text">
   <dl class="row mb-0 ml-1">
-    <!-- CALL NUMBER -->
-    <ng-container *ngIf="record.metadata.call_number">
-      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number</dt>
+    <!-- INHERITED CALL NUMBER -->
+    <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
-        {{ record.metadata.call_number }}
+        <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
       </dd>
     </ng-container>
     <ng-container *ngIf="record.metadata.barcode">

--- a/projects/admin/src/app/record/detail-view/collection-detail-view/collection-items/collection-items.component.html
+++ b/projects/admin/src/app/record/detail-view/collection-detail-view/collection-items/collection-items.component.html
@@ -52,13 +52,12 @@
               <span class="font-weight-bold" translate>Barcode</span>:
               {{ itemData.metadata.barcode }}
             </div>
-            <div *ngIf="itemData.metadata.call_number">
+            <!-- INHERITED CALL NUMBER -->
+            <div *ngIf="itemData | itemHoldingsCallNumber | async as callNumber">
               <span class="font-weight-bold" translate>Call number</span>:
-              {{ itemData.metadata.call_number }}
-              <span *ngIf="itemData.metadata.second_call_number">
-              | {{ itemData.metadata.second_call_number }}
-              </span>
+              <shared-inherited-call-number [item]="itemData"></shared-inherited-call-number>
             </div>
+
             <div *ngIf="itemData.metadata.location.pid | getRecord:'locations' | async as location">
               <span class="font-weight-bold" translate>Library</span>:
               <ng-container *ngIf="location.metadata.library.pid | getRecord: 'libraries' | async as library">

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -23,7 +23,9 @@
     </div>
     <div class="col-sm-2" name="status">{{ item.metadata.status | translate }}</div>
     <div class="col-sm-3" name="issue">{{ item.metadata.enumerationAndChronology }}</div>
-    <div class="col-sm-2" name="call-number">{{ callNumbers }}</div>
+    <div class="col-sm-2" name="call-number">
+      <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
+    </div>
     <div class="col-sm-2 text-right" name="buttons">
       <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
               type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
@@ -17,12 +17,12 @@
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { RecordUiService } from '@rero/ng-core';
+import { ItemHoldingsCallNumberPipe, UserService } from '@rero/shared';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ItemsService } from 'projects/admin/src/app/service/items.service';
 import { RecordPermissionService } from 'projects/admin/src/app/service/record-permission.service';
 import { forkJoin } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { UserService } from '@rero/shared';
 import { ItemRequestComponent } from '../../item-request/item-request.component';
 
 @Component({
@@ -41,17 +41,6 @@ export class DefaultHoldingItemComponent implements OnInit {
 
   /** Item permissions */
   permissions: any;
-
-  // GETTER & SETTER =================================================================
-  /**
-   * Get formatted item call numbers
-   * @return formatted string
-   */
-  get callNumbers(): string {
-    return [this.item.metadata.call_number, this.item.metadata.second_call_number || null]
-      .filter(element => element !== null)
-      .join(' | ');
-  }
 
   // CONSTRUCTOR & HOOKS ==============================================================
   /**

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -23,7 +23,9 @@
     </div>
     <div class="col-sm-2" name="status">{{ item.metadata.status | translate }}</div>
     <div class="col-sm-3" name="issue">{{ item.metadata.enumerationAndChronology }}</div>
-    <div class="col-sm-2" name="call-number">{{ callNumbers }}</div>
+    <div class="col-sm-2" name="call-number">
+      <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
+    </div>
     <div class="col-sm-2 text-right" name="buttons">
       <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
               type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -23,15 +23,10 @@
     <a [routerLink]="['/records', 'documents', 'detail', document.metadata.pid]" class="col-1">
       <i class="fa fa-arrow-left"></i>
     </a>
-    <admin-documents-brief-view
-      class="col"
-      [record]="document"
-      [type]="'documents'"
-      [detailUrl]="{
+    <admin-documents-brief-view class="col" [record]="document" [type]="'documents'" [detailUrl]="{
         link: '/records/documents/detail/' + document.metadata.pid,
         external: false
-      }"
-    ></admin-documents-brief-view>
+      }"></admin-documents-brief-view>
   </div>
 </div>
 
@@ -51,8 +46,7 @@
                 'holding': holding.id,
                 'irregular': true,
                 'redirectTo': 'records/holdings/detail/' + holding.id
-            }"
-          >
+            }">
             <i class="fa fa-plus-square-o"></i>
             {{ 'Add irregular issue' | translate }} ...
           </button>
@@ -116,7 +110,9 @@
                   [ngClass]="getIcon(item.metadata.issue.status)"
                 ></i>
               </div>
-              <div class="col-sm-2 text">{{ item.metadata.call_number }}</div>
+              <div class="col-sm-2 text">
+                <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
+              </div>
               <div class="col-sm-3 text">{{ item.metadata.issue.received_date | dateTranslate }}</div>
               <div class="col-sm-2 text-right">
                 <!-- DETAIL BUTTON -->

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -21,11 +21,12 @@
   </header>
   <section class="mb-4">
     <dl class="row mb-0">
-      <!-- CALL NUMBER -->
-      <ng-container *ngIf="record.metadata.call_number">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number</dt>
+
+      <!-- INHERITED CALL NUMBER -->
+      <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.call_number }}
+          <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
         </dd>
       </ng-container>
       <!-- SECOND CALL NUMBER -->
@@ -122,7 +123,7 @@
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Status</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
           <i class="fa" [ngClass]="getIcon(record.metadata.issue.status)"></i>
-          {{ record.metadata.issue.status | translate }} [{{ record.metadata.issue.status_date | dateTranslate}}]
+          {{ record.metadata.issue.status | translate }} ({{ record.metadata.issue.status_date | dateTranslate}})
         </dd>
       </dl>
     </section>

--- a/projects/shared/src/lib/pipe/item-holdings-call-number.pipe.spec.ts
+++ b/projects/shared/src/lib/pipe/item-holdings-call-number.pipe.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ItemHoldingsCallNumberPipe } from './item-holdings-call-number.pipe';
+import { of } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RecordService } from '@rero/ng-core';
+
+describe('ItemHoldingsCallNumberPipe', () => {
+
+  let itemHoldingsCallNumberPipe: ItemHoldingsCallNumberPipe;
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecord']);
+  recordServiceSpy.getRecord.and.returnValue(of({}));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        ItemHoldingsCallNumberPipe,
+        { provide: RecordService, useValue: recordServiceSpy }
+      ]
+    });
+    itemHoldingsCallNumberPipe = TestBed.inject(ItemHoldingsCallNumberPipe);
+  });
+
+  it('create an instance', () => {
+    expect(itemHoldingsCallNumberPipe).toBeTruthy();
+  });
+});

--- a/projects/shared/src/lib/pipe/item-holdings-call-number.pipe.ts
+++ b/projects/shared/src/lib/pipe/item-holdings-call-number.pipe.ts
@@ -1,0 +1,76 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { RecordService } from '@rero/ng-core';
+import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+
+@Pipe({
+  name: 'itemHoldingsCallNumber'
+})
+export class ItemHoldingsCallNumberPipe implements PipeTransform {
+
+  constructor(private _recordService: RecordService) { }
+
+  /**
+   * Get item call numbers
+   * @return object: first, second are the item first, second call numbers.
+   */
+  transform(record: any): Observable<any> {
+    if (record.call_number) {
+      return of({
+        first: {
+          source: 'item',
+          value: record.call_number
+        },
+        second: {
+          source: 'item',
+          value: record.second_call_number
+        }
+      });
+    } else {
+      return this._recordService.getRecord('holdings', record.holding.pid, 1).pipe(map(data => {
+        if (data && data.metadata && 'call_number' in data.metadata) {
+          return {
+            first: {
+              source: 'holding',
+              value: data.metadata.call_number
+            },
+            second: {
+              source: 'item',
+              value: record.second_call_number
+            }
+          };
+        } else {
+          return {
+            first: {
+              source: undefined,
+              value: undefined
+            },
+            second: {
+              source: undefined,
+              value: undefined
+            }
+          };
+        }
+      }));
+    }
+  }
+
+
+}

--- a/projects/shared/src/lib/shared.module.ts
+++ b/projects/shared/src/lib/shared.module.ts
@@ -18,7 +18,7 @@
 import { CommonModule, DatePipe } from '@angular/common';
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { CoreModule, Nl2brPipe, TruncateTextPipe } from '@rero/ng-core';
+import { CoreModule, Nl2brPipe, RecordModule, TruncateTextPipe } from '@rero/ng-core';
 import { NgVarDirective } from './directive/ng-var.directive';
 import { ContributionFormatPipe } from './pipe/contribution-format.pipe';
 import { ContributionTypePipe } from './pipe/contribution-type.pipe';
@@ -35,6 +35,8 @@ import { ContributionBriefComponent } from './view/brief/contribution-brief/cont
 import { ContributionSourcesComponent } from './view/brief/contribution-sources/contribution-sources.component';
 import { OrganisationBriefComponent } from './view/brief/organisation-brief/organisation-brief.component';
 import { PersonBriefComponent } from './view/brief/person-brief/person-brief.component';
+import { ItemHoldingsCallNumberPipe } from './pipe/item-holdings-call-number.pipe';
+import { InheritedCallNumberComponent } from './view/inherited-call-number/inherited-call-number.component';
 
 @NgModule({
   declarations: [
@@ -51,7 +53,9 @@ import { PersonBriefComponent } from './view/brief/person-brief/person-brief.com
     ProvisionActivityPipe,
     ContributionTypePipe,
     UrlActivePipe,
-    NgVarDirective
+    NgVarDirective,
+    ItemHoldingsCallNumberPipe,
+    InheritedCallNumberComponent
   ],
   exports: [
     CommonModule,
@@ -69,11 +73,14 @@ import { PersonBriefComponent } from './view/brief/person-brief/person-brief.com
     ContributionTypePipe,
     UrlActivePipe,
     NgVarDirective,
-    Nl2brPipe
+    Nl2brPipe,
+    ItemHoldingsCallNumberPipe,
+    InheritedCallNumberComponent
   ],
   imports: [
     CommonModule,
     CoreModule,
+    RecordModule,
     RouterModule
   ],
   providers: [

--- a/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.html
+++ b/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.html
@@ -1,0 +1,42 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ng-container *ngIf="itemMetadata" [ngSwitch]="context">
+
+  <ng-container *ngSwitchCase="'first'">
+    <ng-container *ngIf="itemMetadata | itemHoldingsCallNumber | async as callNumber">
+      <ng-container *ngIf="callNumber.first.source === 'holding'">
+        <i class="fa fa-link text-warning" title="{{ 'inherited' | translate }}" aria-hidden="true"></i>
+      </ng-container>
+      {{ callNumber.first.value }}
+    </ng-container>
+  </ng-container>
+
+  <ng-container *ngSwitchDefault>
+    <ng-container *ngIf="itemMetadata | itemHoldingsCallNumber | async as callNumber">
+      <ng-container *ngIf="callNumber.first.value">
+        {{ callNumber.first.value }}
+      </ng-container>
+      <ng-container *ngIf="callNumber.first.value && callNumber.second.value">
+        |
+      </ng-container>
+      <ng-container *ngIf="callNumber.second.value">
+        {{ callNumber.second.value }}
+      </ng-container>
+    </ng-container>
+  </ng-container>
+
+</ng-container>

--- a/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.spec.ts
+++ b/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.spec.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2020 RERO
+ * Copyright (C) 2021 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -14,33 +14,23 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule } from '@ngx-translate/core';
-import { IdAttributePipe, SharedModule } from '@rero/shared';
-import { SubMenuComponent } from './sub-menu.component';
+import { InheritedCallNumberComponent } from './inherited-call-number.component';
 
 
-describe('SubMenuComponent', () => {
-  let component: SubMenuComponent;
-  let fixture: ComponentFixture<SubMenuComponent>;
+describe('InheritedCallNumberComponent', () => {
+  let component: InheritedCallNumberComponent;
+  let fixture: ComponentFixture<InheritedCallNumberComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SubMenuComponent ],
-      imports: [
-        SharedModule,
-        TranslateModule.forRoot()
-      ],
-      providers: [
-        IdAttributePipe
-      ]
+      declarations: [ InheritedCallNumberComponent ]
     })
     .compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SubMenuComponent);
+    fixture = TestBed.createComponent(InheritedCallNumberComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.ts
+++ b/projects/shared/src/lib/view/inherited-call-number/inherited-call-number.component.ts
@@ -1,0 +1,44 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'shared-inherited-call-number',
+  templateUrl: './inherited-call-number.component.html'
+})
+export class InheritedCallNumberComponent implements OnInit {
+
+  /** Current item */
+  @Input() item: any;
+
+  /** context
+   * first to return the first call number
+   * by default to return the concatenated first and second call number
+   */
+  @Input() context: string;
+
+  /** Item metadata */
+  itemMetadata: any;
+
+  ngOnInit(): void {
+    if (this.item) {
+      this.itemMetadata = ('metadata' in this.item)
+      ? this.itemMetadata = this.item.metadata
+      : this.itemMetadata = this.item;
+    }
+  }
+}

--- a/projects/shared/src/public-api.ts
+++ b/projects/shared/src/public-api.ts
@@ -27,6 +27,7 @@ export * from './lib/pipe/contribution-format.pipe';
 export * from './lib/pipe/contribution-type.pipe';
 export * from './lib/pipe/extract-source-field.pipe';
 export * from './lib/pipe/id-attribute.pipe';
+export * from './lib/pipe/item-holdings-call-number.pipe';
 export * from './lib/pipe/join.pipe';
 export * from './lib/pipe/main-title.pipe';
 export * from './lib/pipe/patron-blocked-message.pipe';
@@ -41,3 +42,4 @@ export * from './lib/view/brief/contribution-brief/contribution-brief.component'
 export * from './lib/view/brief/contribution-sources/contribution-sources.component';
 export * from './lib/view/brief/organisation-brief/organisation-brief.component';
 export * from './lib/view/brief/person-brief/person-brief.component';
+export * from './lib/view/inherited-call-number/inherited-call-number.component';


### PR DESCRIPTION
For items, the parent holdings first
call_number is displayed when the item has no first
call_number. This call number is inherited in the
following screens :

* document, holdings and item details view.
* patron profile: loans, requests, history tabs.
* collection details view.

* Closes #1288

Co-Authored-by: Aly Badr <aly.badr@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
