### PR TITLE
circulation: display circulation messages

### DIFF
--- a/projects/admin/src/app/circulation/patron/card/card.component.html
+++ b/projects/admin/src/app/circulation/patron/card/card.component.html
@@ -1,18 +1,18 @@
 <!--
  RERO ILS UI
- Copyright (C) 2019 RERO
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, version 3 of the License.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ Copyright (C) 2019 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div class="m-0" *ngIf="patron && patron.patron" [ngClass]="{'text-muted': !patron.displayPatronMode}">
   <div class="row">
@@ -69,15 +69,19 @@
       </div>
     </div>
     <!-- Circulation message -->
-    <ng-container *ngIf="patron.circulation_informations">
-      <div class="col-sm-12 col-md-6">
-      <ul class="list-group">
-        <li *ngFor="let message of patron.circulation_informations.messages"
+    <ng-container *ngIf="displayCirculationMessages">
+      <ul class="col-6 list-group">
+        <ng-container *ngIf="patron.circulation_information">
+          <li *ngFor="let message of patron.circulation_informations.messages"
             class="list-group-item list-group-item-{{ getBootstrapColor(message.type) }}"
            [innerHTML]="message.content | nl2br"
+          ></li>
+        </ng-container>
+        <li *ngFor="let message of circulationMessages"
+            class="list-group-item list-group-item-{{ getBootstrapColor(message.type) }}"
+            [innerHTML]="message.content | nl2br"
         ></li>
       </ul>
-      </div>
     </ng-container>
   </div>
 </div>

--- a/projects/admin/src/app/circulation/patron/card/card.component.ts
+++ b/projects/admin/src/app/circulation/patron/card/card.component.ts
@@ -16,7 +16,9 @@
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import moment from 'moment';
+import { hasOwnProp } from 'ngx-bootstrap/chronos/utils/type-checks';
 import { getBootstrapLevel } from '../../../utils/utils';
+import { CirculationService } from '../../services/circulation.service';
 
 @Component({
   selector: 'admin-circulation-patron-detailed',
@@ -25,19 +27,19 @@ import { getBootstrapLevel } from '../../../utils/utils';
 })
 export class CardComponent {
 
+  // COMPONENT ATTRIBUTES =====================================================
   /** the patron */
   @Input() patron: any;
-
   /** the patron barcode */
   @Input() barcode: string;
-
   /** is the circulation messages should be displayed */
-  @Input() circulationMessages = false;
+  @Input() displayCirculationMessages = false;
   /** which link should be use on the main patron name */
   @Input() linkMode: 'circulation'|'detail' = 'detail';
   /** event emitter when the close button are fired */
   @Output() clearPatron = new EventEmitter<any>();
 
+  // GETTER & SETTER ==========================================================
   /** Build the link used on the patron name */
   get patronLink(): string {
     if (this.patron) {
@@ -64,6 +66,24 @@ export class CardComponent {
     return false;
   }
 
+  /** Get the circulation messages about the loaded patron if exists */
+  get circulationMessages(): Array<{type: string, content: string}> {
+    return (this._circulationService.hasOwnProperty('circulationInformations'))
+      ? this._circulationService.circulationInformations.messages
+      : [];
+  }
+
+  // CONSTRUCTOR ==============================================================
+  /**
+   * constructor
+   * @param _circulationService - CirculationService
+   */
+  constructor(
+    private _circulationService: CirculationService
+  ) {}
+
+
+  // COMPONENT FUNCTIONS ======================================================
   /** Clear current patron */
   clear(): void {
     if (this.patron) {

--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -20,7 +20,7 @@
     <admin-circulation-patron-detailed
       [patron]="patron"
       [barcode]="barcode"
-      [circulationMessages]="true"
+      [displayCirculationMessages]="true"
       (clearPatron)="clearPatron()"
     ></admin-circulation-patron-detailed>
   </div>


### PR DESCRIPTION
Display circulation messages (blocked, max item checkout, ...) related
to the loaded patrons on the patron circulation view.

Closes rero/rero-ils#1964.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Edit a "patron" user ; block it for some reasons.
- Go to the circulation view of this patron.
- The block message will be displayed.

![image](https://user-images.githubusercontent.com/10031585/120988540-f5e27d80-c77e-11eb-89d0-fadc75f5cdfe.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
