### PR TITLE
patrons: edit the user personal data in a modal

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -151,6 +151,8 @@ import { HoldingItemTemporaryItemTypeComponent } from './record/detail-view/docu
 import { OperationLogsComponent } from './record/operation-logs/operation-logs.component';
 import { HoldingSharedViewComponent } from './record/detail-view/document-detail-view/holding-shared-view/holding-shared-view.component';
 import { OperationLogsDialogComponent } from './record/operation-logs/operation-logs-dialog/operation-logs-dialog.component';
+import { UserIdComponent } from './record/editor/wrappers/user-id/user-id.component';
+import { UserIdEditorComponent } from './record/custom-editor/user-id-editor/user-id-editor.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -249,7 +251,9 @@ export function appInitFactory(appInitService: AppInitService) {
     HoldingItemTemporaryItemTypeComponent,
     OperationLogsComponent,
     HoldingSharedViewComponent,
-    OperationLogsDialogComponent
+    OperationLogsDialogComponent,
+    UserIdComponent,
+    UserIdEditorComponent
   ],
   imports: [
     AppRoutingModule,
@@ -265,7 +269,12 @@ export function appInitFactory(appInitService: AppInitService) {
     TabsModule.forRoot(),
     TooltipModule.forRoot(),
     PopoverModule.forRoot(),
-    FormlyModule.forRoot(),
+    FormlyModule.forRoot({
+      wrappers: [{
+        name: 'user-id',
+        component: UserIdComponent
+      }]
+    }),
     TranslateModule.forRoot({
       loader: {
         provide: BaseTranslateLoader,
@@ -380,7 +389,8 @@ export function appInitFactory(appInitService: AppInitService) {
     DocumentRecordSearchComponent,
     CustomShortcutHelpComponent,
     ContributionDetailViewComponent,
-    OperationLogsComponent
+    OperationLogsComponent,
+    UserIdEditorComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.html
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.html
@@ -1,0 +1,43 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <div class="modal-header">
+    <h4 id="dialog-sizes-name2" class="modal-title pull-left" translate>User Editor</h4>
+    <div class="d-flex">
+      <form>
+        <ng-core-search-input [placeholder]="'username or email' | translate" [searchText]="searchText"
+          (search)="searchValueUpdated($event)" class="form-inline mr-3" [focus]="false" [displayLabel]="false">
+        </ng-core-search-input>
+      </form>
+      <button type="button" id="editor-delete-button" class="btn btn-outline-danger btn-sm mr-1"
+        (click)="bsModalRef.hide()">
+        <i class="fa fa-times"></i>
+        {{ 'Cancel' | translate }}
+      </button>
+      <button type="submit" id="editor-save-button" class="btn btn-primary btn-sm">
+        <i class="fa fa-save"></i>
+        {{ 'Save' | translate }}
+      </button>
+    </div>
+  </div>
+
+  <div class="modal-body">
+    <!-- ngx-formly -->
+    <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
+  </div>
+</form>

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientModule } from '@angular/common/http';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { BsModalRef, ModalModule } from 'ngx-bootstrap/modal';
+import { ToastrModule } from 'ngx-toastr';
+import { UserIdEditorComponent } from './user-id-editor.component';
+
+
+describe('UserIdEditorComponent', () => {
+  let component: UserIdEditorComponent;
+  let fixture: ComponentFixture<UserIdEditorComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        TranslateModule.forRoot({}),
+        ModalModule.forRoot(),
+        ReactiveFormsModule,
+        ToastrModule.forRoot()
+      ],
+      declarations: [ UserIdEditorComponent ],
+      providers: [
+        BsModalRef
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserIdEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
@@ -1,0 +1,201 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
+import { TranslateService } from '@ngx-translate/core';
+import { JSONSchema7, orderedJsonSchema, RecordService } from '@rero/ng-core';
+import { BsModalRef } from 'ngx-bootstrap/modal';
+import { ToastrService } from 'ngx-toastr';
+import { Observable, of } from 'rxjs';
+import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'admin-user-id-editor',
+  templateUrl: './user-id-editor.component.html'
+})
+export class UserIdEditorComponent implements OnInit {
+
+  /** current query to import a user */
+  searchText: string = null;
+
+  /** current User id in the invenio db */
+  userID: string = null;
+
+  /** JOSONSchema */
+  schema = null;
+
+  /** form initial values */
+  model: any = {};
+
+  /** angular form group for ngx-formly */
+  form: FormGroup;
+
+  /** Formly fields configuration populate by the JSONSchema */
+  fields: FormlyFieldConfig[];
+
+  /**
+   * Constructor
+   *
+   * @param _recordService - ng-core RecordService
+   * @param bsModalRef - ngx-boostrap BsModalRef
+   * @param _formlyJsonschema - ngx-formly FormlyJsonschema
+   * @param _toastService - ngx-toastr ToastrService
+   * @param _translateService - ngx-translate TranslateService
+   */
+  constructor(
+    private _recordService: RecordService,
+    public bsModalRef: BsModalRef,
+    private _formlyJsonschema: FormlyJsonschema,
+    private _toastService: ToastrService,
+    private _translateService: TranslateService) {
+    this.form = new FormGroup({});
+  }
+
+  /**
+   * Get the JSONSchema and add validators.
+   */
+  ngOnInit(): void {
+    this._recordService.getSchemaForm('users').pipe(
+      tap(
+        schema => {
+          if (schema != null) {
+            this.fields = [
+              this._formlyJsonschema.toFieldConfig(orderedJsonSchema(schema.schema), {
+                // post process JSONSChema7 to FormlyFieldConfig conversion
+                map: (field: FormlyFieldConfig, jsonSchema: JSONSchema7) => {
+                  if (field.templateOptions.label === 'Email') {
+                    if (field.asyncValidators == null) {
+                      field.asyncValidators = {};
+                    }
+                    field.asyncValidators.uniqueEmailMessage = this.getUniqueValidator('email');
+                  }
+                  if (field.templateOptions.label === 'Username') {
+                    if (field.asyncValidators == null) {
+                      field.asyncValidators = {};
+                    }
+                    field.asyncValidators.uniqueUsernameMessage = this.getUniqueValidator('username');
+                  }
+                  return field;
+                }
+              })
+            ];
+          }
+        }
+      ),
+      switchMap(() => {
+        return (this.userID == null)
+          ? of({})
+          : this._recordService.getRecord('users', this.userID);
+      }),
+      map(user => user.metadata)
+    ).subscribe(model => this.model = model);
+  }
+
+  /**
+   * Retrieve a User given an email or a username.
+   *
+   * @param query - username or email to retrieve a User
+   */
+  searchValueUpdated(query: (string | null)): void {
+    this._recordService.getRecords('users', query).pipe(
+      map((res: any) => {
+        if (res.hits.hits.length === 0) {
+          this._toastService.warning(
+            this._translateService.instant('User not found.')
+          );
+          return of(null);
+        }
+
+        return res.hits.hits[0];
+      }),
+      map(model => {
+        const roles = model.metadata.roles as Array<string>;
+        if (roles) {
+          const alreadyExists = roles.some(v => ['patron', 'librarian', 'system_librarian'].some(r => r === v));
+          if (alreadyExists) {
+            this._toastService.info(
+              this._translateService.instant('This person is already registered in your organisation.')
+            );
+            return of(null);
+          }
+        }
+        this._toastService.info(
+          this._translateService.instant('The personal data has been successfully linked to this patron.')
+        );
+        this.userID = model.id;
+        return this.model = model.metadata ? model.metadata : null;
+      }),
+    ).subscribe();
+  }
+
+  /**
+   * Submit the data if the form is valid.
+   *
+   * Create if the userID is null else update.
+   */
+  submit(): void {
+    this.form.updateValueAndValidity();
+    if (this.form.valid === false) {
+      this._toastService.error(
+        this._translateService.instant('The form contains errors.')
+      );
+      return;
+    }
+
+    const data = this.form.value;
+    if (this.userID != null) {
+      data.pid = this.userID;
+      this._recordService.update('users', data).subscribe(() => {
+        this.bsModalRef.hide();
+      });
+    } else {
+      this._recordService.create('users', data).subscribe((res) => {
+        this.userID = res.id;
+        this.bsModalRef.hide();
+      });
+    }
+  }
+
+  /**
+   * Create an Async validator to check the uniqueness of a value.
+   *
+   * @param fieldName - name of the field to check the uniqueness such as email
+   *                    or username.
+   */
+  getUniqueValidator(fieldName: string) {
+    return {
+      expression: (control: FormControl): Observable<boolean> => {
+        const value = control.value;
+        if (value == null) {
+          return of(true);
+        }
+        return this._recordService.getRecords(
+          'users',
+          `${fieldName}:${value}`
+        ).pipe(
+          debounceTime(1000),
+          map((res: any) => {
+            return (res.hits.hits.length > 0 && res.hits.hits[0].id !== this.userID);
+          })
+        );
+      }
+    };
+  }
+}

--- a/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.html
+++ b/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.html
@@ -1,0 +1,33 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-container *ngIf="user$ | async as user; else create">
+  <strong>
+    {{user.metadata.last_name}}, {{ user.metadata.first_name }} ({{ user.metadata.city}})
+  </strong>
+  <button type="button" class="btn btn-outline-primary btn-sm align-baseline ml-2" (click)="openModal()" translate>
+    Edit
+  </button>
+</ng-container>
+
+<ng-template #create>
+  <h3>
+    <button type="button" class="btn btn-outline-primary btn-sm align-baseline" (click)="openModal()" translate>
+      Edit
+    </button>
+  </h3>
+</ng-template>

--- a/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
+++ b/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
@@ -1,0 +1,80 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { FieldWrapper } from '@ngx-formly/core';
+import { RecordService } from '@rero/ng-core';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import { Observable, Subscription } from 'rxjs';
+import { UserIdEditorComponent } from '../../../custom-editor/user-id-editor/user-id-editor.component';
+
+@Component({
+  selector: 'admin-user-id',
+  templateUrl: './user-id.component.html'
+})
+export class UserIdComponent extends FieldWrapper implements OnInit {
+
+  /** User component to open in a modal */
+  modalRef: BsModalRef;
+
+  /** current user */
+  user$: Observable<any>;
+
+  /** Modal observable subscription */
+  private _subscription = new Subscription();
+
+  /**
+   * constructor
+   * @param _modalService - ngx-boostrap BsModalService
+   * @param _recordService - ng-core RecordService
+   */
+  constructor(
+    private _modalService: BsModalService,
+    private _recordService: RecordService) {
+    super();
+  }
+
+  /**
+   * Get the user personal information to display in the editor.
+   */
+  ngOnInit(): void {
+    console.log(this.formControl.value);
+    if (this.formControl && this.formControl.value != null) {
+      this.user$ = this._recordService.getRecord('users', this.formControl.value);
+    }
+  }
+
+  /**
+   * Open the modal with the User personal information editor.
+   */
+  openModal(): void {
+    this.modalRef = this._modalService.show(
+      UserIdEditorComponent,
+      {
+        class: 'modal-lg',
+        initialState: { userID: this.formControl.value }
+      });
+    this._subscription = this.modalRef.onHide.subscribe(() => {
+      const userID = this.modalRef.content.userID;
+      if (userID != null) {
+        this.formControl.setValue(this.modalRef.content.userID);
+        this.user$ = this._recordService.getRecord('users', this.formControl.value);
+      }
+      this._subscription.unsubscribe();
+    });
+  }
+}


### PR DESCRIPTION
* Adds a modal dialog with a new user personal information editor.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

-  https://tree.taiga.io/project/rero21-reroils/us/1889?milestone=282105


## Dependencies

* https://github.com/rero/rero-ils/pull/1675

## How to test?

- Go to the patron editor and edit the personal information.

![image](https://user-images.githubusercontent.com/127249/107530421-242ec280-6bbc-11eb-94a8-263ade2d4a7b.png)

and

![image](https://user-images.githubusercontent.com/127249/107530532-43c5eb00-6bbc-11eb-811a-3decd0feef7b.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
