### PR TITLE
patrons: edit the user personal data in a modal

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -151,6 +151,8 @@ import { HoldingItemTemporaryItemTypeComponent } from './record/detail-view/docu
 import { OperationLogsComponent } from './record/operation-logs/operation-logs.component';
 import { HoldingSharedViewComponent } from './record/detail-view/document-detail-view/holding-shared-view/holding-shared-view.component';
 import { OperationLogsDialogComponent } from './record/operation-logs/operation-logs-dialog/operation-logs-dialog.component';
+import { UserIdComponent } from './record/editor/wrappers/user-id/user-id.component';
+import { UserIdEditorComponent } from './record/custom-editor/user-id-editor/user-id-editor.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -249,7 +251,9 @@ export function appInitFactory(appInitService: AppInitService) {
     HoldingItemTemporaryItemTypeComponent,
     OperationLogsComponent,
     HoldingSharedViewComponent,
-    OperationLogsDialogComponent
+    OperationLogsDialogComponent,
+    UserIdComponent,
+    UserIdEditorComponent
   ],
   imports: [
     AppRoutingModule,
@@ -265,7 +269,12 @@ export function appInitFactory(appInitService: AppInitService) {
     TabsModule.forRoot(),
     TooltipModule.forRoot(),
     PopoverModule.forRoot(),
-    FormlyModule.forRoot(),
+    FormlyModule.forRoot({
+      wrappers: [{
+        name: 'user-id',
+        component: UserIdComponent
+      }]
+    }),
     TranslateModule.forRoot({
       loader: {
         provide: BaseTranslateLoader,
@@ -380,7 +389,8 @@ export function appInitFactory(appInitService: AppInitService) {
     DocumentRecordSearchComponent,
     CustomShortcutHelpComponent,
     ContributionDetailViewComponent,
-    OperationLogsComponent
+    OperationLogsComponent,
+    UserIdEditorComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/admin/src/app/circulation/checkin/checkin.component.ts
+++ b/projects/admin/src/app/circulation/checkin/checkin.component.ts
@@ -120,7 +120,7 @@ export class CheckinComponent implements OnInit {
           case ItemAction.checkin:
             this._displayCirculationNote(item, ItemNoteType.CHECKIN);
             if (item.action_applied && item.action_applied.checkin) {
-              this.getPatronInfo(item.action_applied.checkin.patron.barcode);
+              this.getPatronInfo(item.action_applied.checkin.patron.barcode[0]);
             }
             if (item.status === ItemStatus.IN_TRANSIT) {
               this._toastService.warning(
@@ -214,8 +214,9 @@ export class CheckinComponent implements OnInit {
                 this.checkin(barcode);
               }
             } else {
+              // TODO: which barcode we will take
               this._router.navigate(
-                ['/circulation', 'patron', patron.patron.barcode, 'loan']
+                ['/circulation', 'patron', patron.patron.barcode[0], 'loan']
               );
             }
             this.isLoading = false;

--- a/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
+++ b/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
@@ -70,7 +70,7 @@
       <dt class="col-sm-4 col-md-3 col-lg-2 label-title text-right" translate>Requested by</dt>
       <dd class="col-sm-8 col-md-9 col-lg-10">
         <ng-container *ngIf="item.loan.patron.name as patronName">
-          <a name="patron-name" [routerLink]="['/circulation', 'patron', item.loan.patron.barcode]">{{ patronName }}</a>
+          <a name="patron-name" [routerLink]="['/circulation', 'patron', item.loan.patron.barcode[0]]">{{ patronName }}</a>
         </ng-container>
       </dd>
       <!-- item shelf location + destination -->

--- a/projects/admin/src/app/circulation/patron/card/card.component.html
+++ b/projects/admin/src/app/circulation/patron/card/card.component.html
@@ -56,7 +56,7 @@
             >
               {{ patronTypeName }}
             </div>
-            <div id="patron-barcode">{{ patron.patron.barcode }}</div>
+            <div id="patron-barcode">{{ patron.patron.barcode[0]}}</div>
           </div>
         </div>
       </div>

--- a/projects/admin/src/app/circulation/patron/card/card.component.ts
+++ b/projects/admin/src/app/circulation/patron/card/card.component.ts
@@ -42,7 +42,7 @@ export class CardComponent {
     if (this.patron) {
       return (this.linkMode === 'detail')
         ? '/records/patrons/detail/' + this.patron.pid
-        : '/circulation/patron/' + this.patron.patron.barcode + '/loan';
+        : '/circulation/patron/' + this.patron.patron.barcode[0] + '/loan';
     }
   }
 

--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -32,7 +32,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'loan']">
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'loan']">
           {{ 'On loan' | translate }}
           <span *ngIf="getCirculationStatistics('loans') > 0" class="badge badge-info font-weight-normal">
             {{ getCirculationStatistics('loans') }}
@@ -45,7 +45,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pickup']">
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'pickup']">
           {{ 'To pick up' | translate }}
           <span *ngIf="getCirculationStatistics('pickup') > 0" class="badge badge-info font-weight-normal">
             {{ getCirculationStatistics('pickup') }}
@@ -58,7 +58,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'pending']">
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'pending']">
           {{ 'Pending' | translate }}
           <span *ngIf="getCirculationStatistics('pending') > 0 as stat" class="badge badge-info font-weight-normal">
             {{ getCirculationStatistics('pending') }}
@@ -71,7 +71,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'profile']"
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'profile']"
           translate
           >Profile</a
         >
@@ -82,7 +82,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'fees']">
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'fees']">
           {{ 'Fees' | translate }}
           <span *ngIf="transactionsTotalAmount > 0" class="badge badge-warning font-weight-normal">
             {{ transactionsTotalAmount | currency: organisation.default_currency }}
