### PR TITLE
fees: pay only the fees of my library

### DIFF
--- a/projects/admin/src/app/circulation/classes/patron-transaction.ts
+++ b/projects/admin/src/app/circulation/classes/patron-transaction.ts
@@ -46,6 +46,7 @@ export class PatronTransaction {
   events: Array<PatronTransactionEvent> = [];
   note?: string = null;
   document?: any = null;
+  library?: any = null;
   loan?: any = null;
   patron: any = null;
 

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
@@ -27,7 +27,8 @@
         </button>
         {{ transaction.creation_date | dateTranslate :'shortDate' }}
       </div>
-      <div class="col-lg-7 d-inline-block text-truncate">{{ label }}</div>
+      <div class="col-lg-4 d-inline-block text-truncate">{{ label }}</div>
+      <div class="col-lg-3 d-inline-block text-truncate"><span *ngIf="transaction.library">{{ transaction.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}</span></div>
       <div class="col-lg-2 text-lg-right">{{ transactionAmount | currency: organisation.default_currency }}</div>
       <div class="col-md-1 text-left pl-0 mb-2" dropdown>
         <div class="position-relative" *ngIf="transaction.status === patronTransactionStatus.OPEN">

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
@@ -50,15 +50,26 @@
         <ng-container *ngIf="tabs.engagedFees.transactions.length > 0; else noTransaction">
           <div class="row mb-1 d-flex align-items-center bg-dark text-white rounded">
             <div class="col-2 pl-20" translate>Date</div>
-            <div class="col-7" translate>Category</div>
+            <div class="col-4" translate>Category</div>
+            <div class="col-3" translate>Library</div>
             <div class="col-2 text-right">
               {{ 'Total amount' | translate }} : {{ tabs.engagedFees.totalAmount | currency: organisation.default_currency }}
             </div>
             <div class="col-1 pl-0">
-              <button class="btn btn-primary btn-block d-md-block float-right btn-sm my-1"
-                      (click)="payAllTransactions()" [disabled]="tabs.engagedFees.totalAmount <= 0"
-                      translate
-              >Pay all</button>
+              <div class="btn-group" dropdown>
+                <button class="btn btn-primary btn-sm btn-block d-md-block float-right my-1"
+                (click)="payAllTransactions()" [disabled]="tabs.engagedFees.totalAmount <= 0"
+                translate
+                >Pay all</button>
+                <button id="fees-pay-all-my-library-btn" type="button" dropdownToggle class="btn btn-primary btn-sm my-1 dropdown-toggle dropdown-toggle-split"
+                        aria-controls="dropdown-split">
+                  <span class="caret"></span>
+                </button>
+                <div id="fees-pay-all-my-library-menu" *dropdownMenu class="dropdown-menu"
+                    role="menu" aria-labelledby="button-split">
+                  <a [ngClass]="{'disabled': myLibraryEngagedFees.length === 0}" class="dropdown-item" (click)="payAllTransactionsInMyLibrary()" translate>for my library</a>
+              </div>
+              </div>
             </div>
           </div>
           <admin-patron-transaction
@@ -89,7 +100,8 @@
         <ng-container *ngIf="tabs.historyFees.transactions !== null && tabs.historyFees.transactions.length > 0; else noHistory">
           <div class="row mb-1 d-flex align-items-center bg-dark text-white rounded">
             <div class="col-2 pl-20 my-2" translate>Date</div>
-            <div class="col-10" translate>Category</div>
+            <div class="col-4" translate>Category</div>
+            <div class="col-5" translate>Library</div>
           </div>
           <admin-patron-transaction
             class="row mb-1 align-items-start"

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.ts
@@ -18,7 +18,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { Subscription } from 'rxjs';
-import { User } from '@rero/shared';
+import { User, UserService } from '@rero/shared';
 import { Loan, LoanOverduePreview } from '../../../classes/loans';
 import { OrganisationService } from '../../../service/organisation.service';
 import { PatronService } from '../../../service/patron.service';
@@ -82,7 +82,8 @@ export class PatronTransactionsComponent implements OnInit, OnDestroy {
     private _patronService: PatronService,
     private _organisationService: OrganisationService,
     private _patronTransactionService: PatronTransactionService,
-    private _modalService: BsModalService
+    private _modalService: BsModalService,
+    private _userService: UserService
   ) {}
 
   /** OnInit hook */
@@ -138,6 +139,20 @@ export class PatronTransactionsComponent implements OnInit, OnDestroy {
     };
     this._modalService.show(PatronTransactionEventFormComponent, {initialState});
   }
+    get myLibraryEngagedFees() {
+      const libraryPID = this._userService.user.getCurrentLibrary();
+      return this.tabs.engagedFees.transactions.filter(t => t.library != null && t.library.pid === libraryPID);
+    }
+
+    /** Allow to pay the total of each pending patron transactions */
+    public payAllTransactionsInMyLibrary() {
+      const initialState = {
+        action: 'pay',
+        mode: 'full',
+        transactions: this.myLibraryEngagedFees
+      };
+      this._modalService.show(PatronTransactionEventFormComponent, {initialState});
+    }
 
   /**
    * Behavior to perform when user asked to open a 'vertical tab'.


### PR DESCRIPTION
* Adds a library column in the fees tabs.
* Adds a dropdown button to pay all the fees related to the current
  logged user library.
* Closes #1533.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- issue #1533

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* https://github.com/rero/rero-ils/pull/1773

## How to test?

- Go to the patron fees, a new library column should be present, a new dropdown button is present to pay only the current library fees.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
