### PR TITLE
search: update search tab title & aggregation name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,9 +2562,9 @@
       }
     },
     "@rero/ng-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-1.6.0.tgz",
-      "integrity": "sha512-8ihHQZko6k6SJkj3kZMNgvCJEsZH67iPvPwolWdJrrPT7lE/1X2R6XG2q4a7pVS2t9WyBRGKQ1bav9WLyErG6Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-1.7.0.tgz",
+      "integrity": "sha512-og6fA/gAkS9/o0AZzk7AUFEM5S5ZqiHibyzMMrhEMQPWkQcpYaa0kuFz/j+nEHg8QFwd5l4kzDuJkDwkXLzBjQ==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@ngx-loading-bar/http-client": "^5.1.1",
     "@ngx-loading-bar/router": "^5.1.1",
     "@ngx-translate/core": "^13.0.0",
-    "@rero/ng-core": "^1.6.0",
+    "@rero/ng-core": "^1.7.0",
     "bootstrap": "^4.6.0",
     "crypto-js": "^3.3.0",
     "document-register-element": "^1.14.10",

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, RouteInterface } from '@rero/ng-core';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { DocumentsBriefViewComponent } from '../record/brief-view/documents-brief-view/documents-brief-view.component';
@@ -74,6 +75,9 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
             },
             aggregations: (aggregations: any) => this._routeToolService
               .aggregationFilter(aggregations),
+            aggregationsName: {
+              organisation: _('Library')
+            },
             aggregationsOrder: [
               'document_type',
               'author',

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -80,6 +80,9 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
               component: DocumentBriefComponent,
               label: _('Documents'),
               aggregations: (aggregations: any) => this.aggFilter(aggregations),
+              aggregationsName: {
+                organisation: _('Library')
+              },
               aggregationsOrder: this.aggregations(viewcode),
               aggregationsExpand: ['document_type'],
               aggregationsBucketSize: 10,
@@ -111,7 +114,7 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
               key: 'corporate-bodies',
               index: 'contributions',
               component: ContributionBriefComponent,
-              label: _('Organisations'),
+              label: _('Corporate bodies'),
               aggregationsOrder: ['sources'],
               aggregationsExpand: ['sources'],
               listHeaders: {


### PR DESCRIPTION
* Closes rero/rero-ils#1728.
* Renames the title of the "Organisations" tab into "Corporate bodies".
* Allows to configure the aggregation name.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- To personalize aggregation title

## Dependencies

My PR depends on `ng-core`'s PR(s):

* rero/ng-core#375

## How to test?

- check if the name of the "organization" aggregation is personalized

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
