### PR TITLE
items: complete item model

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -16,7 +16,7 @@
  */
 
 import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { APP_INITIALIZER, LOCALE_ID, NgModule } from '@angular/core';
+import { APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, LOCALE_ID, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -153,6 +153,7 @@ import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/cust
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
 import { UserIdComponent } from './record/editor/wrappers/user-id/user-id.component';
 import { UserIdEditorComponent } from './record/custom-editor/user-id-editor/user-id-editor.component';
+import { RecordMaskedComponent } from './record/detail-view/record-masked/record-masked.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -252,7 +253,8 @@ export function appInitFactory(appInitService: AppInitService) {
     OperationLogsDialogComponent,
     CipoPatronTypeItemTypeComponent,
     UserIdComponent,
-    UserIdEditorComponent
+    UserIdEditorComponent,
+    RecordMaskedComponent
   ],
   imports: [
     AppRoutingModule,
@@ -392,6 +394,9 @@ export function appInitFactory(appInitService: AppInitService) {
     OperationLogsComponent,
     UserIdEditorComponent
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
+  schemas: [
+    CUSTOM_ELEMENTS_SCHEMA
+  ]
 })
 export class AppModule { }

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -97,10 +97,10 @@
 
       <!-- IS PART OF -->
       <shared-part-of [record]="record" isBrief="false"></shared-part-of>
-      
+
       <!-- ABSTRACT -->
       <ng-container *ngIf=" record.metadata.abstracts && record.metadata.abstracts.length > 0">
-        <ul class="list-unstyled my-3">
+        <ul class="list-unstyled my-0">
           <li *ngFor="let abstract of record.metadata.abstracts; let i = index"
           [attr.id]="i | idAttribute:{prefix: 'doc-abstract'}">
             <ng-core-text-read-more
@@ -114,6 +114,9 @@
           </li>
         </ul>
       </ng-container>
+
+      <!-- MASKED -->
+      <admin-record-masked *ngIf="record.metadata._masked" [record]="record" [withLabel]="true"></admin-record-masked>
 
       <!-- SUBJECTS -->
       <div class="row" *ngIf="record.metadata.subjects">

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -17,6 +17,7 @@
 <div class="container px-0 mt-1 mb-2" *ngIf="item && permissions">
   <div id="item-{{ item.metadata.barcode }}" class="row">  <!-- First row :: item detail -->
     <div class="col-sm-3">
+      <admin-record-masked *ngIf="item.metadata._masked" [record]="item"></admin-record-masked>
       <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
         {{ item.metadata.barcode }}
       </a>
@@ -67,9 +68,15 @@
       </ng-template>
     </div>
   </div>
+  <div class="row" *ngIf="item.metadata.url">
+      <div class="col-sm-4 col-md-3 font-weight-bold label-title pl-5" translate>
+        Online access
+      </div>
+      <div class="col-sm-8 col-md-9">
+        <a href="{{ item.metadata.url }}">{{ item.metadata.url }}</a>
+      </div>
+    </div>
   <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
   <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
   <admin-holding-item-in-collection [itemPid]="item.metadata.pid"></admin-holding-item-in-collection>
 </div>
-
-

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -23,6 +23,7 @@
             <i [ngClass]="{ 'fa-caret-down':!isItemsCollapsed, 'fa-caret-right': isItemsCollapsed }"
                class="fa mr-1" aria-hidden="true"></i>
           </button>
+          <admin-record-masked *ngIf="holding.metadata._masked" [record]="holding"></admin-record-masked>
           <ng-container *ngIf="holding.metadata.location.pid | getRecord: 'locations' | async as location" class="col-sm-5">
             {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}:
             {{ location.metadata.name }}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -17,6 +17,7 @@
 <div class="container px-0 mt-1 mb-2" *ngIf="item && permissions && item.metadata.issue.status !== itemIssueStatus.DELETED">
   <div class="row">  <!-- First row :: item detail -->
     <div class="col-sm-3">
+      <admin-record-masked *ngIf="item.metadata._masked" [record]="holding"></admin-record-masked>
       <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
         {{ item.metadata.barcode }}
       </a>

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -14,9 +14,11 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<h1 class="mb-5">
+<h1 class="mb-2">
   {{ 'Holdings' | translate }}
 </h1>
+
+<admin-record-masked *ngIf="holding.metadata._masked" [record]="holding" [withLabel]="true"></admin-record-masked>
 
 <div class="card mb-3" *ngIf="holding.metadata.document.pid | getRecord:'documents' | async as document">
   <div class="card-body row">
