### PR TITLE
documents: allow to add either holdings or items

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -167,7 +167,7 @@
         </ng-template>
         <div class="mt-2">
           <!-- HOLDINGS -->
-          <admin-holdings [holdingType]="holdingType" [documentPid]="record.metadata.pid">
+          <admin-holdings [holdingType]="holdingType" [document]="record">
           </admin-holdings>
         </div>
       </tab>
@@ -445,7 +445,11 @@
       <!-- END OF DESCRIPTION TAB --------------------------------------------->
 
       <!-- LOCAL FIELDS TAB ------------------------------------------------------------>
-      <tab id="documents-local-field-tab" tabOrder="4" *ngIf="!record.metadata.harvested">
+      <tab
+        *ngIf="!record.metadata.harvested && record.metadata.pid"
+        id="documents-local-field-tab"
+        tabOrder="4"
+      >
         <ng-template tabHeading>
           <i class="fa fa-list-ul mr-1"></i> {{ 'Local fields' | translate }}
         </ng-template>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
@@ -16,15 +16,40 @@
 -->
 
 <div class="row" *ngIf="canAdd">
-  <div class="col" [ngSwitch]="holdingType">
-    <a *ngSwitchCase="'standard'" class="btn btn-sm btn-outline-primary mt-2 float-right"
-      [routerLink]="['/', 'records', 'items', 'new']" [queryParams]="{ document: documentPid }">
-      <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
-    </a>
-    <a *ngSwitchCase="'serial'" class="btn btn-sm btn-outline-primary float-right"
-      [routerLink]="['/', 'records', 'holdings', 'new']" [queryParams]="{ document: documentPid }">
-      <i class="fa fa-plus-square-o"></i> {{ 'Add' | translate }}...
-    </a>
+  <div class="col">
+    <div class="btn-group pull-right" dropdown>
+      <button
+        id="document-add-actions"
+        dropdownToggle
+        type="button"
+        class="btn btn-sm btn-outline-primary dropdown-toggle"
+        aria-controls="dropdown-animated">
+        {{ 'Add' | translate }}
+        <span class="caret"></span>
+      </button>
+      <ul
+        id="document-add-actions-animated"
+        *dropdownMenu class="dropdown-menu dropdown-menu-right"
+        role="menu"
+        aria-labelledby="document-add-actions"
+      >
+        <li class="text-right" role="menuitem">
+          <a
+            class="dropdown-item"
+            [routerLink]="['/', 'records', 'items', 'new']"
+            [queryParams]="{ document: document.metadata.pid }" translate
+          >an item</a>
+        </li>
+        <li class="text-right" role="menuitem">
+          <a
+            class="dropdown-item"
+            [routerLink]="['/', 'records', 'holdings', 'new']"
+            [queryParams]="{ document: document.metadata.pid }"
+          translate
+          >a holdings</a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
* Allows to attached a serial type holdings on a document, even if the
  document is not a serial.
* Fixes local fields tab display on import.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#1478`'s PR(s):

*https://github.com/rero/rero-ils/pull/1478

## How to test?

- Document actions

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