@@ -95,7 +95,7 @@
           class="nav-link"
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: true}"
-          [routerLink]="['/circulation', 'patron', patron.patron.barcode, 'history']">
+          [routerLink]="['/circulation', 'patron', patron.patron.barcode[0], 'history']">
           {{ 'History' | translate }}
           <span *ngIf="getCirculationStatistics('history') > 0" class="badge badge-info font-weight-normal">
             {{ getCirculationStatistics('history') }}

--- a/projects/admin/src/app/circulation/patron/main/main.component.ts
+++ b/projects/admin/src/app/circulation/patron/main/main.component.ts
@@ -39,42 +39,42 @@ export class MainComponent implements OnInit, OnDestroy {
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "circulation" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'loan']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'loan']);
       }
     }, {
       keys: 'shift.2',
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "pickup" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'pickup']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'pickup']);
       }
     }, {
       keys: 'shift.3',
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "pending" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'pending']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'pending']);
       }
     }, {
       keys: 'shift.4',
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "patron profile" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'profile']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'profile']);
       }
     }, {
       keys: 'shift.5',
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "fees" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'fees']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'fees']);
       }
     }, {
       keys: 'shift.6',
       group: this._translateService.instant('Patron profile shortcuts'),
       description: this._translateService.instant('Go to "history" tab'),
       callback: ($event) => {
-        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode, 'history']);
+        this._router.navigate(['/circulation', 'patron', this.patron.patron.barcode[0], 'history']);
       }
     }
   ];

--- a/projects/admin/src/app/circulation/patron/profile/profile.component.html
+++ b/projects/admin/src/app/circulation/patron/profile/profile.component.html
@@ -50,14 +50,46 @@
         {{ patron.postal_code }} {{ patron.city }}
       </dd>
     </dl>
