### PR TITLE
items: implement circulation history

### DIFF
--- a/projects/admin/src/app/api/operation-logs-api.service.spec.ts
+++ b/projects/admin/src/app/api/operation-logs-api.service.spec.ts
@@ -69,4 +69,12 @@ describe('OperationLogsService', () => {
         next: (response: Record) => expect(response).toEqual(responseRecords)
     });
   });
+
+  it('should return a list of circulation history on a item', () => {
+    service
+      .getCirculationLogs('documents', 1)
+      .subscribe({
+        next: (response: Record) => expect(response).toEqual(responseRecords)
+    });
+  });
 });

--- a/projects/admin/src/app/api/operation-logs-api.service.ts
+++ b/projects/admin/src/app/api/operation-logs-api.service.ts
@@ -49,4 +49,20 @@ export class OperationLogsApiService {
       undefined, undefined, undefined, sort
     );
   }
+
+  /**
+   * Get Circulation logs by item
+   * @param resourcePid - string
+   * @param page - number
+   * @param itemPerPage - number
+   * @param sort - string
+   * @returns Observable
+   */
+  getCirculationLogs(resourcePid: string, page: number, itemPerPage = 5, sort = 'mostrecent'): Observable<Record | Error> {
+    const query = `_exists_:loan AND record.item_pid.value:${resourcePid}`;
+    return this._recordService.getRecords(
+      'operation_logs', query, page, itemPerPage,
+      undefined, undefined, undefined, sort
+    );
+  }
 }

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -159,6 +159,9 @@ import { TypeaheadFactoryService, typeaheadToken } from './service/typeahead-fac
 import { UiRemoteTypeaheadService } from './service/ui-remote-typeahead.service';
 import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/custom-shortcut-help.component';
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
+import { CirculationLogsComponent } from './record/circulation-logs/circulation-logs.component';
+import { CirculationLogsDialogComponent } from './record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component';
+import { CirculationLogComponent } from './record/circulation-logs/circulation-log/circulation-log.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -262,7 +265,10 @@ export function appInitFactory(appInitService: AppInitService) {
     IdentifiedbyValueComponent,
     DialogImportComponent,
     SubjectProcessPipe,
