### PR TITLE
documents: optimize holdings/items display

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -142,7 +142,7 @@
             "main": "projects/public-holdings-items/src/main.ts",
             "polyfills": "projects/public-holdings-items/src/polyfills.ts",
             "tsConfig": "projects/public-holdings-items/tsconfig.app.json",
-            "aot": false,
+            "aot": true,
             "assets": [],
             "styles": [],
             "scripts": []

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -15,42 +15,43 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container>
-  <div class="card mt-2">
-    <div class="card-header">
-      <div class="row">
-        <div class="col-sm-6">
-          <button class="btn btn-link" (click)="toggleCollapse()" aria-expanded="false" aria-controls="itemsList">
-            <i [ngClass]="{ 'fa-caret-down':!isItemsCollapsed, 'fa-caret-right': isItemsCollapsed }"
-               class="fa mr-1" aria-hidden="true"></i>
-          </button>
-          <admin-record-masked *ngIf="holding.metadata._masked" [record]="holding"></admin-record-masked>
-          <ng-container *ngIf="holding.metadata.location.pid | getRecord: 'locations' | async as location" class="col-sm-5">
-            {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}:
-            {{ location.metadata.name }}
-          </ng-container>
-        </div>
-        <div class="col-sm-2 mt-1">{{ holding.metadata.circulation_category.circulation_information | getTranslatedLabel : language }}</div>
-        <div *ngIf="holdingType === 'serial'" class="col-sm-4 text-right">
-          <!-- HOLDING VIEW -->
-          <button [routerLink]="['/', 'records', 'holdings', 'detail', holding.metadata.pid]"
-                  class="btn btn-outline-primary btn-sm ml-1">
-            <i class="fa fa-file-text-o"></i>
-          </button>
-          <!-- EDIT BUTTON -->
-          <button *ngIf="permissions && permissions.update && permissions.update.can"
-                  [routerLink]="['/', 'records', 'holdings', 'edit', holding.metadata.pid]"
-                  class="btn btn-outline-primary btn-sm ml-1">
-            <i class="fa fa-pencil"></i>
-          </button>
-          <!-- DELETE BUTTON -->
-          <button *ngIf="permissions && permissions.delete && permissions.delete.can; else deleteInfo" type="button"
-            class="btn btn-outline-danger btn-sm ml-1" (click)="delete()">
-            <i class="fa fa-trash"></i>
-          </button>
-        </div>
-        <admin-holding-detail *ngIf="holdingType === 'serial'" context="document" [holding]="holding" class="col-sm-12"></admin-holding-detail>
+  <div class="card container mt-2">
+    <div class="card-header row p-2">
+      <div class="col-sm-6">
+        <a href="#" (click)="toggleCollapse($event)"
+           class="collapse-link float-left h-100" data-toggle="collapse"
+           aria-expanded="false" aria-controls="itemsList">
+          <i [ngClass]="{ 'fa-caret-down':!isItemsCollapsed, 'fa-caret-right': isItemsCollapsed }"
+             class="fa fa-lg" aria-hidden="true"></i>
+        </a>
+        <admin-record-masked *ngIf="holding.metadata._masked" [record]="holding"></admin-record-masked>
+        <ng-container *ngIf="holding.metadata.location.pid | getRecord: 'locations' | async as location" class="col-sm-5">
+          {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}:
+          {{ location.metadata.name }}
+        </ng-container>
       </div>
