### PR TITLE
documentation: extend gh-actions labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,7 @@ circulation:
   - projects/admin/src/app/record/item-availability/**/*
   - projects/shared/src/lib/class/item-status.ts
   - projects/admin/src/app/record/formly/type/cipo-patron-type-item-type/**/*
+  - projects/admin/src/app/record/circulation-logs/**/*
 
 "user management":
   - projects/admin/src/app/circulation/patron/**/*
@@ -52,6 +53,8 @@ documentation:
 
 activity-logs:
   - projects/admin/src/app/record/operation-logs/**/*
+  - projects/admin/src/app/api/operation*
+  - projects/admin/src/app/record/circulation-logs/**/*
 
 editor:
   - projects/admin/src/app/record/custom-editor/**/*


### PR DESCRIPTION
* Adds rules for activity-logs and circulation labels when updating
  files related to the item circulation history.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>

## Why are you opening this PR?

- To extend gh-actions labeler rules.

## How to test?

- See changed file. 

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
