### PR TITLE
acquisitions: account selector widget

### DIFF
--- a/projects/admin/src/app/acquisition/acquisition.module.ts
+++ b/projects/admin/src/app/acquisition/acquisition.module.ts
@@ -34,6 +34,9 @@ import { OrderDetailViewComponent } from './components/order/order-detail-view/o
 import { OrderLineComponent } from './components/order/order-detail-view/order-line/order-line.component';
 import { OrderLinesComponent } from './components/order/order-detail-view/order-lines/order-lines.component';
 import { NegativeAmountPipe } from './pipes/negative-amount.pipe';
+import {
+  SelectAccountEditorWidgetComponent
+} from './components/editor/widget/select-account-editor-widget/select-account-editor-widget.component';
 
 @NgModule({
   declarations: [
@@ -47,7 +50,8 @@ import { NegativeAmountPipe } from './pipes/negative-amount.pipe';
     OrderDetailViewComponent,
     OrderLinesComponent,
     OrderLineComponent,
-    NegativeAmountPipe
+    NegativeAmountPipe,
+    SelectAccountEditorWidgetComponent
   ],
   imports: [
     PopoverModule.forRoot(),

--- a/projects/admin/src/app/acquisition/api/acq-account-api.service.ts
+++ b/projects/admin/src/app/acquisition/api/acq-account-api.service.ts
@@ -98,4 +98,29 @@ export class AcqAccountApiService {
     return this._http.get<any>(apiUrl, { params });
   }
 
+
+  /**
+   * Allow to sort accounts to render it correctly (corresponding to hierarchical tree structure)
+   * @param accounts - the accounts to sort.
+   * @return Account list sorted as a hierarchical tree.
+   */
+  orderAccountsAsTree(accounts: Array<AcqAccount>): Array<AcqAccount> {
+    /** Append an account and children accounts into the `accounts` list */
+    const _appendAccount = (account: AcqAccount, list: Array<AcqAccount>) => {
+      list.push(account);
+      accounts.filter(acc => acc.parent !== undefined && acc.parent.pid === account.pid)
+              .forEach(acc => _appendAccount(acc, list));
+    };
+    // First sort on depth and name.
+    accounts.sort((a, b) => {
+      return (a.depth === b.depth)
+        ? a.name.localeCompare(b.name)
+        : a.depth - b.depth;
+    });
+    // Rebuild hierarchical account tree.
+    const sortedAccounts: Array<AcqAccount> = [];
+    accounts.filter(acc => acc.depth === 0).forEach(acc => _appendAccount(acc, sortedAccounts));
+    return sortedAccounts;
+  }
+
 }

--- a/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.spec.ts
+++ b/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.spec.ts
@@ -20,10 +20,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { testUserPatronMultipleOrganisationsWithSettings, UserApiService, UserService } from '@rero/shared';
+import { UserService } from '@rero/shared';
 import { of } from 'rxjs';
 import { AcquisitionModule } from '../../../acquisition.module';
-import { AcqAccountApiService } from '../../../api/acq-account-api.service';
+import { RecordService } from '@rero/ng-core';
 
 import { AccountTransferComponent } from './account-transfer.component';
 
@@ -31,7 +31,8 @@ describe('AccountTransferComponent', () => {
   let component: AccountTransferComponent;
   let fixture: ComponentFixture<AccountTransferComponent>;
 
-  const accountsApiServiceSpy = jasmine.createSpyObj('AcqAccountApiService', ['getAccounts']);
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecords', 'totalHits']);
+  const userServiceSpy = jasmine.createSpyObj('UserService', ['']);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -43,14 +44,17 @@ describe('AccountTransferComponent', () => {
         AcquisitionModule
       ],
       providers: [
-        { provide: AcqAccountApiService, useValue: accountsApiServiceSpy }
+        { provide: RecordService, useValue: recordServiceSpy },
+        { provide: UserService, useValue: userServiceSpy },
       ]
     })
     .compileComponents();
   });
 
   beforeEach(() => {
-    accountsApiServiceSpy.getAccounts.and.returnValue(of([]));
+    userServiceSpy.user = {currentLibrary: 1};
+    recordServiceSpy.totalHits.and.returnValue(0);
+    recordServiceSpy.getRecords.and.returnValue(of({hits: {total: 0}}));
     fixture = TestBed.createComponent(AccountTransferComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.ts
+++ b/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.ts
@@ -148,34 +148,12 @@ export class AccountTransferComponent implements OnInit {
   /** Load accounts and budgets. Order accounts as a hierarchical tree */
   private _loadData(): void {
     this._accountApiService.getAccounts(undefined, 'depth').subscribe((accounts: AcqAccount[]) => {
-      this._accountsTree = accounts;
-      this._orderAccounts();
+      this._accountsTree = this._accountApiService.orderAccountsAsTree(accounts);
 
       this.budgets = Array.from(new Set(this._accountsTree.map((account: AcqAccount) => account.budget.pid)));
       this._selectedBudgetPid = this.budgets.find(Boolean);  // get the first element
       this._filterAccountToDisplay();
     });
-  }
-
-  /** Allow to sort accounts to render it correctly (corresponding to hierarchical tree structure) */
-  private _orderAccounts(): void {
-    /** Append an account and children accounts into the `accounts` list */
-    const _appendAccount = (account: AcqAccount, list: Array<AcqAccount>) => {
-      list.push(account);
-      this._accountsTree
-        .filter(acc => acc.parent !== undefined && acc.parent.pid === account.pid)
-        .forEach(acc => _appendAccount(acc, list));
-    };
-    // First sort on depth and name.
-    this._accountsTree.sort((a, b) => {
-      return (a.depth === b.depth)
-        ? a.name.localeCompare(b.name)
-        : a.depth - b.depth;
-    });
-    // Rebuild hierarchical account tree.
-    const accounts: Array<AcqAccount> = [];
-    this._accountsTree.filter(acc => acc.depth === 0).forEach(acc => _appendAccount(acc, accounts));
-    this._accountsTree = accounts;
   }
 
   /** Allow to filter loaded accounts by the selected budget */

--- a/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.html
+++ b/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.html
@@ -1,0 +1,51 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+  Copyright (C) 2021 UCLouvain
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div class="btn-group my-2 w-100" dropdown #dropdown="bs-dropdown" [insideClick]="true" [isDisabled]="to.readonly">
+  <button id="button-basic" dropdownToggle type="button" aria-controls="dropdown-basic"
+          class="btn btn-sm btn-block text-left dropdown-toggle p-2 d-flex align-items-center">
+    {{ selectedAccount
+         ? selectedAccount.name
+         : (to.placeholder | translate) || ('Select an option...' | translate)
+    }}
+    <span class="caret ml-auto"></span>
+  </button>
+  <div id="dropdown-basic" *dropdownMenu class="dropdown-menu w-100" role="menu" aria-labelledby="button-basic">
+    <ng-container *ngIf="accountList.length; else noResult">
+      <a *ngFor="let account of accountList"
+         href="#"
+         class="dropdown-item account d-flex"
+         (click)="$event.preventDefault(); selectAccount(account); dropdown.hide()"
+      >
+        <div class="pr-5">
+          {{ account.depth > 0 ? '&nbsp;&nbsp;&nbsp;&nbsp;'.repeat(account.depth) + ' ' : '' }}
+          {{ account.name }}
+        </div>
+        <div class="ml-auto pl-5 amount" [class]="{
+            'text-success': account.remaining_balance.self > 0,
+            'text-muted': account.remaining_balance.self === 0,
+            'text-warning': account.remaining_balance.self < 0
+        }">
+          {{ account.remaining_balance.self | currency: organisation.default_currency }}
+        </div>
+      </a>
+    </ng-container>
+    <ng-template #noResult>
+      <p class="m-0 px-4 py-2 text-muted" translate>No result</p>
+    </ng-template>
+  </div>
+</div>

--- a/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.scss
+++ b/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.scss
@@ -1,0 +1,27 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ * Copyright (C) 2021 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import '~bootstrap/scss/_functions';
+@import '~bootstrap/scss/_variables';
+
+.dropdown-toggle.btn {
+  border: $input-border-width solid $input-border-color;
+}
+.amount {
+  font-family: Arial;
+}

--- a/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.ts
+++ b/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.ts
@@ -1,0 +1,91 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ * Copyright (C) 2021 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { getCurrencySymbol } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { ApiService } from '@rero/ng-core';
+import { AcqAccountApiService } from 'projects/admin/src/app/acquisition/api/acq-account-api.service';
+import { AcqAccount } from 'projects/admin/src/app/acquisition/classes/account';
+import { OrganisationService } from 'projects/admin/src/app/service/organisation.service';
+
+@Component({
+  selector: 'admin-select-account-editor-widget',
+  templateUrl: './select-account-editor-widget.component.html',
+  styleUrls: ['../../../../acquisition.scss', './select-account-editor-widget.component.scss']
+})
+export class SelectAccountEditorWidgetComponent extends FieldType implements OnInit {
+
+  // COMPONENT ATTRIBUTES =======================================================
+  /** accounts list */
+  accountList: Array<AcqAccount> = [];
+  /** the selected account */
+  selectedAccount: AcqAccount = null;
+
+  // GETTER & SETTER ============================================================
+  /** Get the current organisation */
+  get organisation(): any {
+    return this._organisationService.organisation;
+  }
+
+  /** Get the currency symbol for the organisation */
+  get currencySymbol(): any {
+    return getCurrencySymbol(this.organisation.default_currency, 'wide');
+  }
+
+  // CONSTRUCTOR & HOOKS ======================================================
+  /**
+   * Constructor
+   * @param _accountApiService - AcqAccountApiService
+   * @param _organisationService - OrganisationService
+   * @param _apiService - ApiService
+   */
+  constructor(
+    private _accountApiService: AcqAccountApiService,
+    private _organisationService: OrganisationService,
+    private _apiService: ApiService
+  ) {
+    super();
+  }
+
+  /** OnInit hook */
+  ngOnInit(): void {
+    this._accountApiService.getAccounts().subscribe((accounts: AcqAccount[]) => {
+      accounts = this._accountApiService.orderAccountsAsTree(accounts);
+      this.accountList = accounts;
+
+      if (this.formControl.value) {
+        const currentPid = this.formControl.value.substring(this.formControl.value.lastIndexOf('/') + 1);
+        const currentAccount = this.accountList.find((account: AcqAccount) => account.pid === currentPid);
+        if (currentAccount !== undefined) {
+          this.selectedAccount = currentAccount;
+        }
+      }
+    });
+  }
+
+  // COMPONENT FUNCTIONS ======================================================
+  /**
+   * Store the selected option, when an option is clicked in the list
+   * @param account - The selected account.
+   */
+  selectAccount(account: AcqAccount): void {
+    const accountRef = this._apiService.getRefEndpoint('acq_accounts', account.pid);
+    this.selectedAccount = account;
+    this.formControl.patchValue(accountRef);
+  }
+}

--- a/projects/admin/src/app/acquisition/routes/order-lines-route.ts
+++ b/projects/admin/src/app/acquisition/routes/order-lines-route.ts
@@ -45,12 +45,7 @@ export class OrderLinesRoute extends BaseRoute implements RouteInterface {
             canAdd: () => this._routeToolService.canSystemLibrarian(),
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),
             preCreateRecord: (data: any) => this._addDefaultInformation(data),
-            redirectUrl: (record: any) => this.redirectUrl(record.metadata.acq_order, '/records/acq_orders/detail'),
-            formFieldMap: (field: FormlyFieldConfig, jsonSchema: JSONSchema7): FormlyFieldConfig => {
-              return this.populateAcquisitionAccountsByCurrentUserLibrary(
-                field, jsonSchema
-              );
-            },
+            redirectUrl: (record: any) => this.redirectUrl(record.metadata.acq_order, '/records/acq_orders/detail')
           }
         ]
       }
@@ -67,50 +62,5 @@ export class OrderLinesRoute extends BaseRoute implements RouteInterface {
       $ref: this._routeToolService.apiService.getRefEndpoint('acq_orders', this._routeToolService.getRouteQueryParam('order'))
     };
     return data;
-  }
-
-  /**
-   * Populate select menu with acquisition accounts of current user library
-   * @param field - FormlyFieldConfig
-   * @param jsonSchema - JSONSchema7
-   * @return FormlyFieldConfig
-   */
-  private populateAcquisitionAccountsByCurrentUserLibrary(
-    field: FormlyFieldConfig,
-    jsonSchema: JSONSchema7): FormlyFieldConfig {
-    const formOptions = jsonSchema.form;
-    if (formOptions && formOptions.fieldMap === 'acq_account') {
-      field.type = 'select';
-      field.hooks = {
-        ...field.hooks,
-        afterContentInit: (f: FormlyFieldConfig) => {
-          const user = this._routeToolService.userService.user;
-          const recordService = this._routeToolService.recordService;
-          const apiService = this._routeToolService.apiService;
-          const libraryPid = user.currentLibrary;
-          const query = `library.pid:${libraryPid}`;
-          f.templateOptions.options = recordService.getRecords(
-            'acq_accounts',
-            query, 1,
-            RecordService.MAX_REST_RESULTS_SIZE
-          ).pipe(
-            map((result: Record) => this._routeToolService
-              .recordService.totalHits(result.hits.total) === 0 ? [] : result.hits.hits),
-            map(hits => {
-              return hits.map((hit: any) => {
-                return {
-                  label: hit.metadata.name,
-                  value: apiService.getRefEndpoint(
-                    'acq_accounts',
-                    hit.metadata.pid
-                  )
-                };
-              });
-            })
-          );
-        }
-      };
-    }
-    return field;
   }
 }

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -37,6 +37,9 @@ import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
+import {
+  SelectAccountEditorWidgetComponent
+} from './acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DocumentsTypeahead } from './classes/typeahead/documents-typeahead';
@@ -256,7 +259,8 @@ export function appInitFactory(appInitService: AppInitService) {
     PopoverModule.forRoot(),
     FormlyModule.forRoot({
       types: [
-        { name: 'cipo-pt-it', component: CipoPatronTypeItemTypeComponent }
+        { name: 'cipo-pt-it', component: CipoPatronTypeItemTypeComponent },
+        { name: 'account-select', component: SelectAccountEditorWidgetComponent}
       ],
       wrappers: [
         { name: 'user-id', component: UserIdComponent },


### PR DESCRIPTION
Creates a formly widget especially for `AcqAccount` resource. This
widget will generate a hierarchical dropdown list with a remaining
balance statement.


![image](https://user-images.githubusercontent.com/10031585/121361623-c2961f00-c935-11eb-9f9e-bc8f07f891ed.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