-
-    <!-- PHONE -->
-    <dl class="row mb-0" *ngIf="patron.phone">
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Phone' | translate }}:
+    <!-- Country -->
+    <dl class="row mb-0" *ngIf="patron.country">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Country
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
-        {{ patron.phone }}
+        {{ 'country_' + patron.country | translate}}
+      </dd>
+    </dl>
+    <!-- PHONE -->
+    <dl class="row mb-0" *ngIf="patron.home_phone">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Home phone number
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.home_phone }}
+      </dd>
+    </dl>
+    <dl class="row mb-0" *ngIf="patron.business_phone">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Buisness phone number
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.business_phone }}
+      </dd>
+    </dl>
+    <dl class="row mb-0" *ngIf="patron.mobile_phone">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Mobile phone
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.mobile_phone }}
+      </dd>
+    </dl>
+    <dl class="row mb-0" *ngIf="patron.other_phone">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Other phone
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.other_phone }}
       </dd>
     </dl>
     <!-- EMAIL -->
@@ -69,10 +101,66 @@
         {{ patron.email }}
       </dd>
     </dl>
+    <!-- SOURCE -->
+    <dl *ngIf="patron.source" class="row mb-0">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Source
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.source }}
+      </dd>
+    </dl>
+    <!-- Local Code -->
+    <dl *ngIf="patron.local_code" class="row mb-0">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Local code
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.local_code }}
+      </dd>
+    </dl>
     <button *ngIf="canUpdate()" class="btn btn-sm btn-outline-primary mt-2" id="profile-change-password-button"
-      (click)="updatePatronPassword(patron)" title="Change Password">{{ 'Change Password' | translate }}</button>
-
+      (click)="updatePatronPassword(patron)" title="Change Password">{{ 'Change Password' | translate }}
+    </button>
   </section>
+
+  <section class="m-2 p-2" *ngIf="patron.second_address">
+    <h5 translate>Second address</h5>
+    <!-- STREET -->
+    <dl class="row mb-0">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" *ngIf="patron.second_address.street" translate>
+        Street
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ patron.second_address.street }}
+      </dd>
+    </dl>
+    <!-- CITY -->
+    <dl class="row mb-0">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title"
+        *ngIf="patron.second_address.postal_code ||  patron.second_address.city" translate>
+        City
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        <span *ngIf="patron.second_address.postal_code">
+          {{ patron.second_address.postal_code }}
+        </span>
+        <span *ngIf="patron.second_address.city">
+          {{ patron.second_address.city }}
+        </span>
+      </dd>
+    </dl>
+    <!-- Country -->
+    <dl class="row mb-0" *ngIf="patron.second_address.country">
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Country
+      </dt>
+      <dd class="col-sm-7 col-md-8 mb-0">
+        {{ 'country_' + patron.second_address.country | translate }}
+      </dd>
+    </dl>
+  </section>
+
   <section class="m-2 p-2" *ngIf="patron.isLibrarian">
     <h5 translate>Librarian Information</h5>
     <!-- LIBRARY -->
@@ -101,11 +189,13 @@
     </dl>
     <!-- BARCODE -->
     <dl class="row mb-0">
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Barcode' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Patron's barcodes or cards number
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
-        <a [routerLink]="['/circulation', 'patron', patron.patron.barcode]">{{ patron.patron.barcode }}</a>
+        <a [routerLink]="['/circulation', 'patron', patron.patron.barcode[0]]">
+          {{ patron.patron.barcode | join: ', '}}
+        </a>
       </dd>
     </dl>
     <!-- TYPE -->

--- a/projects/admin/src/app/record/brief-view/ill-requests-brief-view/ill-requests-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/ill-requests-brief-view/ill-requests-brief-view.component.html
@@ -26,7 +26,7 @@
   <dl class="mt-2 row">
     <dt class="col-sm-6 col-md-3 label-title" translate>Requested by</dt>
     <dd class="col-sm-6 col-md-9 mb-0">
-      <a *ngIf="requester && requester.patron && requester.patron.barcode" [routerLink]="['/circulation', 'patron', requester.patron.barcode]">
+      <a *ngIf="requester && requester.patron && requester.patron.barcode[0]" [routerLink]="['/circulation', 'patron', requester.patron.barcode[0]]">
         <span id="patron-last-name">{{ requester.last_name }}</span>
         <span id="patron-first-name" *ngIf="requester.first_name as firstName">, {{ firstName }}</span>
       </a>

