### PR TITLE
search: fix encoding parameters problem

### DIFF
--- a/projects/public-search/src/app/app.module.ts
+++ b/projects/public-search/src/app/app.module.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClient, HttpClientModule } from '@angular/common/http';
 import { APP_INITIALIZER, Injector, LOCALE_ID, NgModule } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 import { BrowserModule } from '@angular/platform-browser';
@@ -33,6 +33,7 @@ import { CollectionBriefComponent } from './collection-brief/collection-brief.co
 import { DocumentBriefComponent } from './document-brief/document-brief.component';
 import { DocumentRecordSearchComponent } from './document-record-search/document-record-search.component';
 import { ErrorPageComponent } from './error/error-page.component';
+import { CustomRequestInterceptor } from './interceptor/custom-request.interceptor';
 import { MainComponent } from './main/main.component';
 import { SearchBarComponent } from './search-bar/search-bar.component';
 
@@ -73,11 +74,8 @@ export function appInitFactory(appInitializerService: AppInitializerService) {
   providers: [
     { provide: APP_INITIALIZER, useFactory: appInitFactory, deps: [AppInitializerService], multi: true },
     { provide: CoreConfigService, useClass: AppConfigService },
-    {
-      provide: LOCALE_ID,
-      useFactory: (translate: TranslateService) => translate.currentLanguage,
-      deps: [TranslateService]
-    },
+    { provide: LOCALE_ID, useFactory: (translate: TranslateService) => translate.currentLanguage, deps: [TranslateService] },
+    { provide: HTTP_INTERCEPTORS, useClass: CustomRequestInterceptor, multi: true },
     BsLocaleService
   ],
   entryComponents: [

--- a/projects/public-search/src/app/interceptor/custom-request.interceptor.ts
+++ b/projects/public-search/src/app/interceptor/custom-request.interceptor.ts
@@ -1,0 +1,70 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import {
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpParams,
+  HttpEvent,
+  HttpUrlEncodingCodec
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+
+class SafeUrlParamsEncoder extends HttpUrlEncodingCodec {
+
+  /**
+   * Encodes a key name for a URL parameter or query-string.
+   * @param key The key name.
+   * @returns The encoded key name.
+   */
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+
+  /**
+   * Encodes the value of a URL parameter or query-string.
+   * @param value The value.
+   * @returns The encoded value.
+   */
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+}
+
+
+@Injectable()
+export class CustomRequestInterceptor implements HttpInterceptor {
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    // encode URL parameters
+    // angular does not do it by default,
+    // see: https://github.com/angular/angular/issues/18261 for more details
+    const params = new HttpParams({ encoder: new SafeUrlParamsEncoder(), fromString: req.params.toString() });
+    const authReq = req.clone({
+      // Prevent caching in IE, in particular IE11.
+      // See: https://support.microsoft.com/en-us/help/234067/how-to-prevent-caching-in-internet-explorer
+      setHeaders: {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache'
+      }
+    });
+    return next.handle(authReq.clone({ params }));
+  }
+}


### PR DESCRIPTION
Some characters into the params are escaped by default by the query
request encoder. This commit make the request more robust.

Closes rero/rero-ils#1237.

Co-Authored-By : Renaud Michotte <renaud.michotte@gmail.com>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## How to test?

try to call the URL https://localhost:5000/global/search/documents?q=&page=1&size=10&new_acquisition=:now+1w
The server will answer with a HTTP/200 instead of HTTP/500

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
