### PR TITLE
circulation: display item info when no circ action is performed

### DIFF
--- a/projects/admin/src/app/circulation/checkin/checkin.component.ts
+++ b/projects/admin/src/app/circulation/checkin/checkin.component.ts
@@ -119,7 +119,7 @@ export class CheckinComponent implements OnInit {
             break;
           case ItemAction.checkin:
             this._displayCirculationNote(item, ItemNoteType.CHECKIN);
-            if (item.action_applied.checkin) {
+            if (item.action_applied && item.action_applied.checkin) {
               this.getPatronInfo(item.action_applied.checkin.patron.barcode);
             }
             if (item.status === ItemStatus.IN_TRANSIT) {
@@ -276,6 +276,7 @@ export class CheckinComponent implements OnInit {
           const library_code = item.loan.item_destination.library_code;
           const location_name = item.loan.item_destination.location_name;
           message += ` (${this._translate.instant('to')} ${library_code}:${location_name})`;
+          this._itemsList.unshift(item); // Display item info
         }
       },
       () => {

--- a/projects/admin/src/app/circulation/item/item.component.ts
+++ b/projects/admin/src/app/circulation/item/item.component.ts
@@ -117,7 +117,7 @@ export class ItemComponent implements OnInit {
    * @return: transit location pid
    */
   getTransitLocationPid() {
-    if (this.patron) {
+    if (this.patron || this.item.action_applied === undefined) {
       if (this.item.loan && this.item.loan.state === LoanState.ITEM_IN_TRANSIT_FOR_PICKUP) {
         return this.item.loan.pickup_location_pid;
       }


### PR DESCRIPTION
* Adds conditions to consider a checkin with no action performed in
order to display item info (for example, when an in-transit item barcode
is scanned at a wrong library).
* Closes rero/rero-ils#1168.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To solve the issue mentioned above.

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

N/A

## How to test?

See issue description

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