--- a/projects/admin/src/app/record/brief-view/patrons-brief-view.component.ts
+++ b/projects/admin/src/app/record/brief-view/patrons-brief-view.component.ts
@@ -27,7 +27,7 @@ import { ResultItem } from '@rero/ng-core';
         {{ record.metadata.last_name }}, {{ record.metadata.first_name }}
       </a>
       <small class="ml-3" *ngIf="record.metadata.patron">
-        <a id="{{record.metadata.patron.barcode + '-loans'}}" [routerLink]="['/circulation', 'patron', record.metadata.patron.barcode]">
+        <a id="{{record.metadata.patron.barcode[0] + '-loans'}}" [routerLink]="['/circulation', 'patron', record.metadata.patron.barcode[0]]">
           <i class="fa fa-exchange mr-2"></i>
           <span translate>Circulation</span>
         </a>

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.html
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.html
@@ -1,0 +1,43 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <div class="modal-header">
+    <h4 id="dialog-sizes-name2" class="modal-title pull-left" translate>User Editor</h4>
+    <div class="d-flex">
+      <form>
+        <ng-core-search-input [placeholder]="'username or email' | translate" [searchText]="searchText"
+          (search)="searchValueUpdated($event)" class="form-inline mr-3" [focus]="false" [displayLabel]="false">
+        </ng-core-search-input>
+      </form>
+      <button type="button" id="editor-delete-button" class="btn btn-outline-danger btn-sm mr-1"
+        (click)="bsModalRef.hide()">
+        <i class="fa fa-times"></i>
+        {{ 'Cancel' | translate }}
+      </button>
+      <button type="submit" id="editor-save-button" class="btn btn-primary btn-sm">
+        <i class="fa fa-save"></i>
+        {{ 'Save' | translate }}
+      </button>
+    </div>
+  </div>
+
+  <div class="modal-body">
+    <!-- ngx-formly -->
+    <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
+  </div>
+</form>

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientModule } from '@angular/common/http';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { BsModalRef, ModalModule } from 'ngx-bootstrap/modal';
+import { ToastrModule } from 'ngx-toastr';
+import { UserIdEditorComponent } from './user-id-editor.component';
+
+
+describe('UserIdEditorComponent', () => {
+  let component: UserIdEditorComponent;
+  let fixture: ComponentFixture<UserIdEditorComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        TranslateModule.forRoot({}),
+        ModalModule.forRoot(),
+        ReactiveFormsModule,
+        ToastrModule.forRoot()
+      ],
+      declarations: [ UserIdEditorComponent ],
+      providers: [
+        BsModalRef
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserIdEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
@@ -1,0 +1,236 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
+import { TranslateService } from '@ngx-translate/core';
+import { JSONSchema7, orderedJsonSchema, RecordService, removeEmptyValues } from '@rero/ng-core';
+import { BsModalRef } from 'ngx-bootstrap/modal';
+import { ToastrService } from 'ngx-toastr';
+import { of } from 'rxjs';
+import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'admin-user-id-editor',
+  templateUrl: './user-id-editor.component.html'
+})
+export class UserIdEditorComponent implements OnInit {
+
+  /** current query to import a user */
+  searchText: string = null;
+
+  /** current User id in the invenio db */
+  userID: string = null;
+
+  /** remotely loaded User id in the invenio db */
+  loadedUserID: string = null;
+
+  /** JOSONSchema */
+  schema = null;
+
+  /** form initial values */
+  model: any = {};
+
+  /** angular form group for ngx-formly */
+  form: FormGroup;
+
+  /** Formly fields configuration populate by the JSONSchema */
+  fields: FormlyFieldConfig[];
+
+  /**
+   * Constructor
+   *
+   * @param _recordService - ng-core RecordService
+   * @param bsModalRef - ngx-boostrap BsModalRef
+   * @param _formlyJsonschema - ngx-formly FormlyJsonschema
+   * @param _toastService - ngx-toastr ToastrService
+   * @param _translateService - ngx-translate TranslateService
+   */
+  constructor(
+    private _recordService: RecordService,
+    public bsModalRef: BsModalRef,
+    private _formlyJsonschema: FormlyJsonschema,
+    private _toastService: ToastrService,
+    private _translateService: TranslateService) {
+    this.form = new FormGroup({});
+  }
+
+  /**
+   * Get the JSONSchema and add validators.
+   */
+  ngOnInit(): void {
+    this._recordService.getSchemaForm('users').pipe(
+      tap(
+        schema => {
+          if (schema != null) {
+            this.fields = [
+              this._formlyJsonschema.toFieldConfig(orderedJsonSchema(schema.schema), {
+
+                // post process JSONSChema7 to FormlyFieldConfig conversion
+                map: (field: FormlyFieldConfig, jsonSchema: JSONSchema7) => {
+                  // selection option i.e. countries
+                  if (jsonSchema.form && jsonSchema.form.options) {
+                    field.templateOptions.options = jsonSchema.form.options;
+                  }
+                  if (field.templateOptions.label === 'Email') {
+                    if (field.asyncValidators == null) {
+                      field.asyncValidators = {};
+                    }
+                    field.asyncValidators.uniqueEmail = this.getUniqueValidator('email');
+                  }
+                  if (field.templateOptions.label === 'Username') {
+                    if (field.asyncValidators == null) {
+                      field.asyncValidators = {};
+                    }
+                    field.asyncValidators.uniqueUsername = this.getUniqueValidator('username');
+                  }
+                  // remove Message suffix to the message validation key
+                  // (required for backend  translations)
+                  if (field.validation) {
+                    Object.keys(field.validation.messages).map(msg => {
+                      if (msg.endsWith('Message')) {
+                        const val = field.validation.messages[msg];
+                        delete(field.validation.messages[msg]);
+                        const newMsg = msg.replace(/Message$/, '');
+                        field.validation.messages[newMsg] = val;
+                      }
+                    });
+                  }
+                  return field;
+                }
+              })
+            ];
+          }
+        }
+      ),
+      switchMap(() => {
+        return (this.userID == null)
+          ? of({})
+          : this._recordService.getRecord('users', this.userID);
+      }),
+      map(user => user.metadata)
+    ).subscribe(model => this.model = model);
+  }
+
+  /**
+   * Retrieve a User given an email or a username.
+   *
+   * @param query - username or email to retrieve a User
+   */
+  searchValueUpdated(query: (string | null)): void {
+    if (!query) {
+      this.loadedUserID = null;
+      this.form.reset();
+      this.model = {};
+      return;
+    }
+    this._recordService.getRecords('users', query).pipe(
+      map((res: any) => {
+        if (res.hits.hits.length === 0) {
+          this._toastService.warning(
+            this._translateService.instant('User not found.')
+          );
+          return null;
+        }
+
+        return res.hits.hits[0];
+      }),
+      map(model => {
+        if (model == null) {
+          return null;
+        }
+        const roles = model.metadata.roles as Array<string>;
+        if (roles) {
+          const alreadyExists = roles.some(v => ['patron', 'librarian', 'system_librarian'].some(r => r === v));
+          if (alreadyExists) {
+            this._toastService.info(
+              this._translateService.instant('This person is already registered in your organisation.')
+            );
+            return of(null);
+          }
+        }
+        this._toastService.info(
+          this._translateService.instant('The personal data has been successfully linked to this patron.')
+        );
+        this.loadedUserID = model.id;
+        this.form.reset();
+        return this.model = model.metadata ? model.metadata : null;
+      }),
+    ).subscribe();
+  }
+
+  /**
+   * Submit the data if the form is valid.
+   *
+   * Create if the userID is null else update.
+   */
+  submit(): void {
+    this.form.updateValueAndValidity();
+    if (this.form.valid === false) {
+      this._toastService.error(
+        this._translateService.instant('The form contains errors.')
+      );
+      return;
+    }
+
+    const data = removeEmptyValues(this.form.value);
+    if (this.loadedUserID != null) {
+      this.userID = this.loadedUserID;
+    }
+    if (this.userID != null) {
+      data.pid = this.userID;
+      this._recordService.update('users', data).subscribe(() => {
+        this.bsModalRef.hide();
+      });
+    } else {
+      this._recordService.create('users', data).subscribe((res) => {
+        this.userID = res.id;
+        this.bsModalRef.hide();
+      });
+    }
+  }
+
+  /**
+   * Create an Async validator to check the uniqueness of a value.
+   *
+   * @param fieldName - name of the field to check the uniqueness such as email
+   *                    or username.
+   */
+  getUniqueValidator(fieldName: string) {
+    return {
+      expression: (control: FormControl) => {
+        const value = control.value;
+        if (value == null) {
+          return of(true);
+        }
+        return this._recordService.getRecords(
+          'users',
+          `${fieldName}:${value}`
+        ).pipe(
+          debounceTime(1000),
+          map((res: any) => {
+            const id = this.loadedUserID ? this.loadedUserID : this.userID;
+            return (res.hits.hits.length === 0) ||
+              (res.hits.hits.length === 1 && res.hits.hits[0].id === id);
+          })
+        );
+      }
+    };
+  }
+}

