### PR TITLE
translations: fix string extraction problem

### DIFF
--- a/projects/admin/src/app/circulation/classes/patron-transaction.ts
+++ b/projects/admin/src/app/circulation/classes/patron-transaction.ts
@@ -18,22 +18,17 @@
 /* tslint:disable */
 // required as json properties is not lowerCamelCase
 
-import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 import * as moment from 'moment';
 
-export function _(str) {
-  return marker(str);
-}
-
 export enum PatronTransactionStatus {
-  OPEN = _('open'),
-  CLOSED = _('closed')
+  OPEN = 'open',
+  CLOSED = 'closed'
 }
 export enum PatronTransactionEventType {
-  FEE = _('fee'),
-  PAYMENT = _('payment'),
-  DISPUTE = _('dispute'),
-  CANCEL = _('cancel')
+  FEE = 'fee',
+  PAYMENT = 'payment',
+  DISPUTE = 'dispute',
+  CANCEL = 'cancel'
 }
 
 export class PatronTransaction {

--- a/projects/admin/src/app/circulation/services/patron-transaction.service.ts
+++ b/projects/admin/src/app/circulation/services/patron-transaction.service.ts
@@ -233,19 +233,15 @@ export class PatronTransactionService {
     this._recordService.create('patron_transaction_events', record).subscribe(
       () => {
         this.emitPatronTransactionByPatron(affectedPatron, undefined, 'open');
-        this._toastService.success(this._translateService.instant(
-          '{{ type }} registered',
-          {type: record.type}
-        ));
+        const translateType = this._translateService.instant(record.type);
+        this._toastService.success(this._translateService.instant('{{ type }} registered', {type: translateType}));
       },
       (error) => {
         const message = '[' + error.status + ' - ' + error.statusText + '] ' + error.error.message;
+        const translateType = this._translateService.instant(record.type);
         this._toastService.error(
           message,
-          this._translateService.instant(
-            '{{ type }} creation failed!',
-            { type: record.type }
-          )
+          this._translateService.instant('{{ type }} creation failed!', { type: translateType })
         );
       }
     );

--- a/projects/admin/src/app/classes/ill-request.ts
+++ b/projects/admin/src/app/classes/ill-request.ts
@@ -19,15 +19,9 @@
 /* tslint:disable */
 // required as json properties is not lowerCamelCase
 
-import { marker } from '@biesbjerg/ngx-translate-extract-marker';
-
-export function _(str) {
-  return marker(str);
-}
-
 export enum ILLRequestStatus {
-  PENDING = _('pending'),
-  VALIDATED = _('validated'),
-  DENIED = _('denied'),
-  CLOSED = _('closed'),
+  PENDING = 'pending',
+  VALIDATED = 'validated',
+  DENIED = 'denied',
+  CLOSED = 'closed'
 }

--- a/projects/admin/src/app/classes/items.ts
+++ b/projects/admin/src/app/classes/items.ts
@@ -18,25 +18,20 @@
 /* tslint:disable */
 // required as json properties is not lowerCamelCase
 
-import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 import { Moment } from 'moment';
 import { ItemStatus, User } from '@rero/shared';
 import { Loan } from './loans'
 
-export function _(str) {
-  return marker(str);
-}
-
 export enum ItemNoteType {
-  GENERAL = _('general_note'),
-  STAFF = _('staff_note'),
-  CHECKIN = _('checkin_note'),
-  CHECKOUT = _('checkout_note'),
-  BINDING = _('binding_note'),
-  PROVENANCE = _('provenance_note'),
-  CONDITION = _('condition_note'),
-  PATRIMONIAL = _('patrimonial_note'),
-  ACQUISITION = _('acquisition_note'),
+  GENERAL = 'general_note',
+  STAFF = 'staff_note',
+  CHECKIN = 'checkin_note',
+  CHECKOUT = 'checkout_note',
+  BINDING = 'binding_note',
+  PROVENANCE = 'provenance_note',
+  CONDITION = 'condition_note',
+  PATRIMONIAL = 'patrimonial_note',
+  ACQUISITION = 'acquisition_note',
 }
 
 export interface Organisation {
@@ -49,16 +44,15 @@ export interface Document {
 }
 
 export enum ItemAction {
-  checkout = _('checkout'),
-  checkin = _('checkin'),
-  request = _('request'),
-  lose = _('lose'),
-  receive = _('receive'),
-  return_missing = _('return_missing'),
-  // cancel_loan = _('cancel_loan'),
-  extend_loan = _('extend_loan'),
-  validate = _('validate'),
-  no = _('no')
+  checkout = 'checkout',
+  checkin = 'checkin',
+  request = 'request',
+  lose = 'lose',
+  receive = 'receive',
+  return_missing = 'return_missing',
+  extend_loan = 'extend_loan',
+  validate = 'validate',
+  no = 'no'
 }
 
 type ItemActionObjectType<R> = {[key in keyof typeof ItemAction]: R };

--- a/projects/admin/src/app/classes/library.ts
+++ b/projects/admin/src/app/classes/library.ts
@@ -19,14 +19,9 @@
 // required as json properties is not lowerCamelCase
 
 import { WeekDay } from '@angular/common';
-import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 import * as moment from 'moment';
 import { WeekDays } from './week-days';
 
-
-export function _(str) {
-  return marker(str);
-}
 
 export interface OpeningHours {
   day: string;
@@ -59,10 +54,10 @@ export interface ExceptionDates {
 }
 
 export enum NotificationType {
-  DUE_SOON = _('due_soon'),
-  RECALL = _('recall'),
-  OVERDUE = _('overdue'),
-  AVAILABILITY = _('availability')
+  DUE_SOON = 'due_soon',
+  RECALL = 'recall',
+  OVERDUE = 'overdue',
+  AVAILABILITY = 'availability'
 }
 
 export interface NotificationSettings {

--- a/projects/admin/src/app/classes/loans.ts
+++ b/projects/admin/src/app/classes/loans.ts
@@ -17,25 +17,19 @@
 /* tslint:disable */
 // required as json properties is not lowerCamelCase
 
-import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 import moment, { Moment } from 'moment';
-
-
-export function _(str) {
-  return marker(str);
-}
 
 // ENUM ========================================================================
 /** All possible state about a loan */
 export enum LoanState {
-  CREATED = _('CREATED'),
-  PENDING = _('PENDING'),
-  ITEM_ON_LOAN = _('ITEM_ON_LOAN'),
-  ITEM_RETURNED = _('ITEM_RETURNED'),
-  ITEM_IN_TRANSIT_FOR_PICKUP = _('ITEM_IN_TRANSIT_FOR_PICKUP'),
-  ITEM_IN_TRANSIT_TO_HOUSE = _('ITEM_IN_TRANSIT_TO_HOUSE'),
-  ITEM_AT_DESK = _('ITEM_AT_DESK'),
-  CANCELLED = _('CANCELLED')
+  CREATED = 'CREATED',
+  PENDING = 'PENDING',
+  ITEM_ON_LOAN = 'ITEM_ON_LOAN',
+  ITEM_RETURNED = 'ITEM_RETURNED',
+  ITEM_IN_TRANSIT_FOR_PICKUP = 'ITEM_IN_TRANSIT_FOR_PICKUP',
+  ITEM_IN_TRANSIT_TO_HOUSE = 'ITEM_IN_TRANSIT_TO_HOUSE',
+  ITEM_AT_DESK = 'ITEM_AT_DESK',
+  CANCELLED = 'CANCELLED'
 }
 
 // INTERFACE ===================================================================

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -69,7 +69,6 @@ _('ordered');
 _('pending');
 _('received');
 
-
 // Electronic locator types
 _('noInfo');
 _('resource');
@@ -105,6 +104,54 @@ _('pressReview');
 _('webSite');
 _('tableOfContents');
 _('fullText');
+
+// Enum values
+//  - patron transaction
+_('open');
+_('closed');
+_('fee');
+_('payment');
+_('dispute');
+_('cancel');
+//  - ill requests
+_('pending');
+_('validated');
+_('denied');
+_('closed');
+//  - notification type
+_('due_soon');
+_('recall');
+_('overdue');
+_('availability');
+//  - loan state
+_('CREATED');
+_('PENDING');
+_('ITEM_ON_LOAN');
+_('ITEM_RETURNED');
+_('ITEM_IN_TRANSIT_FOR_PICKUP');
+_('ITEM_IN_TRANSIT_TO_HOUSE');
+_('ITEM_AT_DESK');
+_('CANCELLED');
+//  - Item note type
+_('general_note');
+_('staff_note');
+_('checkin_note');
+_('checkout_note');
+_('binding_note');
+_('provenance_note');
+_('condition_note');
+_('patrimonial_note');
+_('acquisition_note');
+//  - Item circulation action
+_('checkout');
+_('checkin');
+_('request');
+_('lose');
+_('receive');
+_('return_missing');
+_('extend_loan');
+_('validate');
+_('no');
 
 // Item Request messages
 _('Request not allowed by the circulation policy.');
@@ -154,7 +201,6 @@ _('My organisation');
 _('My library');
 _('Public interface');
 _('Logout');
-
 
 _('Masked');
 _('No masked');


### PR DESCRIPTION
* The `marker` funuction (used to mark a string as extractable for
  translation) cannot be used as enum value. Place these values into the
  manual_translation file.
* Fix translation issues.
* Closes rero/rero-ils#1814

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
