### PR TITLE
gh-actions: mark PR and issue stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: "Mark stale issues/PR"
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Make issue/PR as stale after 3 months
+        days-before-stale: 90
+        # Do not close issue/PR marked as stale (will be changed later)
+        days-before-close: 0
+        stale-issue-message: 'This issue is stale because it has been open 3 months with no activity.'
+        stale-pr-message: 'This PR is stale because it has been open 3 months with no activity.'
+        # Set the label added to issue marked as stale (leave default value)
+        # stale-issue-label: 'stale'
+        # Set the label added to the PR marked stale
+        stale-pr-label: 'stale'
+        # Labels on an issue exempted from being marked as stale
+        exempt-issue-labels: 'bug,P: High'
+        exempt-pr-labels: 'translations'


### PR DESCRIPTION
* Adds a gh-actions workflow to mark issue and PR opened since 3 months
  without activity stale.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To mark PR with no activity for the last 3 months to be marked as stale. 

## How to test?

- Check changes.
- Check the workflow on https://github.com/iGormilhit/rero-ils-ui/actions

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
