### PR TITLE
Issue: update links on late issue brief view

### DIFF
--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
@@ -16,67 +16,62 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<h5 class="mb-0 card-title">
-    <a [routerLink]="[detailUrl.link]">
-        {{ record.metadata.ui_title_text }}
-    </a>
-  </h5>
-  <ng-container class="card-text">
-    <dl class="row mb-0 ml-1">
-
-    <!-- INHERITED CALL NUMBER -->
-    <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
-      <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Call number </dt>
-      <dd class="col-sm-7 col-md-8 mb-0">
-        <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
-      </dd>
-    </ng-container>
-
-      <ng-container *ngIf="record.metadata.barcode">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Barcode</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.barcode }}
-        </dd>
-      </ng-container>
-      <!-- ENUMERATION AND CHRONOLOGY -->
-      <ng-container *ngIf="record.metadata.enumerationAndChronology">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Numbering</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.enumerationAndChronology }}
-        </dd>
-      </ng-container>
-      <!-- EXPECTED DATE -->
-      <ng-container *ngIf="record.metadata.issue.expected_date">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Expected date</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.issue.expected_date | dateTranslate }}
-        </dd>
-      </ng-container>
-      <!-- NUMBER OF CLAIMS SENT -->
-      <ng-container *ngIf="record.metadata.issue.claims_count">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Claims sent</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.issue.claims_count }}
-        </dd>
-      </ng-container>
-      <!-- VENDOR -->
-      <ng-container *ngIf="record.metadata.vendor">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Vendor</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          {{ record.metadata.vendor.pid | getRecord: 'vendors': 'field': 'name' | async }}
-        </dd>
-      </ng-container>
-      <!-- ISSUE STATUS AND DATE-->
-      <ng-container *ngIf="record.metadata.issue.status as status">
-        <dt class="col-sm-3 offset-sm-2 offset-md-0 label-title" translate>Issue status</dt>
-        <dd class="col-sm-7 col-md-8 mb-0">
-          <i class="fa text-warning" [ngClass]="{
-            'fa-envelope': status == issueItemStatus.CLAIMED,
-            'fa-envelope-open-o': status == issueItemStatus.LATE
-          }"
-          ></i>
-        {{ status | translate }} [{{ record.metadata.issue.status_date | dateTranslate}}]
-        </dd>
-      </ng-container>
-    </dl>
+<h5 class="card-title mb-0">
+  <a [routerLink]="[parentUrl.link]">{{ record.metadata.ui_title_text }}</a>
+</h5>
+<dl class="row ml-1 card-text brief-view">
+  <!-- INHERITED CALL NUMBER -->
+  <ng-container *ngIf="record | itemHoldingsCallNumber | async as callNumber">
+    <dt class="col-3 label-title" translate>Call number </dt>
+    <dd class="col-9">
+      <shared-inherited-call-number [item]="record" context="first"></shared-inherited-call-number>
+    </dd>
   </ng-container>
+  <!-- BARCODE -->
+  <ng-container *ngIf="record.metadata.barcode">
+    <dt class="col-3 label-title" translate>Barcode</dt>
+    <dd class="col-9">
+      <a [routerLink]="[detailUrl.link]">{{ record.metadata.barcode }}</a>
+    </dd>
+  </ng-container>
+  <!-- ENUMERATION AND CHRONOLOGY -->
+  <ng-container *ngIf="record.metadata.enumerationAndChronology">
+    <dt class="col-3 label-title" translate>Numbering</dt>
+    <dd class="col-9">
+      {{ record.metadata.enumerationAndChronology }}
+    </dd>
+  </ng-container>
+  <!-- VENDOR -->
+  <ng-container *ngIf="record.metadata.vendor">
+    <dt class="col-3 label-title" translate>Vendor</dt>
+    <dd class="col-9">
+      {{ record.metadata.vendor.pid | getRecord: 'vendors': 'field': 'name' | async }}
+    </dd>
+  </ng-container>
+  <!-- EXPECTED DATE -->
+  <ng-container *ngIf="record.metadata.issue.expected_date">
+    <dt class="col-3 label-title" translate>Expected date</dt>
+    <dd class="col-9">
+      {{ record.metadata.issue.expected_date | dateTranslate }}
+    </dd>
+  </ng-container>
+  <!-- NUMBER OF CLAIMS SENT -->
+  <ng-container *ngIf="record.metadata.issue.claims_count">
+    <dt class="col-3 label-title" translate>Claims sent</dt>
+    <dd class="col-9">
+      {{ record.metadata.issue.claims_count }}
+    </dd>
+  </ng-container>
+  <!-- ISSUE STATUS AND DATE-->
+  <ng-container *ngIf="record.metadata.issue.status as status">
+    <dt class="col-3 label-title" translate>Issue status</dt>
+    <dd class="col-9">
+      <i class="fa text-warning" [ngClass]="{
+        'fa-envelope': status == issueItemStatus.CLAIMED,
+        'fa-envelope-open-o': status == issueItemStatus.LATE
+      }"
+      ></i>
+    {{ status | translate }} [{{ record.metadata.issue.status_date | dateTranslate }}]
+    </dd>
+  </ng-container>
+</dl>

