### PR TITLE
typeahead: remove HTML tags from suggestion

### DIFF
--- a/projects/admin/src/app/class/typeahead/documents-typeahead.ts
+++ b/projects/admin/src/app/class/typeahead/documents-typeahead.ts
@@ -119,9 +119,8 @@ export class DocumentsTypeahead implements ITypeahead {
       truncate = true;
       text = this._mainTitlePipe.transform(metadata.title).substr(0, this.maxLengthSuggestion);
     }
-    text = text.replace(new RegExp(escapeRegExp(query), 'gi'), `<b>${query}</b>`);
     if (truncate) {
-      text = text + ' ...';
+      text = text + '…';
     }
     return {
       label: text,

--- a/projects/admin/src/app/class/typeahead/patrons-typeahead.ts
+++ b/projects/admin/src/app/class/typeahead/patrons-typeahead.ts
@@ -106,12 +106,8 @@ export class PatronsTypeahead implements ITypeahead {
    * @return Metadata - the label, $ref.
    */
   private _getPatronsRef(metadata: any, query: string): SuggestionMetadata {
-    let label = this._patronService.getFormattedName(metadata);
-    if (metadata.hasOwnProperty('birth_date')) {
-      label += `<small class="ml-2 font-weight-bold">[${metadata.birth_date}]</small>`;
-    }
     return {
-      label,
+      label: this._patronService.getFormattedName(metadata),
       value: this._apiService.getRefEndpoint('patrons', metadata.pid)
     };
   }


### PR DESCRIPTION
The ngx-bootstrap library doesn't allow html tags into typeahead
suggestion anymore.

Closes rero/rero-ils#1708

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