@@ -106,6 +108,7 @@
                 *ngFor="let item of this.receivedItems"
                 [ngClass]="{'deleted-status': item.metadata.issue.status == 'deleted'}">
               <div class="col-sm-4 text">
+                <admin-record-masked *ngIf="item.metadata._masked" [record]="holding"></admin-record-masked>
                 {{ item.metadata.enumerationAndChronology }}
                 <span class="badge badge-pill badge-info pl-2" *ngIf="item.new_issue" translate>New</span>
               </div>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -16,18 +16,20 @@
 -->
 
 <ng-container *ngIf="record">
-  <header class="row mb-3">
+  <header class="row mb-2">
     <h1>{{ 'Barcode' | translate }} {{ record.metadata.barcode }}</h1>
   </header>
   <section class="mb-4">
+    <admin-record-masked *ngIf="record.metadata._masked" [record]="record" [withLabel]="true"></admin-record-masked>
     <dl class="row mb-0">
-
       <!-- INHERITED CALL NUMBER -->
       <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
-        </dd>
+        <ng-container *ngIf="(callNumber | json) != ({ first: {}, second: {} } | json)">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
+          </dd>
+        </ng-container>
       </ng-container>
       <!-- SECOND CALL NUMBER -->
       <ng-container *ngIf="record.metadata.second_call_number">
@@ -44,8 +46,8 @@
         </dd>
       </ng-container>
       <!-- ITEM TYPE -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Type' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Type
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0" *ngVar="record.metadata.item_type.pid | getRecord:'item_types': 'field':'name' | async as defaultItty">
         <ng-container *ngIf="hasTemporaryItemType(); else defaultItemTypeBlock">
@@ -60,8 +62,8 @@
         </ng-template>
       </dd>
       <!-- DOCUMENT -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Document' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Document
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
         <a [routerLink]="['/records', 'documents', 'detail', record.metadata.document.pid]">
@@ -69,8 +71,8 @@
         </a>
       </dd>
       <!-- LIBRARY -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Library' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Library
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
         <ng-container *ngIf="location">
@@ -78,22 +80,22 @@
         </ng-container>
       </dd>
       <!-- LOCATION -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Location' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Location
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
         <ng-container *ngIf="location">{{ location.metadata.name }}</ng-container>
       </dd>
       <!-- AVAILIBILITY -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'Availability' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        Availability
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
         <admin-item-availability [item]="record"></admin-item-availability>
       </dd>
       <!-- ACQUISITION -->
-      <dt class="col-sm-3 offset-sm-2 offset-md-0">
-        {{ 'New acquisition' | translate }}:
+      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+        New acquisition
       </dt>
       <dd class="col-sm-7 col-md-8 mb-0">
         <i class="fa"
@@ -104,6 +106,33 @@
           ({{ record.metadata.acquisition_date | dateTranslate : 'shortDate' }})
         </span>
       </dd>
+      <!-- PRICE -->
+      <ng-container *ngIf="record.metadata | keyExists:'price'">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Price
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.price | currency:organisationCurrency:'symbol' }}
+        </dd>
+      </ng-container>
+      <!-- PAC CODE -->
+      <ng-container *ngIf="record.metadata | keyExists:'pac_code'">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          PAC code
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          {{ record.metadata.pac_code | translate }}
+        </dd>
+      </ng-container>
+      <!-- URL -->
+      <ng-container *ngIf="record.metadata | keyExists:'url'">
+        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+          Online access
+        </dt>
+        <dd class="col-sm-7 col-md-8 mb-0">
+          <a href="{{ record.metadata.url }}">{{ record.metadata.url }}</a>
+        </dd>
+      </ng-container>
     </dl>
   </section>
 
@@ -162,6 +191,82 @@
       </div>
     </div>
   </section>
