### PR TITLE
menu: fix menu double entries

### DIFF
--- a/projects/admin/src/app/menu/service/menu-user-services.service.ts
+++ b/projects/admin/src/app/menu/service/menu-user-services.service.ts
@@ -263,7 +263,7 @@ export class MenuUserServicesService extends MenuBase {
     .setRouterLink(['/', 'records', 'item_types'])
     .setAttribute('id', 'item-types-menu')
     .setExtra('iconClass', 'fa fa-file-o');
-    this._translatedName(itemTypesMenu, 'Patron types');
+    this._translatedName(itemTypesMenu, 'Item types');
 
     // ----- PATRON TYPES
     const patronTypesMenu = adminMenu.addChild('Patron types')


### PR DESCRIPTION
The label "patron types" is present twice in the admin menus ; indeed
the first one corresponding to 'item types' result list.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
