### PR TITLE
menu: translate menu entries

### DIFF
--- a/projects/admin/src/app/routes/acquisition-accounts-route.ts
+++ b/projects/admin/src/app/routes/acquisition-accounts-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { EditorComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { BaseRoute } from './base-route';
@@ -38,7 +39,7 @@ export class AcquisitionAccountsRoute extends BaseRoute implements RouteInterfac
         types: [
           {
             key: this.name,
-            label: 'Acquisition accounts',
+            label: _('Acquisition accounts'),
             preCreateRecord: (data: any) => {
               const user = this._routeToolService.userService.user;
               data.organisation = {

--- a/projects/admin/src/app/routes/acquisition-order-lines-route.ts
+++ b/projects/admin/src/app/routes/acquisition-order-lines-route.ts
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { DetailComponent, EditorComponent, RecordService, RouteInterface } from '@rero/ng-core';
-import { Record, JSONSchema7 } from '@rero/ng-core';
+import { DetailComponent, EditorComponent, JSONSchema7, Record, RecordService, RouteInterface } from '@rero/ng-core';
 import { map } from 'rxjs/operators';
 import { AcqOrderLineGuard } from '../guard/acq-order-line.guard';
 import { CanUpdateGuard } from '../guard/can-update.guard';
@@ -49,7 +49,7 @@ export class AcquisitionOrderLinesRoute extends BaseRoute implements RouteInterf
         types: [
           {
             key: this.name,
-            label: 'Order lines',
+            label: _('Order lines'),
             detailComponent: AcquisitionOrderLineDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),

--- a/projects/admin/src/app/routes/acquisition-orders-route.ts
+++ b/projects/admin/src/app/routes/acquisition-orders-route.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { formatDate } from '@angular/common';
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { AcquisitionOrderBriefViewComponent } from '../record/brief-view/acquisition-order-brief-view.component';
@@ -48,7 +49,7 @@ export class AcquisitionOrdersRoute extends BaseRoute implements RouteInterface 
         types: [
           {
             key: this.name,
-            label: 'Orders',
+            label: _('Orders'),
             component: AcquisitionOrderBriefViewComponent,
             detailComponent: AcquisitionOrderDetailViewComponent,
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),

--- a/projects/admin/src/app/routes/budgets-route.ts
+++ b/projects/admin/src/app/routes/budgets-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { RoleGuard } from '../guard/role.guard';
@@ -46,7 +47,7 @@ export class BudgetsRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Budgets',
+            label: _('Budgets'),
             component: BudgetsBriefViewComponent,
             detailComponent: BudgetDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),

--- a/projects/admin/src/app/routes/circulation-policies-route.ts
+++ b/projects/admin/src/app/routes/circulation-policies-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { RoleGuard } from '../guard/role.guard';
@@ -47,7 +48,7 @@ export class CirculationPoliciesRoute extends BaseRoute implements RouteInterfac
         types: [
           {
             key: this.name,
-            label: 'Circulation policies',
+            label: _('Circulation policies'),
             component: CircPoliciesBriefViewComponent,
             detailComponent: CircPolicyDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),

--- a/projects/admin/src/app/routes/item-types-route.ts
+++ b/projects/admin/src/app/routes/item-types-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { RoleGuard } from '../guard/role.guard';
@@ -46,7 +47,7 @@ export class ItemTypesRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Item types',
+            label: _('Item types'),
             component: ItemTypesBriefViewComponent,
             detailComponent: ItemTypeDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),

--- a/projects/admin/src/app/routes/locations-route.ts
+++ b/projects/admin/src/app/routes/locations-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { LibraryGuard } from '../guard/library.guard';
@@ -44,7 +45,7 @@ export class LocationsRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Locations',
+            label: _('Locations'),
             detailComponent: LocationDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),

--- a/projects/admin/src/app/routes/organisations-route.ts
+++ b/projects/admin/src/app/routes/organisations-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RouteInterface } from '@rero/ng-core';
 import { of } from 'rxjs';
 import { CanUpdateGuard } from '../guard/can-update.guard';
@@ -44,7 +45,7 @@ export class OrganisationsRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Organisations',
+            label: _('Organisations'),
             detailComponent: OrganisationDetailViewComponent
           }
         ]

--- a/projects/admin/src/app/routes/patron-types-route.ts
+++ b/projects/admin/src/app/routes/patron-types-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { RoleGuard } from '../guard/role.guard';
@@ -47,7 +48,7 @@ export class PatronTypesRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Patron types',
+            label: _('Patron types'),
             component: PatronTypesBriefViewComponent,
             detailComponent: PatronTypesDetailViewComponent,
             canAdd: () => this._routeToolService.canSystemLibrarian(),

--- a/projects/admin/src/app/routes/patrons-route.ts
+++ b/projects/admin/src/app/routes/patrons-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import {
   DetailComponent, EditorComponent, extractIdOnRef, JSONSchema7, Record, RecordSearchPageComponent, RecordService, RouteInterface
@@ -49,7 +50,7 @@ export class PatronsRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Users',
+            label: _('Users'),
             editorSettings: {
               template: {
                 recordType: 'templates',

--- a/projects/admin/src/app/routes/persons-route.ts
+++ b/projects/admin/src/app/routes/persons-route.ts
@@ -19,6 +19,7 @@ import { of } from 'rxjs';
 import { ContributionBriefComponent } from '@rero/shared';
 import { ContributionDetailViewComponent } from '../record/detail-view/contribution-detail-view/contribution-detail-view.component';
 import { BaseRoute } from './base-route';
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
 export class PersonsRoute extends BaseRoute implements RouteInterface {
 
@@ -45,7 +46,7 @@ export class PersonsRoute extends BaseRoute implements RouteInterface {
           {
             key: 'persons',
             index: 'contributions',
-            label: 'Persons',
+            label: _('Persons'),
             component: ContributionBriefComponent,
             detailComponent: ContributionDetailViewComponent,
             aggregationsOrder: ['sources'],

--- a/projects/admin/src/app/routes/templates-route.ts
+++ b/projects/admin/src/app/routes/templates-route.ts
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { ActionStatus, DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
-import { JSONSchema7 } from '@rero/ng-core';
+import { ActionStatus, DetailComponent, EditorComponent, JSONSchema7, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { Observable, Subscriber } from 'rxjs';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { TemplatesBriefViewComponent } from '../record/brief-view/templates-brief-view.component';
@@ -48,7 +48,7 @@ export class TemplatesRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Templates',
+            label: _('Templates'),
             component: TemplatesBriefViewComponent,
             detailComponent: TemplateDetailViewComponent,
             canAdd: () => this._routeToolService.canNot(),

--- a/projects/admin/src/app/routes/vendors-route.ts
+++ b/projects/admin/src/app/routes/vendors-route.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, EditorComponent, RecordSearchPageComponent, RouteInterface } from '@rero/ng-core';
 import { VendorBriefViewComponent } from '../record/brief-view/vendor-brief-view.component';
 import { VendorDetailViewComponent } from '../record/detail-view/vendor-detail-view/vendor-detail-view.component';
@@ -44,7 +45,7 @@ export class VendorsRoute extends BaseRoute implements RouteInterface {
         types: [
           {
             key: this.name,
-            label: 'Vendors',
+            label: _('Vendors'),
             component: VendorBriefViewComponent,
             detailComponent: VendorDetailViewComponent,
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -21,31 +21,19 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
 // Resources
 _('acq_accounts');
-_('Acquisition accounts');
 _('acq_order_lines');
-_('Order lines');
 _('acq_orders');
-_('Orders');
 _('budgets');
-_('Budgets');
 _('circ_policies');
-_('Circulation policies');
 _('documents');
 _('item_types');
-_('Item types');
 _('libraries');
-_('Libraries');
 _('locations');
-_('Locations');
 _('organisations');
-_('Organisations');
 _('Patrons');
 _('patron_types');
-_('Patron types');
 _('persons');
-_('Persons');
 _('vendors');
-_('Vendors');
 
 // Facets
 _('author');
@@ -152,3 +140,17 @@ _('{{ counter }} hidden item');
 _('{{ counter }} hidden items');
 _('{{ counter }} hidden holding');
 _('{{ counter }} hidden holdings');
+
+// Menu entries
+_('User services');
+_('ILL requests');
+_('Import from the web');
+_('Corporate bodies');
+_('Late issues');
+_('Reports & monitoring');
+_('Inventory list');
+_('Admin');
+_('My organisation');
+_('My library');
+_('Public interface');
+_('Logout');


### PR DESCRIPTION
* Adds missing strings to manual translations.
* Removes some strings from manual translations because they are already
extracted somewhere else in the application.
* Harmonize the translation of the labels in 'resource'-route files.
* Closes rero/rero-ils#1627.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To solve the issue mentioned above.

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

N/A

## How to test?

See issue description.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