--- a/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.html
@@ -72,7 +72,7 @@
         </ng-container>
         <dt class="col-sm-5 col-md-3 col-lg-2 offset-1 label-title" translate>Requester</dt>
         <dd class="col-sm-6 col-md-8 col-lg-9 mb-1">
-          <a *ngIf="requester && requester.patron && requester.patron.barcode" [routerLink]="['/circulation', 'patron', requester.patron.barcode]">
+          <a *ngIf="requester && requester.patron && requester.patron.barcode[0]" [routerLink]="['/circulation', 'patron', requester.patron.barcode[0]]">
             <span id="patron-last-name">{{ requester.last_name }}</span>
             <span id="patron-first-name" *ngIf="requester.first_name as firstName">, {{ firstName }}</span>
           </a>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
@@ -17,9 +17,9 @@
 
 <ng-container *ngIf="transaction">
   <ng-container *ngIf="transaction.metadata.patron_pid | getRecord:'patrons' | async as patron">
-    <div id="{{patron.metadata.patron.barcode}}" class="row mb-2">
+    <div id="{{patron.metadata.patron.barcode[0]}}" class="row mb-2">
       <div class="col-4">
-        <a name="loans" [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode]">
+        <a name="loans" [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode[0]]">
           {{ patron.metadata.last_name }} {{ patron.metadata.first_name }} ({{ patron.metadata.patron.barcode }})
         </a>
       </div>

