### PR TITLE
circulation: fix fixed date datepicker input

### DIFF
--- a/projects/admin/src/app/circulation/patron/loan/fixed-date-form/fixed-date-form.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/fixed-date-form/fixed-date-form.component.ts
@@ -44,7 +44,7 @@ export class FixedDateFormComponent implements OnInit {
     endDate: new FormControl('', [
       Validators.required,
       DateValidators.minimumDateValidator(
-        moment().toDate(),
+        new Date(),
         FixedDateFormComponent.DATE_FORMAT
       )
     ])

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -19,6 +19,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { DateTranslatePipe } from '@rero/ng-core';
 import { User, UserService } from '@rero/shared';
+import moment from 'moment';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { ToastrService } from 'ngx-toastr';
 import { Item, ItemAction, ItemNoteType, ItemStatus } from 'projects/admin/src/app/class/items';
@@ -437,12 +438,12 @@ export class LoanComponent implements OnInit, OnDestroy {
     });
     this._modalRef.content.onSubmit.subscribe(result => {
       if ('action' in result && result.action === 'submit') {
-        const checkoutEndDate = result.content.endDate;
+        const checkoutEndDate = moment(result.content.endDate, FixedDateFormComponent.DATE_FORMAT).toDate().setHours(23, 59);
         const formattedDate = this._dateTranslatePipe.transform(checkoutEndDate, 'shortDate');
         this._setCheckoutSetting({
           key: 'endDate',
           label: this._translateService.instant('End date: {{ endDate }}', {endDate: formattedDate}),
-          value: checkoutEndDate
+          value: new Date(checkoutEndDate).toISOString()
         });
       }
     });

--- a/projects/admin/src/app/utils/validators.ts
+++ b/projects/admin/src/app/utils/validators.ts
@@ -35,17 +35,20 @@ export class DateValidators {
       if (control.value == null) {
         return null;
       }
-      const controlDate = moment(control.value, DateValidators.FORMAT_DATE);
-      if (!controlDate.isValid()) {
+      const controlMoment = moment(control.value, DateValidators.FORMAT_DATE);
+      if (!controlMoment.isValid()) {
         return null;
       }
-      const validationDate = moment(minDate, DateValidators.FORMAT_DATE);
-      return controlDate.isAfter(validationDate) ? null : {
-        'minimum-date': {
-          'date-minimum': validationDate.format(DateValidators.FORMAT_DATE),
-          actual: controlDate.format(DateValidators.FORMAT_DATE)
-        }
-      };
+      const validationDate = minDate.setHours(0, 0, 0, 0);
+      const controlDate = controlMoment.toDate().setHours(0, 0, 0, 0);
+      return controlDate >= validationDate
+        ? null
+        : {
+          'minimum-date': {
+            'date-minimum': moment(validationDate).format(DateValidators.FORMAT_DATE),
+            actual: controlMoment.format(DateValidators.FORMAT_DATE)
+          }
+        };
     };
   }
 }


### PR DESCRIPTION
It was impossible to choose the current date for a fixed date checkout.
Additionally, the end date sent to backend was time agnostic ; we now
set it to 23:59.

Closes rero/rero-ils#1574

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Execute a fixed date checkout on the current date.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