--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.ts
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.ts
@@ -15,29 +15,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { ResultItem } from '@rero/ng-core';
 import { IssueItemStatus } from '@rero/shared';
 
 @Component({
   selector: 'admin-inventory-brief-view',
-  templateUrl: './issues-brief-view.component.html'
+  templateUrl: './issues-brief-view.component.html',
 })
-export class IssuesBriefViewComponent implements ResultItem {
+export class IssuesBriefViewComponent implements ResultItem, OnInit {
 
+  /** Record */
+  @Input() record: any;
+  /** Type of record */
+  @Input() type: string;
+  /** Detail Url */
+  @Input() detailUrl: { link: string, external: boolean };
+
+  /** prent holding url */
+  parentUrl: { link: string, external: boolean };
   /** reference to IssueItemStatus */
   issueItemStatus = IssueItemStatus;
 
-  /** Record */
-  @Input()
-  record: any;
-
-  /** Type of record */
-  @Input()
-  type: string;
-
-  /** Detail Url */
-  @Input()
-  detailUrl: { link: string, external: boolean };
+  /** OnInit hook */
+  ngOnInit() {
+    if (this.record) {
+      this.parentUrl = {
+        link: `/records/holdings/detail/${this.record.metadata.holding.pid}`,
+        external: false
+      };
+    }
+  }
 
 }

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -16,10 +16,16 @@
 -->
 
 <ng-container *ngIf="record">
+  <div *ngIf="isIssue">
+    <a [routerLink]="parentHoldingUrl">
+      <i class="fa fa-arrow-left mr-1"></i>
+      {{ 'Back to parent holding' | translate }}
+    </a>
+  </div>
+  <header>
+    <h1>{{ 'Barcode' | translate }} {{ record.metadata.barcode }}</h1>
+  </header>
   <section class="mb-4">
-    <header>
-      <h1>{{ 'Barcode' | translate }} {{ record.metadata.barcode }}</h1>
-    </header>
     <admin-record-masked *ngIf="record.metadata._masked" [record]="record" [withLabel]="true"></admin-record-masked>
     <dl class="row">
       <!-- INHERITED CALL NUMBER -->
@@ -107,7 +113,7 @@
   </section>
 
   <!-- ISSUE DATA -->
-  <section *ngIf="record.metadata.type == 'issue'">
+  <section *ngIf="isIssue">
     <header>
       <h3 translate>Issue data</h3>
     </header>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -58,6 +58,22 @@ export class ItemDetailViewComponent implements DetailRecord, OnInit, OnDestroy 
   }
 
   /**
+   * Is this record is an issue
+   * @return True if the record is an issue ; false otherwise
+   */
+  get isIssue(): boolean {
+    return this.record.metadata.type === 'issue';
+  }
+
+  /**
+   * Get the URL for the parent holding.
+   * @return the url to parent holding.
+   */
+  get parentHoldingUrl(): string {
+    return `/records/holdings/detail/${this.record.metadata.holding.pid}`;
+  }
+
+  /**
    * Get organisation currency
    * @return string
    */

--- a/projects/admin/src/app/scss/styles.scss
+++ b/projects/admin/src/app/scss/styles.scss
@@ -91,6 +91,11 @@ span.no-data {
   cursor: not-allowed;
 }
 
+// Data list into brief view
+dl.brief-view dd {
+  margin-bottom: 0;
+}
+
 json-schema-form {
   input.ng-valid,
   textarea.ng-valid {


### PR DESCRIPTION
* For a late issue brief view, the main ink should point to the holdings
  detail view instead of item detail view. The item detail link is now
  placed on the barcode.
* Adds a link to point on holding parent detail view on the item detail
  view if the item is an issue.
* Closes rero/rero-ils#1808.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

![image](https://user-images.githubusercontent.com/10031585/117424268-e8d53300-af21-11eb-972f-d6e4b32c01e9.png)
![image](https://user-images.githubusercontent.com/10031585/117424222-d824bd00-af21-11eb-9a11-22cdec20310a.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
