### PR TITLE
holdings: enable long mode for holdings editor

### DIFF
--- a/projects/admin/src/app/routes/holdings-route.ts
+++ b/projects/admin/src/app/routes/holdings-route.ts
@@ -49,6 +49,7 @@ export class HoldingsRoute extends BaseRoute implements RouteInterface {
             key: this.name,
             label: 'Holdings',
             editorSettings: {
+              longMode: true,
               template: {
                 recordType: 'templates',
                 loadFromTemplate: true,


### PR DESCRIPTION
Updates the holdings route definition to use a 'long mode' editor for holdings.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