-
+      <div class="col-sm-2 mt-1">
+        {{ holding.metadata.circulation_category.circulation_information | getTranslatedLabel : language }}
+      </div>
+      <div *ngIf="holdingType === 'serial'" class="col-sm-4 text-right">
+        <!-- HOLDING VIEW -->
+        <button [routerLink]="['/', 'records', 'holdings', 'detail', holding.metadata.pid]"
+                class="btn btn-outline-primary btn-sm ml-1">
+          <i class="fa fa-file-text-o"></i>
+        </button>
+        <!-- EDIT BUTTON -->
+        <button *ngIf="permissions && permissions.update && permissions.update.can"
+                [routerLink]="['/', 'records', 'holdings', 'edit', holding.metadata.pid]"
+                class="btn btn-outline-primary btn-sm ml-1">
+          <i class="fa fa-pencil"></i>
+        </button>
+        <!-- DELETE BUTTON -->
+        <button *ngIf="permissions && permissions.delete && permissions.delete.can; else deleteInfo" type="button"
+          class="btn btn-outline-danger btn-sm ml-1" (click)="delete()">
+          <i class="fa fa-trash"></i>
+        </button>
+      </div>
+      <admin-holding-detail *ngIf="holdingType === 'serial'" context="document" [holding]="holding" class="col-sm-12"></admin-holding-detail>
     </div>
     <div class="card-body" *ngIf="!isItemsCollapsed">
       <ng-container [ngSwitch]="holdingType">

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
@@ -26,7 +26,8 @@ import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'admin-document-holding',
-  templateUrl: './holding.component.html'
+  templateUrl: './holding.component.html',
+  styles: ['a.collapse-link i { min-width: 16px}']
 })
 export class HoldingComponent implements OnInit, OnDestroy {
 
@@ -35,6 +36,8 @@ export class HoldingComponent implements OnInit, OnDestroy {
   @Input() holding: any;
   /** Event for delete holding */
   @Output() deleteHolding = new EventEmitter();
+  /** Items collapsed */
+  @Input() isItemsCollapsed = true;
 
   /** shortcut for holding type */
   holdingType: 'electronic' | 'serial' | 'standard';
@@ -42,15 +45,14 @@ export class HoldingComponent implements OnInit, OnDestroy {
   items: any = null;
   /** Items observable reference */
   itemsRef: any;
-  /** Items collapsed */
-  isItemsCollapsed = false;
   /** Holding permissions */
   permissions: RecordPermission;
   /** total number of items for this holding */
   totalItemsCounter = 0;
   /** number of item to load/display */
-  displayItemsCounter = 5;
+  displayItemsCounter = 10;
 
+  // GETTER & SETTER ==========================================================
   /** Current interface language */
   get language() {
     return this._translateService.currentLang;
@@ -121,7 +123,8 @@ export class HoldingComponent implements OnInit, OnDestroy {
 
   // COMPONENT FUNCTIONS ======================================================
   /** Reload items when they are displayed. */
-  toggleCollapse() {
+  toggleCollapse(event: Event) {
+    event.preventDefault();
     if (this.isItemsCollapsed) {
       this._loadItems();
     }

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
@@ -54,10 +54,14 @@
 </div>
 
 <ng-container *ngIf="holdings">
-  <admin-document-holding *ngFor="let holding of holdings" [holding]="holding" (deleteHolding)="deleteHolding($event)">
+  <admin-document-holding *ngFor="let holding of holdings"
+                          [holding]="holding"
+                          [isItemsCollapsed]="holdingsTotal > 1"
+                          (deleteHolding)="deleteHolding($event)"
+  >
   </admin-document-holding>
   <ng-container *ngIf="isLinkShowMore">
-    <button type="button" id="show-more-{{ document.metadata.pid }}" class="btn btn-link" (click)="showMore()">
+    <button class="btn btn-link" (click)="showMore()">
       <i class="fa fa-arrow-circle-o-down"></i>
         {{ 'Show more' | translate }}
     </button>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
@@ -29,32 +29,30 @@ import { RecordPermissionService } from '../../../../service/record-permission.s
   templateUrl: './holdings.component.html'
 })
 export class HoldingsComponent implements OnInit {
+
+  // COMPONENT ATTRIBUTES =====================================================
   /** Document */
   @Input() document: any;
-
-  /** Holdings total */
-  holdingsTotal = 0;
-
-  /** Holdings per page */
-  private holdingsPerPage = 5;
-
-  /** Current page */
-  page = 1;
-
-  /** query */
-  query: string;
-
-  /** Holdings */
-  holdings: any[];
-
   /** Holding type related to the parent document. */
   @Input() holdingType: 'electronic' | 'serial' | 'standard';
 
+  /** Holdings total */
+  holdingsTotal = 0;
+  /** Current page */
+  page = 1;
+  /** query */
+  query: string;
+  /** Holdings */
+  holdings: any[];
   /** Can a new holding be added? */
   canAdd = false;
 
+  /** Holdings per page */
+  private holdingsPerPage = 10;
+
+  // GETTER & SETTER ==========================================================
   /**
-   * Is link show more
+   * Is the link `show more holdings` must be displayed.
    * @return boolean
    */
   get isLinkShowMore(): boolean {
@@ -78,6 +76,7 @@ export class HoldingsComponent implements OnInit {
     return linkTextTranslate.replace('{{ counter }}', count);
   }
 
+  // CONSTRUCTOR & HOOKS ======================================================
   /**
    * Constructor
    * @param _userService - UserService
@@ -112,7 +111,8 @@ export class HoldingsComponent implements OnInit {
       });
   }
 
-  /** Show more */
+  // COMPONENT FUNCTIONS ======================================================
+  /** Handler when `show more` ink is clicked */
   showMore() {
     this.page++;
     this._holdingsQuery(this.page, this.query).subscribe((holdings: any[]) => {

--- a/projects/public-holdings-items/src/index.html
+++ b/projects/public-holdings-items/src/index.html
@@ -37,18 +37,11 @@
     />
   </head>
   <body class="d-flex flex-column">
-    <container>
-      <div class="align-self-center justify-content-between ml-5 mb-5">
-        <div class="row col">
-          <h4 class="col">Document holdings items</h4>
-        </div>
-        <div class="row col">
-          <public-search-holdings
-            documentpid="2000017"
-            viewcode="global"
-          ></public-search-holdings>
-        </div>
+    <div class="container">
+      <div class="align-self-center justify-content-between row">
+        <h4 class="col-12">Document holdings items</h4>
+        <public-search-holdings documentpid="2000017" viewcode="global" class="col-12"></public-search-holdings>
       </div>
-    </container>
+    </div>
   </body>
 </html>

--- a/projects/public-search/src/app/api/item-api.service.ts
+++ b/projects/public-search/src/app/api/item-api.service.ts
@@ -78,7 +78,7 @@ export class ItemApiService extends BaseApi {
   /**
    * Item request
    * @param data - Object
-   * @return Obserable
+   * @return Observable
    */
   request(data: { item_pid: string, pickup_location_pid: string }): Observable<any> {
     return this._httpClient.post('/api/item/patron_request', data);

--- a/projects/public-search/src/app/api/location-api.service.spec.ts
+++ b/projects/public-search/src/app/api/location-api.service.spec.ts
@@ -57,7 +57,7 @@ describe('LocationService', () => {
 
   it('should a set of pickup locations', () => {
     service.getPickupLocationsByItemId('1').subscribe(response => {
-      expect(response).toBeTruthy(locationsResponse);
+      expect(response).toEqual(locationsResponse);
     });
   });
 });

--- a/projects/public-search/src/app/api/patron-transaction-api.service.spec.ts
+++ b/projects/public-search/src/app/api/patron-transaction-api.service.spec.ts
@@ -69,7 +69,7 @@ describe('PatronTranslationApiService', () => {
 
   it('should load the fees', () => {
     service.getFees('1', 'open', 1).subscribe((response: any) => {
-      expect(response).toBeTruthy(apiResponse);
+      expect(response).toEqual(apiResponse);
     });
   });
 });

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
@@ -14,11 +14,15 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div id="holding-{{ holding.metadata.pid }}" class="card-header p-2">
+<div class="card-header p-2">
   <div class="row">
     <div id="holding-location-{{ holding.metadata.pid }}" class="col-sm-4">
-      <a href="#" class="collapse-link mr-2" data-toggle="collapse" aria-expanded="false" (click)="isCollapsed = !isCollapsed">
-        <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }" [hidden]="itemsCount==0" class="fa fa-lg" aria-hidden="true"></i>
+      <a href="#" class="collapse-link float-left h-100" data-toggle="collapse" aria-expanded="false"
+         (click)="$event.preventDefault(); isCollapsed = !isCollapsed">
+        <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }"
+           [hidden]="itemsCount==0"
+           class="fa fa-lg" aria-hidden="true">
+        </i>
       </a>
       {{ holding.metadata.library.name }}: {{ holding.metadata.location.name }}
     </div>
@@ -38,10 +42,9 @@
           {{ 'see collections and items' | translate }}
         </ng-container>
         <ng-template #available>
-          <i
-            class="fa fa-circle"
-            [ngClass]="{'text-success': holding.metadata.available, 'text-danger': !holding.metadata.available }"
-          ></i>
+          <i class="fa fa-circle"
+             [ngClass]="{'text-success': holding.metadata.available, 'text-danger': !holding.metadata.available }">
+          </i>
           {{ (holding.metadata.available ? 'available' : 'not available') | translate }}
         </ng-template>
       </span>
@@ -92,12 +95,6 @@
     </div>
   </div>
 </div>
-<div
-  id="holding-{{ holding.metadata.pid }}"
-  class="collapse show"
-  [hidden]="isCollapsed"
->
-  <div class="card-body p-2">
-    <public-search-items [holding]="holding" [viewcode]="viewcode" (eItemsCount)="eItemsCount($event)"></public-search-items>
-  </div>
+<div class="card-body p-2" [hidden]="isCollapsed">
+  <public-search-items [holding]="holding" [viewcode]="viewcode" (eItemsCount)="eItemsCount($event)"></public-search-items>
 </div>

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.spec.ts
@@ -37,7 +37,9 @@ describe('HoldingComponent', () => {
         name: 'location name'
       },
       circulation_category: {
-        name: 'default'
+        circulation_information: [
+          { label: 'default', language: 'en'}
+        ]
       },
       holdings_type: 'serial',
       available: true,
@@ -81,34 +83,32 @@ describe('HoldingComponent', () => {
 
   it('should display all data into the template', () => {
     let data = fixture.nativeElement.querySelector('#holding-location-1');
-    expect(data.textContent).toBeTruthy('library name: location name');
+    expect(data.textContent).toContain('library name: location name');
 
     data = fixture.nativeElement.querySelector('#holding-category-name-1');
-    expect(data.textContent).toBeTruthy('default');
-
-    data = fixture.nativeElement.querySelector('#holding-category-name-1');
-    expect(data.textContent).toBeTruthy('default');
+    expect(data.textContent).toContain('default');
 
     component.isCollapsed = true;
     data = fixture.nativeElement.querySelector('#holding-available-1');
-    expect(data.textContent).toBeTruthy('see collections and items');
+    expect(data.textContent).toContain('see collections and items');
 
     data = fixture.nativeElement.querySelector('#holding-call-number-1');
-    expect(data.textContent).toBeTruthy('F123456 | S123456');
+    expect(data.textContent).toContain('F123456');
+    expect(data.textContent).toContain('S123456');
 
     data = fixture.nativeElement.querySelector('#holding-enum-chro-1');
-    expect(data.textContent).toBeTruthy('enum and chro');
+    expect(data.textContent).toContain('enum and chro');
 
     data = fixture.nativeElement.querySelector('#holding-sup-content-1');
-    expect(data.textContent).toBeTruthy('sup content');
+    expect(data.textContent).toContain('sup content');
 
     data = fixture.nativeElement.querySelector('#holding-index-1');
-    expect(data.textContent).toBeTruthy('record index');
+    expect(data.textContent).toContain('record index');
 
     data = fixture.nativeElement.querySelector('#holding-missing-issues-1');
-    expect(data.textContent).toBeTruthy('missing');
+    expect(data.textContent).toContain('missing');
 
     data = fixture.nativeElement.querySelector('#holding-note-1');
-    expect(data.textContent).toBeTruthy('public note');
+    expect(data.textContent).toContain('public note');
   });
 });

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
@@ -19,38 +19,42 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'public-search-holding',
-  templateUrl: './holding.component.html'
+  templateUrl: './holding.component.html',
+  styles: ['a.collapse-link i { min-width: 16px}']
 })
 export class HoldingComponent {
 
+  // COMPONENT ATTRIBUTES =====================================================
   /** Holdings record */
   @Input() holding: any;
   /** View code */
   @Input() viewcode: string;
-
   /** Is collapsed holdings */
-  isCollapsed = false;
+  @Input() isCollapsed = true;
+
   /** Items count */
   itemsCount = 0;
   /** Authorized types of note */
-  noteAuthorizedTypes: string[] = [
-    'general_note'
-  ];
+  noteAuthorizedTypes: string[] = ['general_note'];
 
+  // GETTER & SETTER ==========================================================
   /** Current interface language */
   get language() {
     return this._translateService.currentLang;
   }
 
+  // CONSTRUCTOR & HOOKS ======================================================
   /**
    * Constructor
    * @param _translateService - TranslateService
    */
   constructor(private _translateService: TranslateService) {}
 
+
+  // COMPONENT FUNCTIONS ======================================================
   /**
-   * Event items count
-   * @param event - number
+   * Handler to manage event items count emitter
+   * @param event - number : the number of items for this holding
    */
   eItemsCount(event: number): void {
     this.itemsCount = event;

--- a/projects/public-search/src/app/document-detail/holdings/holdings.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holdings.component.html
@@ -16,11 +16,15 @@
 -->
 <ngx-loading-bar [includeSpinner]="false" height="3px"></ngx-loading-bar>
 <ng-container *ngIf="holdings.length > 0">
-  <div class="card mt-2" *ngFor="let holding of holdings">
-    <public-search-holding [holding]="holding" [viewcode]="viewcode"></public-search-holding>
-  </div>
+  <public-search-holding *ngFor="let holding of holdings"
+                         [holding]="holding"
+                         [viewcode]="viewcode"
+                         [isCollapsed]="holdingsTotal > 1"
+                         [attr.id]="holding.metadata.pid | idAttribute : {prefix: 'holding'}"
+                         class="card mt-2 w-100">
+  </public-search-holding>
   <ng-container *ngIf="isLinkShowMore">
-    <button type="button" id="show-more-{{ documentpid }}" class="btn btn-link pr-1" (click)="showMore()">
+    <button class="btn btn-link p-0 pr-1 show-more-holdings" (click)="showMore($event)">
       <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
     </button>
     <small>({{ hiddenHoldings }})</small>

--- a/projects/public-search/src/app/document-detail/holdings/holdings.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holdings.component.spec.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoadingBarModule } from '@ngx-loading-bar/core';
@@ -22,6 +23,7 @@ import { CoreModule } from '@rero/ng-core';
 import { of } from 'rxjs';
 import { HoldingsApiService } from '../../api/holdings-api.service';
 import { QueryResponse } from '../../record';
+import { IdAttributePipe, SharedModule } from '@rero/shared';
 import { HoldingsComponent } from './holdings.component';
 
 
@@ -34,9 +36,11 @@ describe('HoldingsComponent', () => {
       value: 10,
       relation: 'eq'
     },
-    hits: [
-      { pid: 1 }
-    ]
+    hits: [{
+      metadata: {
+        pid: 1
+      }
+    }]
   };
 
   const recordServiceSpy = jasmine.createSpyObj('HoldingsService', [
@@ -49,10 +53,13 @@ describe('HoldingsComponent', () => {
       imports: [
         TranslateModule.forRoot(),
         LoadingBarModule,
-        CoreModule
+        HttpClientTestingModule,
+        CoreModule,
+        SharedModule
       ],
       declarations: [ HoldingsComponent ],
       providers: [
+        IdAttributePipe,
         { provide: HoldingsApiService, useValue: recordServiceSpy }
       ],
       schemas: [
@@ -74,16 +81,16 @@ describe('HoldingsComponent', () => {
   });
 
   it('should display the link more holdings', () => {
-    component.holdingsTotal = 10;
+    component.holdingsTotal = 20;
     fixture.detectChanges();
-    const showMore = fixture.nativeElement.querySelector('#show-more-1');
+    const showMore = fixture.nativeElement.querySelector('.show-more-holdings');
     expect(showMore.textContent.trim()).toEqual('Show more');
   });
 
   it('should don\'t display the link more holdings', () => {
     component.holdingsTotal = 4;
     fixture.detectChanges();
-    const showMore = fixture.nativeElement.querySelector('#show-more-1');
+    const showMore = fixture.nativeElement.querySelector('.show-more-holdings');
     expect(showMore).toBeNull();
   });
 });

--- a/projects/public-search/src/app/document-detail/holdings/holdings.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holdings.component.ts
@@ -28,41 +28,39 @@ import { QueryResponse } from '../../record';
 })
 export class HoldingsComponent implements OnInit {
 
+  // COMPONENTS ATTRIBUTES ====================================================
   /** View code */
   @Input() viewcode: string;
-
   /** Document pid */
   @Input() documentpid: string;
 
   /** Holdings total */
   holdingsTotal = 0;
-
-  /** Holdings per page */
-  private holdingsPerPage = 4;
-
   /** Current page */
   page = 1;
-
   /** Holdings records */
   holdings = [];
 
+  /** Holdings per page */
+  private holdingsPerPage = 10;
+
+  // GETTER & SETTER ==========================================================
   /**
-   * Is link show more
+   * Is the link `show more holdings` must be displayed
    * @return boolean
    */
   get isLinkShowMore() {
-    return this.holdingsTotal > 0
-      && ((this.page * this.holdingsPerPage) < this.holdingsTotal);
+    return this.holdingsTotal > 0 && ((this.page * this.holdingsPerPage) < this.holdingsTotal);
   }
 
   /**
-   * Hidden holdings count
+   * Get the string to use when some holdings are still hidden
    * @return string
    */
   get hiddenHoldings(): string {
-    let count = this.holdingsTotal - (this.page * this.holdingsPerPage);
-    if (count < 0) {
-      count = 0;
+    const count = this.holdingsTotal - (this.page * this.holdingsPerPage);
+    if (count <= 0) {
+      return '';
     }
     const linkText = (count > 1)
       ? _('{{ counter }} hidden holdings')
@@ -70,6 +68,7 @@ export class HoldingsComponent implements OnInit {
     return this._translateService.instant(linkText, { counter: count });
   }
 
+  // CONSTRUCTOR & HOOKS ======================================================
   /**
    * Constructor
    * @param _holdingsApiService - HoldingsApiService
@@ -86,18 +85,18 @@ export class HoldingsComponent implements OnInit {
   ngOnInit(): void {
     // Set view code to app settings
     this._appSettingsService.currentViewCode = this.viewcode;
-    this._HoldingsQuery(1).subscribe((response: QueryResponse) => {
+    this._holdingsQuery(1).subscribe((response: QueryResponse) => {
       this.holdingsTotal = response.total.value;
       this.holdings = response.hits;
     });
   }
 
-  /** Show more */
-  showMore() {
+  // COMPONENT FUNCTIONS ======================================================
+  /** Handler when 'show more holdings' link is clicked. */
+  showMore(event: Event) {
+    event.preventDefault();  // Doesn't follow any `href` link
     this.page++;
-    this._HoldingsQuery(this.page).subscribe((response: QueryResponse) => {
-      this.holdings = this.holdings.concat(response.hits);
-    });
+    this._holdingsQuery(this.page).subscribe((response: QueryResponse) => this.holdings = this.holdings.concat(response.hits));
   }
 
   /**
@@ -105,7 +104,7 @@ export class HoldingsComponent implements OnInit {
    * @param page - number
    * @return Observable
    */
-  private _HoldingsQuery(page: number): Observable<QueryResponse> {
+  private _holdingsQuery(page: number): Observable<QueryResponse> {
     return this._holdingsApiService
       .getHoldingsByDocumentPidAndViewcode(this.documentpid, this.viewcode, page, this.holdingsPerPage);
   }

--- a/projects/public-search/src/app/document-detail/holdings/items/items.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/items/items.component.html
@@ -15,18 +15,23 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="items.length > 0; else noItems">
-  <ng-container *ngFor="let item of items; let index = index">
-    <public-search-item context="holding" [item]="item" [viewcode]="viewcode" [index]="index"></public-search-item>
-  </ng-container>
+  <public-search-item *ngFor="let item of items; let index = index"
+                      context="holding"
+                      [item]="item"
+                      [viewcode]="viewcode"
+                      [index]="index">
+
+  </public-search-item>
   <ng-container *ngIf="isLinkShowMore">
-    <button type="button" id="show-more-{{ holding.metadata.pid }}" class="btn btn-link pr-1" (click)="showMore()">
+    <button type="button" class="btn btn-link pr-1" (click)="showMore()">
       <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
     </button>
     <small>({{ hiddenItems }})</small>
   </ng-container>
 </ng-container>
+
 <ng-template #noItems>
   <div class="row">
-    <div class="ml-2 col-sm-11" translate>No item received.</div>
+    <div class="col-12 pl-2" translate>No item received.</div>
   </div>
 </ng-template>

--- a/projects/public-search/src/app/document-detail/holdings/items/items.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/items/items.component.ts
@@ -27,7 +27,7 @@ import { QueryResponse } from '../../../record';
 })
 export class ItemsComponent implements OnInit {
 
-  // COMPONENT ATTRIBUTE ====================================================
+  // COMPONENT ATTRIBUTES =====================================================
   /** Holding */
   @Input() holding: any;
   /** View code */
@@ -43,27 +43,26 @@ export class ItemsComponent implements OnInit {
   items = [];
 
   /** Items per page */
-  private itemsPerPage = 4;
+  private itemsPerPage = 10;
 
 
   // GETTER & SETTER ========================================================
   /**
-   * Is link show more
+   * Is the link `show more items` must be displayed
    * @return boolean
    */
   get isLinkShowMore() {
-    return this.itemsTotal > 0
-      && ((this.page * this.itemsPerPage) < this.itemsTotal);
+    return this.itemsTotal > 0 && ((this.page * this.itemsPerPage) < this.itemsTotal);
   }
 
   /**
-   * Hidden items count
+   * Get the string to use when some items are still hidden.
    * @return string
    */
   get hiddenItems(): string {
-    let count = this.itemsTotal - (this.page * this.itemsPerPage);
-    if (count < 0) {
-      count = 0;
+    const count = this.itemsTotal - (this.page * this.itemsPerPage);
+    if (count <= 0) {
+      return '';
     }
     const linkText = (count > 1)
       ? _('{{ counter }} hidden items')
@@ -93,7 +92,7 @@ export class ItemsComponent implements OnInit {
   }
 
   // COMPONENT FUNCTIONS ==================================================
-  /** Show more */
+  /** Handler when 'show more items' link is clicked. */
   showMore() {
     this.page++;
     this._ItemsQuery(this.page).subscribe((response: QueryResponse) => {
@@ -102,7 +101,7 @@ export class ItemsComponent implements OnInit {
   }
 
   /**
-   * Return a selected items by page number
+   * Return selected items by page number
    * @param page - number
    * @return Observable
    */

--- a/projects/public-search/src/app/document-detail/item/item.component.html
+++ b/projects/public-search/src/app/document-detail/item/item.component.html
@@ -14,86 +14,93 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div id="item-detail-{{ item.metadata.pid }}" class="row pl-4 py-2 mx-1" [class]="{'bg-light': index % 2 === 0}">
-  <!-- LIBRARY AND LOCATION -->
-  <ng-container *ngIf="context === 'book'">
-    <dt class="mb-0 col-lg-2 col-sm-3" translate>Location</dt>
-    <dd id="item-location-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">
-      {{ item.metadata.library.name }}:
-      {{ item.metadata.location.name }}
+<div [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-detail'}"
+     class="mx-1"
+     [class]="{'bg-light': index % 2 === 0}">
+  <dl class="m-0 ml-4 py-2 row">
+    <!-- LIBRARY AND LOCATION -->
+    <ng-container *ngIf="context === 'book'">
+      <dt class="mb-0 col-lg-2 col-sm-3" translate>Location</dt>
+      <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-location'}" class="mb-0 col-lg-10 col-sm-9">
+        {{ item.metadata.library.name }}: {{ item.metadata.location.name }}
+      </dd>
+    </ng-container>
+    <!-- CALL NUMBER -->
+    <ng-container *ngIf="item.metadata.call_number">
+      <dt class="mb-0 col-lg-2 col-sm-3" translate>Call number</dt>
+      <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-call-number'}" class="mb-0 col-lg-10 col-sm-9">
+        {{ item.metadata.call_number }}
+        <ng-container *ngIf="item.metadata.second_call_number">
+          | {{ item.metadata.second_call_number }}
+        </ng-container>
+      </dd>
+    </ng-container>
+    <!-- ITEM IN COLLECTION -->
+    <ng-container *ngIf="item.metadata.in_collection; else temporaryLocation">
+      <dt class="mb-0 col-lg-2 col-sm-3" translate>Temporary location</dt>
+      <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-location-temporary'}" class="mb-0 col-lg-10 col-sm-9">
+        <ng-container *ngFor="let collection of item.metadata.in_collection; let last = last">
+          <a [routerLink]="[collection.viewcode, 'collections', collection.pid]">{{ collection.title }}</a>
+          {{ last ? '' : '; ' }}
+        </ng-container>
+      </dd>
+    </ng-container>
+    <!-- ITEM TEMPORARY LOCATION -->
+    <ng-template #temporaryLocation>
+      <ng-container *ngIf="item.metadata.temporary_location">
+        <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>Temporary location</dt>
+        <dd class="mb-0 col-lg-10 col-sm-9">{{ item.metadata.temporary_location.name }}</dd>
+      </ng-container>
+    </ng-template>
+    <!-- ENUMERATION AND CHRONOLOGY -->
+    <ng-container *ngIf="item.metadata.enumerationAndChronology">
+      <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>Unit</dt>
+      <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-enum-chrono'}" class="mb-0 col-lg-10 col-sm-9">
+        {{ item.metadata.enumerationAndChronology }}
+      </dd>
+    </ng-container>
+    <!-- BARCODE -->
+    <dt class="mb-0 col-lg-2 col-sm-3" translate>Barcode</dt>
+    <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-barcode'}" class="mb-0 col-lg-10 col-sm-9">
+      {{ item.metadata.barcode }}
     </dd>
-  </ng-container>
-  <!-- CALL NUMBER -->
-  <ng-container *ngIf="item.metadata.call_number">
-    <dt class="mb-0 col-lg-2 col-sm-3" translate>Call number</dt>
-    <dd id="item-call-number-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">
-      {{ item.metadata.call_number }}
-      <ng-container *ngIf="item.metadata.second_call_number">
-        | {{ item.metadata.second_call_number }}
+    <!-- NOTES -->
+    <ng-container *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
+      <ng-container *ngFor="let note of item.metadata.notes | notesFilter : noteAuthorizedTypes">
+        <dt class="mb-0 col-lg-2 col-sm-3">{{ note.type | translate }}</dt>
+        <dd class="mb-0 col-lg-10 col-sm-9" [innerHTML]="note.content | nl2br"></dd>
+      </ng-container>
+    </ng-container>
+    <!-- URL -->
+    <ng-container *ngIf="item.metadata.url">
+      <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>URL</dt>
+      <dd class="mb-0 col-lg-10 col-sm-9">
+        <a href="{{ item.metadata.url }}">{{ item.metadata.url }}</a>
+      </dd>
+    </ng-container>
+    <!-- STATUS -->
+    <dt class="mb-0 col-lg-2 col-sm-3" translate>Status</dt>
+    <dd [attr.id]="item.metadata.pid | idAttribute : {prefix: 'item-status'}" class="mb-0 col-lg-10 col-sm-9">
+      <i class="mr-1 fa fa-circle"
+         [ngClass]="{
+            'text-success': item.metadata.availability.available,
+            'text-danger': !item.metadata.availability.available
+         }"></i>
+      <ng-container [ngSwitch]="item.metadata.status">
+        <span *ngSwitchCase="'on_loan'">
+          {{ 'due until' | translate }}
+          {{ item.metadata.availability.due_date | dateTranslate :'shortDate' }}
+        </span>
+        <span *ngSwitchDefault>
+          {{ item.metadata.availability.display_text | getTranslatedLabel : language }}
+        </span>
+      </ng-container>
+      <ng-container *ngIf="item.metadata.availability.request > 0">
+        ({{ item.metadata.availability.request }} {{ (item.metadata.availability.request > 1 ? 'requests' : 'request') | translate }})
       </ng-container>
     </dd>
-  </ng-container>
-  <!-- ITEM IN COLLECTION -->
-  <ng-container *ngIf="item.metadata.in_collection; else temporaryLocation">
-    <dt class="mb-0 col-lg-2 col-sm-3" translate>Temporary location</dt>
-    <dd id="item-location-temporary-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">
-      <ng-container *ngFor="let collection of item.metadata.in_collection; let last = last">
-        <a href="/{{ collection.viewcode }}/collections/{{ collection.pid }}">{{ collection.title }}</a>
-        {{ last ? '' : '; ' }}
-      </ng-container>
-    </dd>
-  </ng-container>
-  <!-- ITEM TEMPORARY LOCATION -->
-  <ng-template #temporaryLocation>
-    <ng-container *ngIf="item.metadata.temporary_location">
-      <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>Temporary location</dt>
-      <dd class="mb-0 col-lg-9 col-sm-8">{{ item.metadata.temporary_location.name }}</dd>
-    </ng-container>
-  </ng-template>
-  <!-- ENUMERATION AND CHRONOLOGY -->
-  <ng-container *ngIf="item.metadata.enumerationAndChronology">
-    <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>Unit</dt>
-    <dd id="item-enum-chrono-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">{{ item.metadata.enumerationAndChronology }}</dd>
-  </ng-container>
-  <!-- BARCODE -->
-  <dt class="mb-0 col-lg-2 col-sm-3" translate>Barcode</dt>
-  <dd id="item-barcode-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">{{ item.metadata.barcode }}</dd>
-  <!-- NOTES -->
-  <ng-container *ngIf="item.metadata.notes && item.metadata.notes.length > 0">
-    <ng-container *ngFor="let note of item.metadata.notes | notesFilter : noteAuthorizedTypes">
-      <dt class="mb-0 col-lg-2 col-sm-3">{{ note.type | translate }}</dt>
-      <dd class="mb-0 col-lg-9 col-sm-8" [innerHTML]="note.content | nl2br"></dd>
-    </ng-container>
-  </ng-container>
-  <!-- URL -->
-  <ng-container *ngIf="item.metadata.url">
-    <dt class="mb-0 col-lg-2 col-sm-3 label-title" translate>URL</dt>
-    <dd class="mb-0 col-lg-9 col-sm-8">
-      <a href="{{ item.metadata.url }}">{{ item.metadata.url }}</a>
-    </dd>
-  </ng-container>
-  <!-- STATUS -->
-  <dt class="mb-0 col-lg-2 col-sm-3" translate>Status</dt>
-  <dd id="item-status-{{ item.metadata.pid }}" class="mb-0 col-lg-9 col-sm-8">
-    <i class="mr-1 fa fa-circle"
-       [ngClass]="{
-          'text-success': item.metadata.availability.available,
-          'text-danger': !item.metadata.availability.available
-       }"></i>
-    <ng-container [ngSwitch]="item.metadata.status">
-      <span *ngSwitchCase="'on_loan'">
-        {{ 'due until' | translate }}
-        {{ item.metadata.availability.due_date | dateTranslate :'shortDate' }}
-      </span>
-      <span *ngSwitchDefault>
-        {{ item.metadata.availability.display_text | getTranslatedLabel : language }}
-      </span>
-    </ng-container>
-    <ng-container *ngIf="item.metadata.availability.request > 0">
-      ({{ item.metadata.availability.request }} {{ (item.metadata.availability.request > 1 ? 'requests' : 'request') | translate }})
-    </ng-container>
-  </dd>
+  </dl>
 
   <!-- REQUEST DIALOG -->
-  <public-search-request [item]="item" [viewcode]="viewcode" class="col-11"></public-search-request>
+  <public-search-request [item]="item" [viewcode]="viewcode" class="col-12"></public-search-request>
 </div>

--- a/projects/public-search/src/app/document-detail/item/item.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/item/item.component.spec.ts
@@ -14,11 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { DateTranslatePipe, Nl2brPipe } from '@rero/ng-core';
 import { BsLocaleService } from 'ngx-bootstrap/datepicker';
+import { IdAttributePipe, SharedModule} from '@rero/shared';
 import { NotesFilterPipe } from '../../pipe/notes-filter.pipe';
 import { ItemComponent } from './item.component';
 
@@ -63,7 +65,9 @@ describe('ItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        SharedModule,
+        HttpClientTestingModule
       ],
       declarations: [
         ItemComponent,
@@ -72,6 +76,7 @@ describe('ItemComponent', () => {
         DateTranslatePipe
       ],
       providers: [
+        IdAttributePipe,
         BsLocaleService
       ],
       schemas: [
@@ -95,24 +100,25 @@ describe('ItemComponent', () => {
 
   it('should display all data into the template', () => {
     let data = fixture.nativeElement.querySelector('#item-location-1');
-    expect(data.textContent).toBeTruthy('library name: location name');
+    expect(data.textContent).toContain('library name: location name');
 
     data = fixture.nativeElement.querySelector('#item-call-number-1');
-    expect(data.textContent).toBeTruthy('F123456');
+    expect(data.textContent).toContain('F123456');
 
     data = fixture.nativeElement.querySelector('#item-call-number-1');
-    expect(data.textContent).toBeTruthy('F123456');
+    expect(data.textContent).toContain('F123456');
 
     data = fixture.nativeElement.querySelector('#item-location-temporary-1');
-    expect(data.textContent).toBeTruthy('collection');
+    expect(data.textContent).toContain('collection');
 
     data = fixture.nativeElement.querySelector('#item-enum-chrono-1');
-    expect(data.textContent).toBeTruthy('enum and chro');
+    expect(data.textContent).toContain('enum and chro');
 
     data = fixture.nativeElement.querySelector('#item-barcode-1');
-    expect(data.textContent).toBeTruthy('B12222');
+    expect(data.textContent).toContain('B12222');
 
     data = fixture.nativeElement.querySelector('#item-status-1');
-    expect(data.textContent).toBeTruthy('due until 2/1/21 (2 requests)');
+    expect(data.textContent).toContain('due until 2/1/21');
+    expect(data.textContent).toContain('(2 requests)');
   });
 });

--- a/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.spec.ts
@@ -89,7 +89,7 @@ describe('PickupLocationComponent', () => {
   });
 
   it('should have the request button', () => {
-    const pickup = fixture.nativeElement.querySelector('#pickup-location-1');
-    expect(pickup.textContent).toBeTruthy('Request');
+    const pickup = fixture.nativeElement.querySelector('#pickup-location-1-confirm-button');
+    expect(pickup.textContent).toBeTruthy();
   });
 });

--- a/projects/public-search/src/app/document-detail/request/request.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/request/request.component.spec.ts
@@ -81,6 +81,6 @@ describe('RequestComponent', () => {
   it('should have the request button', () => {
     const id = `#item-${itemRecord.metadata.pid}-request-button`;
     const showMore = fixture.nativeElement.querySelector(id);
-    expect(showMore.textContent).toBeTruthy('Request');
+    expect(showMore.textContent).toContain('Request');
   });
 });


### PR DESCRIPTION
* Loads/displays more holding by default (10). Collapse holdings panels if
  there are more than 1 holdings to display.
* Loads/displays more items by default (10).
* Fixes linting of `public-search` project.
* Harmonizes public/professional document view.
* Closes rero/rero-ils#2134.
* Closes rero/rero-ils#2133.
* Closes rero/rero-ils#2172.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