--- a/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail-view.component.html
@@ -63,14 +63,46 @@
           {{ patron.postal_code }} {{ patron.city }}
         </dd>
       </dl>
-
-      <!-- PHONE -->
-      <dl class="row mb-0" *ngIf="patron.phone">
+      <!-- Country -->
+      <dl class="row mb-0" *ngIf="patron.country">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
-          Phone
+          Country
         </dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          {{ patron.phone }}
+          {{ 'country_' + patron.country | translate}}
+        </dd>
+      </dl>
+      <!-- PHONE -->
+      <dl class="row mb-0" *ngIf="patron.home_phone">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Home phone number
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.home_phone }}
+        </dd>
+      </dl>
+      <dl class="row mb-0" *ngIf="patron.business_phone">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Business phone number
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.business_phone }}
+        </dd>
+      </dl>
+      <dl class="row mb-0" *ngIf="patron.mobile_phone">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Mobile phone
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.mobile_phone }}
+        </dd>
+      </dl>
+      <dl class="row mb-0" *ngIf="patron.other_phone">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Other phone
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.other_phone }}
         </dd>
       </dl>
       <!-- EMAIL -->
@@ -82,7 +114,66 @@
           {{ patron.email }}
         </dd>
       </dl>
+      <!-- SOURCE -->
+      <dl *ngIf="patron.source" class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Source
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.source }}
+        </dd>
+      </dl>
+      <!-- Local Code -->
+      <dl *ngIf="patron.local_code" class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Local code
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.local_code }}
+        </dd>
+      </dl>
     </section>
