### PR TITLE
translation: fix show more resources link

### DIFF
--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -144,3 +144,9 @@ _('local_field_7');
 _('local_field_8');
 _('local_field_9');
 _('local_field_10');
+
+// Show more resources
+_('{{ counter }} hidden issue');
+_('{{ counter }} hidden issues');
+_('{{ counter }} hidden item');
+_('{{ counter }} hidden items');


### PR DESCRIPTION
When an holding has a lot of related items, the interface display the 5
first ones followed by a "show more" link containing a counter
corresponding to the hidden resources number. This message is now
extracted for translation.

Closes rero/rero-ils#1400

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

Can noly be tested after weblate translation porcess done and integration.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
