### PR TITLE
items: add temporary circulation category

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -147,6 +147,7 @@ import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/cust
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
 import { MenuMobileComponent } from './menu/menu-mobile/menu-mobile.component';
 import { SubMenuComponent } from './menu/menu-mobile/sub-menu/sub-menu.component';
+import { HoldingItemTemporaryItemTypeComponent } from './record/detail-view/document-detail-view/holding/holding-item-temporary-item-type/holding-item-temporary-item-type.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -241,7 +242,8 @@ export function appInitFactory(appInitService: AppInitService) {
     MenuUserComponent,
     MenuDashboardComponent,
     MenuMobileComponent,
-    SubMenuComponent
+    SubMenuComponent,
+    HoldingItemTemporaryItemTypeComponent
   ],
   imports: [
     AppRoutingModule,

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -68,6 +68,7 @@
     </div>
   </div>
   <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
+  <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
   <admin-holding-item-in-collection [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
 </div>
 

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-temporary-item-type/holding-item-temporary-item-type.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-temporary-item-type/holding-item-temporary-item-type.component.ts
@@ -1,0 +1,55 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, Input } from '@angular/core';
+import moment from 'moment';
+
+@Component({
+  selector: 'admin-holding-item-temporary-item-type',
+  template: `
+    <ng-container *ngIf="hasTemporaryItemType()">
+      <div class="row">
+        <div class="col-sm-4 col-md-3 pl-5">
+          <i class="fa fa-long-arrow-right pr-1"></i>
+          <i class="fa fa-exclamation-triangle text-warning pr-1"></i>
+          <span class="label-title text-warning" translate>Temporary circulation category</span>
+        </div>
+        <div class="col-sm-8 col-md-9">
+          {{ record.metadata.temporary_item_type.pid | getRecord:'item_types': 'field':'name' | async }}
+          <span *ngIf="record.metadata.temporary_item_type.end_date as endDate" class="ml-1 small text-secondary">
+            (<i class="fa fa-long-arrow-right" aria-hidden="true"></i> {{ endDate | dateTranslate :'shortDate' }})
+          </span>
+        </div>
+      </div>
+    </ng-container>
+  `
+})
+export class HoldingItemTemporaryItemTypeComponent {
+
+  /** Item record */
+  @Input() record: any;
+
+
+  hasTemporaryItemType(): boolean {
+    if ('temporary_item_type' in this.record.metadata) {
+      const endDateValue = this.record.metadata.temporary_item_type.end_date || undefined;
+      return !(endDateValue && moment(endDateValue).isBefore(moment()));
+    }
+    return false;
+  }
+
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -68,5 +68,6 @@
     </div>
   </div>
   <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
+  <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
   <admin-holding-item-in-collection [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
 </div>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -47,8 +47,17 @@
       <dt class="col-sm-3 offset-sm-2 offset-md-0">
         {{ 'Type' | translate }}:
       </dt>
-      <dd class="col-sm-7 col-md-8 mb-0">
-        {{ record.metadata.item_type.pid | getRecord:'item_types': 'field':'name' | async }}
+      <dd class="col-sm-7 col-md-8 mb-0" *ngVar="record.metadata.item_type.pid | getRecord:'item_types': 'field':'name' | async as defaultItty">
+        <ng-container *ngIf="hasTemporaryItemType(); else defaultItemTypeBlock">
+          <del class="text-muted mr-2">{{ defaultItty }}</del>
+          {{ record.metadata.temporary_item_type.pid | getRecord:'item_types': 'field':'name' | async }}
+          <span *ngIf="record.metadata.temporary_item_type.end_date as endDate" class="ml-1 small text-secondary">
+            (<i class="fa fa-long-arrow-right" aria-hidden="true"></i> {{ endDate | dateTranslate :'shortDate' }})
+          </span>
+        </ng-container>
+        <ng-template #defaultItemTypeBlock>
+          {{ defaultItty }}
+        </ng-template>
       </dd>
       <!-- DOCUMENT -->
       <dt class="col-sm-3 offset-sm-2 offset-md-0">

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -17,6 +17,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { RecordService } from '@rero/ng-core';
 import { DetailRecord } from '@rero/ng-core/lib/record/detail/view/detail-record';
+import moment from 'moment';
 import { Observable, Subscription } from 'rxjs';
 import { IssueItemStatus, Item, ItemNote } from '../../../class/items';
 import { HoldingsService } from '../../../service/holdings.service';
@@ -43,8 +44,6 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
   /** Location record */
   location: any;
 
-  /** reference to IssueItemStatus */
-  issueItemStatus = IssueItemStatus;
 
   /**
    * Constructor
@@ -69,6 +68,14 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
 
   isPublicNote(note: ItemNote): boolean {
     return Item.PUBLIC_NOTE_TYPES.includes(note.type);
+  }
+
+  hasTemporaryItemType(): boolean {
+    if ('temporary_item_type' in this.record.metadata) {
+      const endDateValue = this.record.metadata.temporary_item_type.end_date || undefined;
+      return !(endDateValue && moment(endDateValue).isBefore(moment()));
+    }
+    return false;
   }
 
   /**

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -57,6 +57,7 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
             key: this.name,
             label: 'Items',
             editorSettings: {
+              longMode: true,
               template: {
                 recordType: 'templates',
                 loadFromTemplate: true,


### PR DESCRIPTION
Updates the item route definition to use a 'long mode' editor for items.
Updates item brief/detailed templates to add the temporary circulation
category information.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies

https://github.com/rero/rero-ils/pull/1606

## How to test?

* Add a temporary circulation category (tmp_itty) on an item.
* Try to display the document detailed view for this item
* Try to display the item detail view for this item.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