+
+    <section class="m-2 p-2" *ngIf="patron.second_address">
+      <h5 translate>Second address</h5>
+      <!-- STREET -->
+      <dl class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title"
+            *ngIf="patron.second_address.street"
+            translate>
+          Street
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ patron.second_address.street }}
+        </dd>
+      </dl>
+      <!-- CITY -->
+      <dl class="row mb-0">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title"
+            *ngIf="patron.second_address.postal_code ||  patron.second_address.city"
+            translate>
+          City
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          <span *ngIf="patron.second_address.postal_code">
+            {{ patron.second_address.postal_code }}
+          </span>
+          <span *ngIf="patron.second_address.city">
+            {{ patron.second_address.city }}
+          </span>
+        </dd>
+      </dl>
+      <!-- Country -->
+      <dl class="row mb-0" *ngIf="patron.second_address.country">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Country
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ 'country_' + patron.second_address.country | translate}}
+        </dd>
+      </dl>
+    </section>
+
     <section class="m-2 p-2" *ngIf="patron.isLibrarian">
       <h5 translate>Librarian Information</h5>
       <!-- LIBRARY -->
@@ -104,15 +195,18 @@
         </dd>
       </dl>
     </section>
+
     <section class="m-2 p-2" *ngIf="patron.patron">
       <h5 translate>Patron Information</h5>
       <!-- BARCODE -->
       <dl class="row mb-0">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
-          Barcode
+          Patron's barcodes or cards number
         </dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          <a [routerLink]="['/circulation', 'patron', patron.patron.barcode]">{{ patron.patron.barcode }}</a>
+          <a [routerLink]="['/circulation', 'patron', patron.patron.barcode[0]]">
+            {{ patron.patron.barcode | join: ', '}}
+          </a>
         </dd>
       </dl>
       <!-- ROLES -->
@@ -139,9 +233,8 @@
       <dl class="row mb-0">
         <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Keep history</dt>
         <dd class="col-sm-7 col-md-8 mb-0">
-          <i class="fa"
-             [ngClass]="patron.patron.keep_history ? 'fa-check text-success' : 'fa-times text-danger'"
-             aria-hidden="true">
+          <i class="fa" [ngClass]="patron.patron.keep_history ? 'fa-check text-success' : 'fa-times text-danger'"
+            aria-hidden="true">
           </i>
         </dd>
       </dl>
@@ -169,10 +262,7 @@
   </article>
 
   <!-- OPERATION LOGS-->
-  <admin-operation-logs
-    *ngIf="isEnabledOperationLog"
-    resourceType="patrons"
-    [resourcePid]="patron.pid"
-  ></admin-operation-logs>
+  <admin-operation-logs *ngIf="isEnabledOperationLog" resourceType="patrons" [resourcePid]="patron.pid">
+  </admin-operation-logs>
 
 </ng-container>

--- a/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.html
+++ b/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.html
@@ -1,0 +1,30 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ng-container *ngIf="user$ | async as user; else create">
+  <strong>
+    {{user.metadata.last_name}}, {{ user.metadata.first_name }} <span *ngIf="user.metadata.city">({{ user.metadata.city}})</span>
+  </strong>
+  <button type="button" class="btn btn-outline-primary btn-sm align-baseline ml-2" (click)="openModal()" translate>
+    Edit
+  </button>
+</ng-container>
+
+<ng-template #create>
+    <button type="button" class="btn btn-outline-primary btn-sm align-baseline ml-2" (click)="openModal()" translate>
+      Edit
+    </button>
+</ng-template>

