### PR TITLE
documents: fix detailed view

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -119,7 +119,7 @@
             class="badge badge-secondary mr-1"
             title="{{ subject.type | translate }}"
             [attr.id]="i | idAttribute:{prefix: 'doc-subject'}">
-            <i class="fa fa-tag"></i> {{ subject.term }}
+            <i class="fa fa-tag"></i> {{ subject.text }}
           </span>
         </div>
       </div>

--- a/projects/public-search/src/app/document-brief/document-brief.component.html
+++ b/projects/public-search/src/app/document-brief/document-brief.component.html
@@ -66,7 +66,7 @@
         </a>
         <pre class="collapse border border-secondary mt-1" id="{{'score'+record.metadata.pid }}">{{record.explanation|json}}</pre>
       </div>
-      <shared-part-of [record]="record"></shared-part-of>
+      <shared-part-of [record]="record" [viewcode]="viewcode" [isPublicView]="true"></shared-part-of>
     </article>
   </div>
 </article>

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.html
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.html
@@ -22,9 +22,16 @@
       <ng-container *ngIf="partOf.document.pid | getRecord: 'documents' : 'object' : '': { 'Content-Type': 'application/rero+json' } | async as hostDocument">
         <div class="mb-0">
             {{ getPartOfLabel(hostDocument) }}:
-            <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', partOf.document.pid]">
-              {{ getShortMainTitle(hostDocument.metadata.title) }}
-            </a>
+            <ng-container *ngIf="isPublicView; else adminLink">
+              <a id="{{'doc-part-of-' + i}}" href="/{{ viewcode }}/documents/{{ partOf.document.pid }}">
+                {{ getShortMainTitle(hostDocument.metadata.title) }}
+              </a>
+            </ng-container>
+            <ng-template #adminLink>
+              <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', partOf.document.pid]">
+                {{ getShortMainTitle(hostDocument.metadata.title) }}
+              </a>
+            </ng-template>
             <ng-container *ngIf="partOf.numbering">
               <span>;</span>
               <ul class="list-unstyled mb-0 ml-1">
@@ -59,9 +66,16 @@
           </dt>
           <dd class="col mb-0">
             <div class="row">
-              <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', document.document.pid]">
-                {{ getShortMainTitle(hostDocument.metadata.title) }}
-              </a>
+              <ng-container *ngIf="isPublicView; else adminLink">
+                <a id="{{'doc-part-of-' + i}}" href="/{{ viewcode }}/documents/{{ document.document.pid }}">
+                  {{ getShortMainTitle(hostDocument.metadata.title) }}
+                </a>
+              </ng-container>
+              <ng-template #adminLink>
+                <a id="{{'doc-part-of-' + i}}" [routerLink]="['/records', 'documents', 'detail', document.document.pid]">
+                  {{ getShortMainTitle(hostDocument.metadata.title) }}
+                </a>
+              </ng-template>
               <ng-container *ngIf="document.numbering">
                 <span>;</span>
                 <ul class="list-unstyled mb-0 ml-1">

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
@@ -27,6 +27,12 @@ export class PartOfComponent {
   /** Document */
   @Input() record: any;
 
+  /** View code */
+  @Input() viewcode: string = null;
+
+  /** is public view */
+  @Input() isPublicView = false;
+
   /** Is it brief or detailed view? */
   @Input() isBrief = true;
 


### PR DESCRIPTION
* Fixes subject badges text on detailed view of the professional interface.
* Fixes `partOf` link on detailed view of the public interface.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- Part-of link on public view.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