+
+  <!-- LEGACY -->
+  <ng-container *ngIf="(record.metadata | keyExists:'legacy_checkout_count') || (record.metadata | keyExists:'legacy_circulation_rules')">
+    <section class="mb-4 mt-4">
+      <header class="row">
+        <h4 translate>Legacy circulation rules</h4>
+      </header>
+      <dl class="row mb-0">
+        <!-- LEGACY CHECKOUT COUNT -->
+        <ng-container *ngIf="record.metadata | keyExists:'legacy_checkout_count'">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+            Checkout count
+          </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            {{ record.metadata.legacy_checkout_count }}
+          </dd>
+        </ng-container>
+        <!-- LEGACY LOAN DURATION -->
+        <ng-container *ngIf="record.metadata.legacy_circulation_rules | keyExists:'loan_duration'">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+            Loan duration
+          </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            {{ record.metadata.legacy_circulation_rules.loan_duration }}
+          </dd>
+        </ng-container>
+        <!-- LEGACY USE ITEM SPECIFIC RULES -->
+        <ng-container *ngIf="record.metadata.legacy_circulation_rules | keyExists:'use_item_specific_rules'">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+            Use item specific rules
+          </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            <i
+              class="fa fa-circle"
+              [ngClass]="{
+                'text-danger': !record.metadata.legacy_circulation_rules.use_item_specific_rules,
+                'text-success': !record.metadata.legacy_circulation_rules.use_item_specific_rules
+              }"
+              aria-hidden="true"
+            ></i>
+          </dd>
+        </ng-container>
+        <!-- LEGACY ALLOW REQUEST -->
+        <ng-container *ngIf="record.metadata.legacy_circulation_rules | keyExists:'allow_request'">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+            Allow request
+          </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            <i
+              class="fa fa-circle"
+              [ngClass]="{
+                'text-danger': !record.metadata.legacy_circulation_rules.allow_request,
+                'text-success': record.metadata.legacy_circulation_rules.allow_request }"
+              aria-hidden="true"
+            ></i>
+          </dd>
+        </ng-container>
+        <!-- LEGACY ALLOW REQUEST -->
+        <ng-container *ngIf="record.metadata.legacy_circulation_rules | keyExists:'floats'">
+          <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>
+            Floats
+          </dt>
+          <dd class="col-sm-7 col-md-8 mb-0">
+            <i
+              class="fa fa-circle"
+              [ngClass]="{
+                'text-danger': !record.metadata.legacy_circulation_rules.floats,
+                'text-success': record.metadata.legacy_circulation_rules.floats
+              }"
+              aria-hidden="true"
+            ></i>
+          </dd>
+        </ng-container>
+      </dl>
+    </section>
+  </ng-container>
 
   <!-- TABS -->
   <section class="mt-3 mb-4">

--- a/projects/admin/src/app/record/detail-view/record-masked/record-masked.component.spec.ts
+++ b/projects/admin/src/app/record/detail-view/record-masked/record-masked.component.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { KeyExistsPipe } from '@rero/shared';
+import { RecordMaskedComponent } from './record-masked.component';
+
+
+describe('MaskedComponent', () => {
+  let component: RecordMaskedComponent;
+  let fixture: ComponentFixture<RecordMaskedComponent>;
+
+  const recordMasked = {
+    metadata: {
+      pid: '1',
+      _masked: true
+    }
+  };
+
+  const recordNoMaskedWithFlag = {
+    metadata: {
+      pid: '1',
+      _masked: false
+    }
+  };
+
+  const recordNoMaskedNoFlag = {
+    metadata: {
+      pid: '1'
+    }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        RecordMaskedComponent,
+        KeyExistsPipe
+      ],
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      schemas: [
+        CUSTOM_ELEMENTS_SCHEMA
+      ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordMaskedComponent);
+    component = fixture.componentInstance;
+    component.record = recordMasked;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should return a eye red icon (record with flag _masked true)', () => {
+    component.record = recordMasked;
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('i');
+    expect(icon.attributes.title.textContent).toContain('Masked');
+    expect(icon.attributes.class.textContent).toContain('fa-eye-slash');
+  });
+
+  it('should return a eye green icon (record with flag _masked false)', () => {
+    component.record = recordNoMaskedWithFlag;
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('i');
+    expect(icon.attributes.title.textContent).toContain('No masked');
+    expect(icon.attributes.class.textContent).toContain('fa-eye');
+  });
+
+  it('should return a eye gree icon (record without flag _masked)', () => {
+    component.record = recordNoMaskedNoFlag;
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('i');
+    expect(icon.attributes.title.textContent).toContain('No masked');
+    expect(icon.attributes.class.textContent).toContain('fa-eye');
+  });
+
+  it('should return a bullet red icon (record with flag _masked true)', () => {
+    component.record = recordMasked;
+    component.context = 'bullet';
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('i');
+    expect(icon.attributes.title.textContent).toContain('Masked');
+    expect(icon.attributes.class.textContent).toContain('fa-circle');
+    expect(icon.attributes.class.textContent).toContain('text-success');
+  });
+
+  it('should return a eye green icon (record without flag _masked)', () => {
+    component.record = recordNoMaskedNoFlag;
+    component.context = 'bullet';
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('i');
+    expect(icon.attributes.title.textContent).toContain('No masked');
+    expect(icon.attributes.class.textContent).toContain('fa-circle');
+    expect(icon.attributes.class.textContent).toContain('text-danger');
+  });
+
+  it('should return a bullet red icon with label (record with flag _masked true)', () => {
+    component.record = recordMasked;
+    component.context = 'bullet';
+    component.withLabel = true;
+    fixture.detectChanges();
+    const label = fixture.nativeElement.querySelector('label');
+    expect(label.textContent).toContain('Masked');
+  });
+
+  it('should return a bullet green icon with label (record without flag _masked)', () => {
+    component.record = recordNoMaskedNoFlag;
+    component.context = 'bullet';
+    component.withLabel = true;
+    fixture.detectChanges();
+    const label = fixture.nativeElement.querySelector('label');
+    expect(label.textContent).toContain('No masked');
+  });
+});