--- a/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
+++ b/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
@@ -1,0 +1,85 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { FieldWrapper } from '@ngx-formly/core';
+import { RecordService } from '@rero/ng-core';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import { Observable, of, Subscription } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { UserIdEditorComponent } from '../../../custom-editor/user-id-editor/user-id-editor.component';
+
+@Component({
+  selector: 'admin-user-id',
+  templateUrl: './user-id.component.html'
+})
+export class UserIdComponent extends FieldWrapper implements OnInit {
+
+  /** User component to open in a modal */
+  modalRef: BsModalRef;
+
+  /** current user */
+  user$: Observable<any>;
+
+  /** Modal observable subscription */
+  private _subscription = new Subscription();
+
+  /**
+   * constructor
+   * @param _modalService - ngx-boostrap BsModalService
+   * @param _recordService - ng-core RecordService
+   */
+  constructor(
+    private _modalService: BsModalService,
+    private _recordService: RecordService) {
+    super();
+  }
+
+  /**
+   * Get the user personal information to display in the editor.
+   */
+  ngOnInit(): void {
+    if (this.formControl && this.formControl.value != null) {
+      this.user$ = this._recordService.getRecord('users', this.formControl.value);
+    }
+  }
+
+  /**
+   * Open the modal with the User personal information editor.
+   */
+  openModal(): void {
+    // return;
+    this.modalRef = this._modalService.show(
+      UserIdEditorComponent,
+      {
+        class: 'modal-lg',
+        initialState: { userID: this.formControl.value }
+      });
+    this.user$ = this.modalRef.onHidden.pipe(
+      switchMap(() => {
+        const userID = this.modalRef.content.userID;
+        console.log(userID);
+        if (userID != null) {
+          this.formControl.setValue(userID);
+          return this._recordService.getRecord('users', userID);
+        }
+        console.log('return null');
+        return of(null);
+      })
+    );
+  }
+}

--- a/projects/admin/src/app/routes/patrons-route.ts
+++ b/projects/admin/src/app/routes/patrons-route.ts
@@ -93,7 +93,11 @@ export class PatronsRoute extends BaseRoute implements RouteInterface {
             preFilters: {
               simple: 1
             },
-            aggregationsExpand: ['roles']
+            aggregationsExpand: ['roles', 'city', 'patron_type'],
+            aggregationsOrder: ['roles', 'city', 'patron_type'],
+            listHeaders: {
+              Accept: 'application/rero+json'
+            }
           }
         ]
       }

--- a/projects/public-search/src/app/document-detail/request/request.component.ts
+++ b/projects/public-search/src/app/document-detail/request/request.component.ts
@@ -62,7 +62,7 @@ export class RequestComponent implements OnInit {
     ) {
       this._itemApiService.canRequest(
         this.item.metadata.pid,
-        this._userService.user.patron.barcode
+        this._userService.user.patron.barcode[0]
       ).subscribe((can: any) => this.canRequest = can);
     }
   }

--- a/projects/shared/src/lib/class/user.ts
+++ b/projects/shared/src/lib/class/user.ts
@@ -27,20 +27,33 @@ export class User {
   $schema: string;
   username: string;
   birth_date: string;
-  city: string;
+  city?: string;
+  country?: string;
+  gender?: string;
   email?: string;
   first_name: string;
   last_name: string;
-  libraries: Library[];
+  libraries?: Library[];
   name: string;
-  phone: string;
+  home_phone?: string;
+  business_phone?: string;
+  mobile_phone?: string;
+  other_phone?: string;
   pid: string;
   circulation_location_pid?: string;
-  postal_code: string;
+  postal_code?: string;
+  source?: string;
+  local_code?: string;
+  second_address?: {
+    street?: string;
+    postal_code?: string;
+    city?: string;
+    country?: string;
+  };
   roles: string[];
-  street: string;
+  street?: string;
   user_id: string;
-  patron: {
+  patron?: {
     barcode: string,
     type: PatronType,
     communication_channel: string,


### PR DESCRIPTION
* Opens an editor in a modal dialog to edit the user personal
  information, from the patron editor of the professional interface.
* Adapts patron detailed and profile view for new fields.
* Makes the patron barcode repeatable.
* Adds a custom user ID editor wrapper.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* https://github.com/rero/ng-core/pull/354
* https://github.com/rero/rero-ils/pull/1695

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
