### PR TITLE
documents: display 'part of' in brief views

### DIFF
--- a/projects/admin/src/app/record/brief-view/documents-brief-view/documents-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/documents-brief-view/documents-brief-view.component.html
@@ -54,6 +54,7 @@
       <ul class="list-unstyled" *ngIf="provisionActivityPublications.length > 0">
         <li *ngFor="let publication of provisionActivityPublications">{{ publication.value }}</li>
       </ul>
+      <shared-part-of [record]="record"></shared-part-of>
     </ng-container>
   </div>
 </article>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -96,30 +96,7 @@
         </ng-container>
 
     <!-- IS PART OF -->
-    <ng-container *ngFor="let document of record.metadata.partOf; let i = index">
-      <ng-container *ngIf="document.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
-        <dl class="row mb-0">
-          <dt id="{{'doc-part-of-label-' + i}}" class="col-auto">
-            {{ getPartOfLabel(hostDocument) }}
-          </dt>
-          <dd class="col mb-0">
-            <div class="row">
-              <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', document.document.pid]">
-                {{ getShortMainTitle(hostDocument.metadata.title) }}
-              </a>
-              <ng-container *ngIf="document.numbering">
-                <span>;</span>
-                <ul class="list-unstyled mb-0 ml-1">
-                  <li *ngFor="let numbering of document.numbering">
-                    <span id="{{'doc-part-of-numbering-' + i}}" *ngIf="formatNumbering(numbering) as num">{{ num }}</span>
-                  </li>
-                </ul>
-              </ng-container>
-            </div>
-          </dd>
-        </dl>
-      </ng-container>
-    </ng-container>
+    <shared-part-of [record]="record" isBrief="false"></shared-part-of>
 
     <!-- ABSTRACT -->
     <ng-container *ngIf=" record.metadata.abstracts && record.metadata.abstracts.length > 0">

--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -66,6 +66,7 @@
         </a>
         <pre class="collapse border border-secondary mt-1" id="{{'score'+record.metadata.pid }}">{{record.explanation|json}}</pre>
       </div>
+      <shared-part-of [record]="record"></shared-part-of>
     </article>
   </div>
 </article>

--- a/projects/shared/src/lib/shared.module.ts
+++ b/projects/shared/src/lib/shared.module.ts
@@ -37,6 +37,7 @@ import { PersonBriefComponent } from './view/brief/person-brief/person-brief.com
 import { ItemHoldingsCallNumberPipe } from './pipe/item-holdings-call-number.pipe';
 import { InheritedCallNumberComponent } from './view/inherited-call-number/inherited-call-number.component';
 import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