-    NotificationTypePipe
+    NotificationTypePipe,
+    CirculationLogsComponent,
+    CirculationLogsDialogComponent,
+    CirculationLogComponent
   ],
   imports: [
     AppRoutingModule,

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.css
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.css
@@ -1,0 +1,33 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.btn-toogle {
+  width: 1em;
+}
+
+.log-date {
+ width: 12em;
+}
+
+.log-action {
+ width: 10em;
+ font-weight: bold;
+}
+
+.log-library {
+ width: 26em;
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.html
@@ -1,0 +1,62 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div class="row col">
+  <div class="log-date">
+    <button
+      id="circulation-history-{{ record.metadata.pid }}"
+      type="button"
+      class="pl-0 pr-2 pt-0 btn btn-toogle"
+      (click)="isCollapsed = !isCollapsed"
+      [attr.aria-expanded]="!isCollapsed"
+      aria-controls="collapseEvent"
+    >
+      <i class="fa pr-0" [ngClass]="{ 'fa-caret-right': isCollapsed, 'fa-caret-down': !isCollapsed }"></i>
+    </button>
+    {{ record.metadata.record.transaction_date | dateTranslate :'shortDate' }}
+    {{ record.metadata.record.transaction_date | dateTranslate :'mediumTime' }}
+  </div>
+  <div class="log-action text-bold">
+    {{ record.metadata.record.trigger | translate }}
+  </div>
+  <div class="log-library">
+    <ng-container *ngIf="record.metadata.record.transaction_location_pid | getRecord: 'locations' | async as location">
+      {{ location.metadata.library.pid | getRecord: 'libraries' : 'field': 'name' | async }}
+    </ng-container>
+  </div>
+  <div class="log-patron">
+    <ng-container *ngIf="record.metadata.record.patron_pid; else anonymous">
+      <ng-container *ngIf="record.metadata.record.patron_pid | getRecord : 'patrons' | async as patron">
+        <a [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode[0]]" (click)="closeDialog()">
+          {{ patron.metadata.last_name }}, {{ patron.metadata.first_name }}
+        </a>
+      </ng-container>
+    </ng-container>
+    <ng-template #anonymous>
+      {{ 'Patron type' | translate }}: {{ record.metadata.loan.patron.type }}
+    </ng-template>
+  </div>
+</div>
+<div id="circulation-history-{{ record.metadata.pid }}" [collapse]="isCollapsed" [isAnimated]="true" class="col-lg-12 pl-3">
+  <dl class="row pl-1">
+    <dt class="col-2 mb-0" translate>Loan status</dt>
+    <dd class="col-10 mb-0 pl-1">{{ record.metadata.record.state | translate }}</dd>
+    <dt class="col-2 mb-0" translate>Pickup location</dt>
+    <dd class="col-10 mb-0 pl-1">{{ record.metadata.record.pickup_location_pid | getRecord : 'locations' : 'field': 'name' | async }}</dd>
+    <dt class="col-2 mb-0" translate>Operator</dt>
+    <dd class="col-10 mb-0 pl-1">{{ record.metadata.user_name }}</dd>
+  </dl>
+</div>

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.spec.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { DateTranslatePipe, RecordModule } from '@rero/ng-core';
+import { BsLocaleService } from 'ngx-bootstrap/datepicker';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { CirculationLogComponent } from './circulation-log.component';
+
+
+describe('CirculationLogComponent', () => {
+  let component: CirculationLogComponent;
+  let fixture: ComponentFixture<CirculationLogComponent>;
+
+  const record = {
+    created: '2021-06-30T06:55:28.261181+00:00',
+    id: '273a0b3e-d970-11eb-b8f9-8c859092e74d',
+    links: {
+      self: 'https://localhost:5000/api/operation_logs/273a0b3e-d970-11eb-b8f9-8c859092e74d'
+    },
+    metadata: {
+      date: '2021-06-30T06:55:28.048793+00:00',
+      loan: {
+        item: {
+          call_number: '00177',
+          category: 'standard',
+          document: {
+            title: 'Poema de Mio Cid',
+            type: 'docsubtype_other_book'
+          },
+          holding: {
+            location_name: 'Section enfants',
+            pid: '172'
+          }
+        },
+        override_flag: false,
+        patron: {
+          age: 59,
+          gender: 'other',
+          name: 'Broglio, Giulia',
+          postal_code: '6500',
+          type: 'Standard'
+        },
+        pickup_location_name: 'Espaces publics',
+        transaction_channel: 'system',
+        transaction_location_name: 'Espaces publics',
+        transaction_user_name: 'Rodriguez, Elena'
+      },
+      operation: 'create',
+      pid: '273a0b3e-d970-11eb-b8f9-8c859092e74d',
+      record: {
+        $schema: 'https://bib.rero.ch/schemas/loans/loan-ils-v0.0.1.json',
+        document_pid: '276',
+        end_date: '2021-07-14T22:00:28.047793+00:00',
+        item_pid: {
+          type: 'item', value: '177'
+        },
+        organisation: {
+          $ref: 'https://bib.rero.ch/api/organisations/1'
+        },
+        patron_pid: '10',
+        pickup_location_pid: '11',
+        pid: '31',
+        start_date: '2021-06-30T06:55:28.048793+00:00',
+        state: 'ITEM_ON_LOAN',
+        to_anonymize: false,
+        transaction_date: '2021-06-30T06:55:28.048793+00:00',
+        transaction_location_pid: '11',
+        transaction_user_pid: '3',
+        trigger: 'checkout'
+      },
+      user_name: 'system'
+    },
+    updated: '2021-06-30T06:55:28.261181+00:00'
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        CirculationLogComponent,
+        DateTranslatePipe
+      ],
+      imports: [
+        HttpClientTestingModule,
+        TranslateModule.forRoot(),
+        RecordModule
+      ],
+      providers: [ BsModalService, BsLocaleService ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CirculationLogComponent);
+    component = fixture.componentInstance;
+    component.record = record;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.ts
@@ -1,0 +1,38 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'admin-circulation-log',
+  templateUrl: './circulation-log.component.html',
+  styleUrls: ['./circulation-log.component.css']
+})
+export class CirculationLogComponent {
+  /** Operation log record */
+  @Input() record: any;
+
+  /** Event for close dialog */
+  @Output() closeDialogEvent  = new EventEmitter();
+
+  /** Circulation informations is collapsed */
+  isCollapsed = true;
+
+  /** Close dialog */
+  closeDialog(): void {
+    this.closeDialogEvent.emit(null);
+  }
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.html
@@ -1,0 +1,22 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<button
+    id="item-circulation-history"
+    class="btn btn-sm btn-light my-2 ml-2"
+    (click)="openDialog()"
+    translate
+  >Circulation history</button>

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.spec.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentLoaderFactory } from 'ngx-bootstrap/component-loader';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { PositioningService } from 'ngx-bootstrap/positioning';
+import { CirculationLogsDialogComponent } from './circulation-logs-dialog.component';
+
+
+describe('CirculationLogsDialogComponent', () => {
+  let component: CirculationLogsDialogComponent;
+  let fixture: ComponentFixture<CirculationLogsDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CirculationLogsDialogComponent ],
+      imports: [ HttpClientTestingModule ],
+      providers: [ BsModalService, ComponentLoaderFactory, PositioningService ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CirculationLogsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs-dialog/circulation-logs-dialog.component.ts
@@ -1,0 +1,55 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input } from '@angular/core';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import { CirculationLogsComponent } from '../circulation-logs.component';
+
+@Component({
+  selector: 'admin-circulation-logs-dialog',
+  templateUrl: './circulation-logs-dialog.component.html'
+})
+export class CirculationLogsDialogComponent {
+
+  /** Resource pid */
+  @Input() resourcePid: string;
+
+  /** Modal ref */
+  bsModalRef: BsModalRef;
+
+  /**
+   * Constructor
+   * @param _modalService - BsModalService
+   */
+  constructor(private _modalService: BsModalService) {}
+
+  /** Open operation logs dialog */
+  openDialog(): void {
+    const config = {
+      ignoreBackdropClick: false,
+      keyboard: true,
+      initialState: {
+        resourcePid: this.resourcePid
+      }
+    };
+    this.bsModalRef = this._modalService.show(CirculationLogsComponent, config);
+    this.bsModalRef.content.dialogClose$.subscribe((value: boolean) => {
+      if (value) {
+        this.bsModalRef.hide();
+      }
+    });
+  }
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.css
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.css
@@ -1,0 +1,20 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.overflow-max-size {
+  max-height: 600px;
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
@@ -1,0 +1,49 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div class="modal d-block" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-xl" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" translate>Circulation history</h5>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="closeDialog()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body overflow-auto overflow-max-size">
+        <ng-container *ngIf="loadedRecord; else loaded">
+          <ul *ngIf="recordTotals > 0; else noRecord" class="list-unstyled mx-2 mb-0">
+            <li *ngFor="let record of records; let index = index" class="py-1" [ngClass]="{ 'bg-light': index % 2 }">
+              <admin-circulation-log [record]="record" (closeDialogEvent)="closeDialog()"></admin-circulation-log>
+            </li>
+          </ul>
+          <ng-container *ngIf="isLinkShowMore">
+            <button type="button" id="show-more-items-{{ resourcePid }}" class="btn btn-link pl-1" (click)="showMore()">
+              <i class="fa fa-arrow-circle-o-down"></i> {{ 'Show more' | translate }}
+            </button>
+            <small *ngIf="isLinkShowMore">({{ hiddenOperationLogs }})</small>
+          </ng-container>
+          <ng-template #noRecord>
+            {{ 'No history for this item' | translate }}
+          </ng-template>
+        </ng-container>
+        <ng-template #loaded>
+          {{ 'loading in progress' | translate }}
+        </ng-template>
+      </div>
+    </div>
+  </div>
+</div>

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.spec.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { CirculationLogsComponent } from './circulation-logs.component';
+
+
+describe('CirculationLogsComponent', () => {
+  let component: CirculationLogsComponent;
+  let fixture: ComponentFixture<CirculationLogsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CirculationLogsComponent ],
+      imports: [ HttpClientTestingModule, TranslateModule.forRoot() ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CirculationLogsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.ts
@@ -1,0 +1,117 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Record } from '@rero/ng-core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { OperationLogsApiService } from '../../api/operation-logs-api.service';
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
+
+@Component({
+  selector: 'admin-circulation-logs',
+  templateUrl: './circulation-logs.component.html',
+  styleUrls: ['./circulation-logs.component.css']
+})
+export class CirculationLogsComponent implements OnInit {
+
+  /** Resource pid */
+  @Input() resourcePid: string;
+
+  /** Current page */
+  page = 1;
+
+  /** items per pages */
+  itemsPerPage = 10;
+
+  /** Total of records */
+  recordTotals = 0;
+
+  /** Array of records */
+  records = [];
+
+  /** first loaded record */
+  loadedRecord = false;
+
+  /** Event on dialog close */
+  dialogClose$ = new BehaviorSubject(false);
+
+  /**
+   * Show more link is visible
+   * @return boolean
+   */
+  get isLinkShowMore(): boolean {
+    return this.recordTotals > 0
+      && ((this.page * this.itemsPerPage) < this.recordTotals);
+  }
+
+  /**
+   * Hidden holdings count
+   * @return string
+   */
+  get hiddenOperationLogs(): string {
+    let count = this.recordTotals - (this.page * this.itemsPerPage);
+    if (count < 0) { count = 0; }
+    const linkText = (count > 1)
+      ? _('{{ counter }} hidden circulations logs')
+      : _('{{ counter }} hidden circulations log');
+    return this._translateService.instant(linkText, { counter: count });
+  }
+
+  /**
+   * Constructor
+   * @param _operationLogsApiService - OperationLogsApiService
+   * @param _translateService - TranslateService
+   */
+  constructor(
+    private _operationLogsApiService: OperationLogsApiService,
+    private _translateService: TranslateService
+  ) {}
+
+  /** OnInit hook */
+  ngOnInit(): void {
+    this._circulationLogsQuery(1).subscribe((response: any) => {
+      this.recordTotals = response.total.value;
+      this.records = response.hits;
+      this.loadedRecord = true;
+    });
+  }
+
+  /** Close operation log dialog */
+  closeDialog(): void {
+    this.dialogClose$.next(true);
+  }
+
+  /** show more */
+  showMore(): void {
+    this.page++;
+    this._circulationLogsQuery(this.page)
+      .subscribe((response: any) => {
+        this.records = this.records.concat(response.hits);
+      });
+  }
+
+  /**
+   * Circulation logs query
+   * @param page - number
+   * @returns Obserable
+   */
+  private _circulationLogsQuery(page: number): Observable<any> {
+    return this._operationLogsApiService.getCirculationLogs(this.resourcePid, page, this.itemsPerPage)
+    .pipe(map((response: Record) =>  response.hits));
+  }
+}

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -277,4 +277,7 @@
     resourceType="items"
     [resourcePid]="record.metadata.pid"
   ></admin-operation-logs-dialog>
+
+    <!-- CIRCULATION LOGS -->
+  <admin-circulation-logs-dialog [resourcePid]="record.metadata.pid"></admin-circulation-logs-dialog>
 </ng-container>


### PR DESCRIPTION
* Displays the circulation history of the item on
the item detailed view of the professional interface.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Display

<img width="1233" alt="history" src="https://user-images.githubusercontent.com/48578/124078696-7d52a200-da48-11eb-9bf7-31dcba4930dd.png">

## How to test?

- Check `circulation history` on item

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
