### PR TITLE
documents: fix items/holdings creation for harvested document

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
@@ -107,7 +107,7 @@ export class HoldingsComponent implements OnInit {
         this.holdings = result[0];
         this.holdingsTotal = result[1];
         const permissions = result[2];
-        this.canAdd = permissions.create.can;
+        this.canAdd = this.canAdd && permissions.create.can;
       });
   }
 


### PR DESCRIPTION
If the document is marked as harvested, the creation of holdings/items
must be disallowed by hiding the "add" drop-down button.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