+import { PartOfComponent } from './view/brief/part-of/part-of.component';
 
 @NgModule({
   declarations: [
@@ -55,7 +56,8 @@ import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
     UrlActivePipe,
     ItemHoldingsCallNumberPipe,
     InheritedCallNumberComponent,
-    ThumbnailComponent
+    ThumbnailComponent,
+    PartOfComponent
   ],
   exports: [
     CommonModule,
@@ -75,7 +77,8 @@ import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
     Nl2brPipe,
     ItemHoldingsCallNumberPipe,
     InheritedCallNumberComponent,
-    ThumbnailComponent
+    ThumbnailComponent,
+    PartOfComponent
   ],
   imports: [
     CommonModule,

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.html
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.html
@@ -1,0 +1,79 @@
+ <!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-container *ngIf="isBrief; else detailedView">
+  <ng-container *ngIf="record && record.metadata.partOf; else seriesStatement">
+    <!-- part of -->
+    <ng-container *ngFor="let partOf of record.metadata.partOf; let i = index">
+      <ng-container *ngIf="partOf.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
+        <div class="mb-0">
+            {{ getPartOfLabel(hostDocument) }}:
+            <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', partOf.document.pid]">
+              {{ getShortMainTitle(hostDocument.metadata.title) }}
+            </a>
+            <ng-container *ngIf="partOf.numbering">
+              <span>;</span>
+              <ul class="list-unstyled mb-0 ml-1">
+                <li *ngFor="let numbering of partOf.numbering">
+                  <span id="{{'doc-part-of-numbering-' + i}}" *ngIf="formatNumbering(numbering) as num">{{ num }}</span>
+                </li>
+              </ul>
+            </ng-container>
+        </div>
+      </ng-container>
+    </ng-container>
+  </ng-container>
+  <ng-template #seriesStatement>
+    <!-- SERIES STATEMENT -->
+    <ng-container *ngIf="record && record.metadata.seriesStatement">
+      {{ 'Series statement' | translate }}:
+      <ng-container *ngFor="let serie of getStatement(record.metadata.seriesStatement); last as isLast; let i = index">
+        <span id="{{'doc-series-statement-' + i}}">{{ serie.value }}</span>
+        <span *ngIf="!isLast">; </span>
+      </ng-container>
+    </ng-container>
+  </ng-template>
+</ng-container>
+<ng-template #detailedView>
+  <ng-container *ngIf="record && record.metadata.partOf">
+    <!-- part of -->
+    <ng-container *ngFor="let document of record.metadata.partOf; let i = index">
+      <ng-container *ngIf="document.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
+        <dl class="row mb-0">
+          <dt id="{{'doc-part-of-label-' + i}}" class="col-auto">
+            {{ getPartOfLabel(hostDocument) }}
+          </dt>
+          <dd class="col mb-0">
+            <div class="row">
+              <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', document.document.pid]">
+                {{ getShortMainTitle(hostDocument.metadata.title) }}
+              </a>
+              <ng-container *ngIf="document.numbering">
+                <span>;</span>
+                <ul class="list-unstyled mb-0 ml-1">
+                  <li *ngFor="let numbering of document.numbering">
+                    <span id="{{'doc-part-of-numbering-' + i}}" *ngIf="formatNumbering(numbering) as num">{{ num }}</span>
+                  </li>
+                </ul>
+              </ng-container>
+            </div>
+          </dd>
+        </dl>
+      </ng-container>
+    </ng-container>
+  </ng-container>
+</ng-template>

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.spec.ts
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { PartOfComponent } from './part-of.component';
+
+describe('PartOfComponent', () => {
+  let component: PartOfComponent;
+  let fixture: ComponentFixture<PartOfComponent>;
+
+  beforeEach(waitForAsync (() => {
+    TestBed.configureTestingModule({
+      declarations: [ PartOfComponent ],
+      imports: [
+        TranslateModule.forRoot({}),
+        HttpClientTestingModule,
+        RouterTestingModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PartOfComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
@@ -1,0 +1,127 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, Input } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'shared-part-of',
+  templateUrl: './part-of.component.html'
+})
+export class PartOfComponent {
+
+  /** Document */
+  @Input() record: any;
+
+  /** Is it brief or detailed view? */
+  @Input() isBrief = true;
+
+  /** Css class for dd in template */
+  ddCssClass = 'col-sm-6 col-md-8 mb-0';
+
+  /** constructor
+   * @param _translateService - TranslateService to translate some strings.
+   */
+  constructor(
+    private _translateService: TranslateService
+  ) { }
+
+  /**
+   * Get "part of" label from host document type
+   * @param hostDocument - host document
+   * @return corresponding translated label
+   */
+  getPartOfLabel(hostDocument: any) {
+    switch (hostDocument.metadata.issuance.subtype) {
+      case 'periodical':
+          return this._translateService.instant('Journal');
+      case 'monographicSeries':
+          return this._translateService.instant('Series');
+      default:
+           return this._translateService.instant('Published in');
+    }
+  }
+
+  /**
+   * Get short main title
+   * @param titles - document titles
+   * @return - main title to display
+   */
+  getShortMainTitle(titles: any) {
+    const bfTitles: Array<any> = titles.filter((title: any) => title.type === 'bf:Title');
+    for (const bfTitle of bfTitles) {
+      for (const mainTitle of bfTitle.mainTitle) {
+        if (!mainTitle.language) {
+          return mainTitle.value;
+        }
+      }
+    }
+  }
+
+  /**
+   * Format "part of" numbering for display
+   *
+   * @param num: numbering to format
+   * @return formatted numbering (example: 2020, vol. 2, nr. 3, p. 302)
+   */
+  formatNumbering(num: any) {
+    const numbering = [];
+    if (num.year) {
+      numbering.push(num.year);
+    }
+    if (num.volume) {
+      const volume = [this._translateService.instant('vol'), num.volume];
+      numbering.push(volume.join('. '));
+    }
+    if (num.issue) {
+      const issue = [this._translateService.instant('nr'), num.issue];
+      numbering.push(issue.join('. '));
+    }
+    if (num.pages) {
+      const pages = [this._translateService.instant('p'), num.pages];
+      numbering.push(pages.join('. '));
+    }
+    return numbering.join(', ');
+  }
+
+  /**
+   * Get list of document edition statement
+   * @return array - edition statement
+   */
+  getStatement(statements: any) {
+    if (null === statements) {
+      return [];
+    }
+    const results = [];
+    statements.forEach((element: any) => {
+      if ('_text' in element) {
+        const elementText = element._text;
+        const keys = Object.keys(elementText);
+        const indexDefault = keys.indexOf('default');
+        if (indexDefault > -1) {
+          results.push(elementText.default);
+          keys.splice(indexDefault, 1);
+        }
+
+        keys.forEach(key => {
+          results.push(elementText[key]);
+        });
+      }
+    });
+    return results;
+  }
+}

--- a/projects/shared/src/public-api.ts
+++ b/projects/shared/src/public-api.ts
@@ -40,6 +40,7 @@ export * from './lib/shared.module';
 export * from './lib/view/brief/contribution-brief/contribution-brief.component';
 export * from './lib/view/brief/contribution-sources/contribution-sources.component';
 export * from './lib/view/brief/organisation-brief/organisation-brief.component';
+export * from './lib/view/brief/part-of/part-of.component';
 export * from './lib/view/brief/person-brief/person-brief.component';
 export * from './lib/view/inherited-call-number/inherited-call-number.component';
 export * from './lib/view/thumbnail/thumbnail.component';


### PR DESCRIPTION
* Moves 'part of' template and code to a new component in shared
library. This component is used in detailed and brief views.
* Closes rero/rero-ils#1596.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To solve the issue mentioned above.

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

N/A

## How to test?

See issue description.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
