### PR TITLE
circulation: improve library closed dates handling

### DIFF
--- a/projects/admin/src/app/api/library-api.service.spec.ts
+++ b/projects/admin/src/app/api/library-api.service.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ * Copyright (C) 2021 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { LibraryApiService } from './library-api.service';
+
+describe('LibraryApiService', () => {
+  let service: LibraryApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ]
+    });
+    service = TestBed.inject(LibraryApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/api/library-api.service.ts
+++ b/projects/admin/src/app/api/library-api.service.ts
@@ -1,0 +1,51 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ * Copyright (C) 2021 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import moment from 'moment';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LibraryApiService {
+
+  /**
+   * constructor
+   * @param _http - HttpClient
+   */
+  constructor(
+    private _http: HttpClient
+  ) { }
+
+  /**
+   * Allow to get the closed date between two dates for a specific library
+   * @param libraryPid: the library pid
+   * @param from: the lower interval (optional)
+   * @param until: the upper interval (optional)
+   */
+  getClosedDates(libraryPid: string, from?: string, until?: string): Observable<Array<moment>> {
+    from = from || moment().subtract(1, 'month');
+    until =  until || moment().add(1, 'year');
+    return this._http.get(`/api/library/${libraryPid}/closed_dates`, {params: {from, until}}).pipe(
+      map((data: any) => data.closed_dates),
+      map((dates: [string]) => dates.map(dateStr => moment(dateStr)))
+    );
+  }
+}

--- a/projects/admin/src/app/menu/service/library-switch.service.ts
+++ b/projects/admin/src/app/menu/service/library-switch.service.ts
@@ -19,6 +19,7 @@ import { Injectable } from '@angular/core';
 import { LocalStorageService } from '@rero/ng-core';
 import { User, UserService } from '@rero/shared';
 import { Subject } from 'rxjs';
+import { LibraryApiService } from '../../api/library-api.service';
 
 export class LibrarySwitchError extends Error {
   constructor(message: string) {
@@ -43,10 +44,12 @@ export class LibrarySwitchService {
   /**
    * Constructor
    * @param _userService - UserService
+   * @param _libraryApiService - LibraryApiService
    * @param _localStorageService - LocalStorageService
    */
   constructor(
     private _userService: UserService,
+    private _libraryApiService: LibraryApiService,
     private _localStorageService: LocalStorageService,
   ) { }
 
@@ -70,6 +73,9 @@ export class LibrarySwitchService {
     }
     // Update current library on user
     user.setCurrentLibrary(libraryPid);
+    this._libraryApiService.getClosedDates(libraryPid).subscribe(
+      (dates) => user.currentLibraryClosedDates = dates
+    );
     // Storage user to the current session
     this._localStorageService.set(User.STORAGE_KEY, user);
     // Emit a new event with user

--- a/projects/shared/src/lib/class/user.ts
+++ b/projects/shared/src/lib/class/user.ts
@@ -16,6 +16,8 @@
  */
 
 import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+import moment from 'moment';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 export function _(str: any) {
   return marker(str);
@@ -76,13 +78,23 @@ export class User {
   circulation_informations: {
     messages: Array<{type: string, content: string}>,
     statistics: any;
-  }
+  };
+  currentLibraryClosedDates$: BehaviorSubject<Array<moment>> = new BehaviorSubject([]);
+  private _currentLibraryClosedDates: Array<moment> = [];
 
   /** Locale storage name key */
   static readonly STORAGE_KEY = 'user';
-
   /** Logged user API url */
   static readonly LOGGED_URL = '/patrons/logged_user?resolve';
+
+  /** Get closed dates of the user current library */
+  get currentLibraryClosedDates(): Array<moment> {
+    return this._currentLibraryClosedDates;
+  }
+  set currentLibraryClosedDates(closedDates: Array<moment>) {
+    this._currentLibraryClosedDates = closedDates;
+    this.currentLibraryClosedDates$.next(closedDates);
+  }
 
   /**
    * Is this user a librarian?
@@ -186,6 +198,7 @@ export class User {
    * Set current library pid
    * @param pid - string
    */
+
   setCurrentLibrary(pid: string) {
     this.currentLibrary = pid;
     return this;


### PR DESCRIPTION
Uses the backend closed dates library API to disallow user to choose a
closed date for a fixed date checkout.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Try to execute a fixed date checkout for any patrons.
- The datepicker field should reflect directly the closed date depending of the current used library.

![image](https://user-images.githubusercontent.com/10031585/109310780-46277680-7845-11eb-8189-0d38cfc4beb4.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