--- a/projects/admin/src/app/record/detail-view/record-masked/record-masked.component.ts
+++ b/projects/admin/src/app/record/detail-view/record-masked/record-masked.component.ts
@@ -1,0 +1,67 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'admin-record-masked',
+  template: `
+  <container-element [ngSwitch]="context">
+    <some-element *ngSwitchCase="'eye'">
+      <ng-container *ngIf="record.metadata | keyExists:'_masked'; else noEyeMasked">
+        <i
+          class="fa"
+          aria-hidden="true"
+          title="{{ (record.metadata._masked ? 'Masked' : 'No masked') | translate }}"
+          [ngClass]="{ 'fa-eye-slash text-danger': record.metadata._masked, 'fa-eye text-success': !record.metadata._masked }"
+        ></i>
+        <label class="ml-1" *ngIf="withLabel">{{ (record.metadata._masked ? 'Masked' : 'No masked') | translate }}</label>
+      </ng-container>
+      <ng-template #noEyeMasked>
+        <i class="fa fa-eye text-success" title="No masked" aria-hidden="true"></i>
+        <label class="ml-1" *ngIf="withLabel" translate>No masked</label>
+      </ng-template>
+    </some-element>
+    <some-element *ngSwitchCase="'bullet'">
+      <ng-container *ngIf="record.metadata | keyExists:'_masked'; else noBulletMasked">
+        <i
+          class="fa fa-circle"
+          title="{{ (record.metadata._masked ? 'Masked' : 'No masked') | translate }}"
+          [ngClass]="{'text-danger': !record.metadata._masked, 'text-success': record.metadata._masked }"
+          aria-hidden="true"
+        ></i>
+        <label class="ml-1" *ngIf="withLabel">{{ (record.metadata._masked ? 'Masked' : 'No masked') | translate }}</label>
+      </ng-container>
+      <ng-template #noBulletMasked>
+        <i class="fa fa-circle text-danger mr-1" title="No masked" aria-hidden="true"></i>
+        <label class="ml-1" *ngIf="withLabel" translate>No masked</label>
+      </ng-template>
+    </some-element>
+  </container-element>
+  `
+})
+export class RecordMaskedComponent {
+
+  /** Record */
+  @Input() record: any;
+
+  /** Context */
+  @Input() context: 'bullet' | 'eye' = 'eye';
+
+  /** Label for bullet context */
+  @Input() withLabel = false;
+
+}

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -48,10 +48,6 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
         { path: 'new', component: EditorComponent }
       ],
       data: {
-        adminMode: () => of({
-          can: false,
-          message: ''
-        }),
         types: [
           {
             key: this.name,

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -154,3 +154,7 @@ _('My organisation');
 _('My library');
 _('Public interface');
 _('Logout');
+
+
+_('Masked');
+_('No masked');

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
@@ -40,7 +40,7 @@
         <ng-template #available>
           <i
             class="fa fa-circle"
-            [ngClass="{'text-success': holding.metadata.available === true, {'text-danger': holding.metadata.available === false }}"]
+            [ngClass]="{'text-success': holding.metadata.available, 'text-danger': !holding.metadata.available }"
           ></i>
           {{ (holding.metadata.available ? 'available' : 'not available') | translate }}
         </ng-template>

--- a/projects/public-search/src/app/document-detail/item/item.component.html
+++ b/projects/public-search/src/app/document-detail/item/item.component.html
@@ -58,6 +58,13 @@
       <dd class="mb-0 col-lg-9 col-sm-8" [innerHTML]="note.content | nl2br"></dd>
     </ng-container>
   </ng-container>
+  <!-- URL -->
+  <ng-container *ngIf="item.metadata.url">
+    <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>URL</dt>
+    <dd class="mb-0 col-lg-9 col-sm-8">
+      <a href="{{ item.metadata.url }}">{{ item.metadata.url }}</a>
+    </dd>
+  </ng-container>
   <!-- STATUS -->
   <dt class="mb-0 col-lg-2 col-sm-3" translate>Status</dt>
   <dd id="item-status-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">
@@ -72,6 +79,7 @@
       ({{ item.metadata.availability.request }} {{ (item.metadata.availability.request > 1 ? 'requests' : 'request') | translate }})
     </ng-container>
   </dd>
+
   <!-- REQUEST DIALOG -->
   <public-search-request [item]="item" [viewcode]="viewcode" class="col-11"></public-search-request>
 </div>

--- a/projects/shared/src/lib/pipe/key-exists.pipe.spec.ts
+++ b/projects/shared/src/lib/pipe/key-exists.pipe.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { KeyExistsPipe } from './key-exists.pipe';
+
+describe('KeyExistsPipe', () => {
+  let pipe: KeyExistsPipe;
+
+  const record = {
+    foo: 'bar'
+  };
+
+  beforeEach(() => {
+    pipe = new KeyExistsPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return false because the field does not exist', () => {
+    expect(pipe.transform(record, 'bar')).toBeFalsy();
+  });
+
+  it('should return true because the field exists', () => {
+    expect(pipe.transform(record, 'foo')).toBeTruthy();
+  });
+});
+
+

--- a/projects/shared/src/lib/pipe/key-exists.pipe.ts
+++ b/projects/shared/src/lib/pipe/key-exists.pipe.ts
@@ -1,0 +1,28 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'keyExists'
+})
+export class KeyExistsPipe implements PipeTransform {
+
+  transform(data: object, field: string): boolean {
+    return data.hasOwnProperty(field);
+  }
+
+}

--- a/projects/shared/src/lib/shared.module.ts
+++ b/projects/shared/src/lib/shared.module.ts
@@ -26,6 +26,7 @@ import { ExtractSourceFieldPipe } from './pipe/extract-source-field.pipe';
 import { IdAttributePipe } from './pipe/id-attribute.pipe';
 import { ItemHoldingsCallNumberPipe } from './pipe/item-holdings-call-number.pipe';
 import { JoinPipe } from './pipe/join.pipe';
+import { KeyExistsPipe } from './pipe/key-exists.pipe';
 import { MainTitlePipe } from './pipe/main-title.pipe';
 import { PatronBlockedMessagePipe } from './pipe/patron-blocked-message.pipe';
 import { ProvisionActivityPipe } from './pipe/provision-activity.pipe';
@@ -59,7 +60,8 @@ import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
     InheritedCallNumberComponent,
     ThumbnailComponent,
     PartOfComponent,
-    ShowMorePagerComponent
+    ShowMorePagerComponent,
+    KeyExistsPipe
   ],
   exports: [
     CommonModule,
@@ -81,7 +83,8 @@ import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
     InheritedCallNumberComponent,
     ThumbnailComponent,
     PartOfComponent,
-    ShowMorePagerComponent
+    ShowMorePagerComponent,
+    KeyExistsPipe
   ],
   imports: [
     CommonModule,
@@ -99,7 +102,8 @@ import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
     UrlActivePipe,
     TruncateTextPipe,
     Nl2brPipe,
-    NgVarDirective
+    NgVarDirective,
+    KeyExistsPipe
   ],
   entryComponents: [
     ContributionBriefComponent

--- a/projects/shared/src/public-api.ts
+++ b/projects/shared/src/public-api.ts
@@ -31,6 +31,7 @@ export * from './lib/pipe/extract-source-field.pipe';
 export * from './lib/pipe/id-attribute.pipe';
 export * from './lib/pipe/item-holdings-call-number.pipe';
 export * from './lib/pipe/join.pipe';
+export * from './lib/pipe/key-exists.pipe';
 export * from './lib/pipe/main-title.pipe';
 export * from './lib/pipe/patron-blocked-message.pipe';
 export * from './lib/pipe/provision-activity.pipe';


### PR DESCRIPTION
* Adds new fields on item detail.
* Adds masked holdings and item on document detail view.
* Activated buttons on item detail view.
* Fixes a bug on holdings availability.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Dependencies

My PR depends on branch:
- https://github.com/rero/rero-ils/tree/US-1906-item-model

## How to test?

- new fields added to the item record
* url
* pac_code
* price
* _masked
* legacy_checkout_count (migrated from Virtua, not possible to edit)
* legacy_circulation_rules (migrated from Virtua, not possible to edit)

- new fields added to the document record
* _masked

- the new fields are displayed in the `item detailed view`
- A new `eye` badge in the admin view to indicate that `item` or `holdings is masked.
- a masked record is not displayed in the public interface
- when a librarian masks all items of a standard holdings,
the system masks the standard holdings automatically.
The standard holdings will be unmasked when there is
at least one unmasked item attached to it.


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
