### PR TITLE
item: sort notifications by chronological order

### DIFF
--- a/projects/admin/src/app/circulation/item/item.component.ts
+++ b/projects/admin/src/app/circulation/item/item.component.ts
@@ -95,7 +95,14 @@ export class ItemComponent implements OnInit {
         }
       );
       this.notifications$ = this._recordService.getRecords(
-        'notifications', `loan.pid:${loanPid}`, 1, RecordService.MAX_REST_RESULTS_SIZE
+        'notifications',
+        `loan.pid:${loanPid}`,
+        1,
+        RecordService.MAX_REST_RESULTS_SIZE,
+        [],
+        {},
+        null,
+        'mostrecent'
       ).pipe(
         map((results: any) => results.hits.hits)
       );


### PR DESCRIPTION
Adds a sort criteria when we search about notifications linked to an
item. The sort criteria used is 'mostrecent'.

Closes rero/rero-ils#1549

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

https://github.com/rero/rero-ils/pull/1553

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
