### PR TITLE
users: close modal by clicking outside the form

### DIFF
--- a/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
+++ b/projects/admin/src/app/record/custom-editor/user-id-editor/user-id-editor.component.ts
@@ -85,7 +85,7 @@ export class UserIdEditorComponent implements OnInit {
             this.fields = [
               this._formlyJsonschema.toFieldConfig(orderedJsonSchema(schema.schema), {
 
-                // post process JSONSChema7 to FormlyFieldConfig conversion
+                // post process JSONSchema7 to FormlyFieldConfig conversion
                 map: (field: FormlyFieldConfig, jsonSchema: JSONSchema7) => {
                   // selection option i.e. countries
                   if (jsonSchema.form && jsonSchema.form.options) {

--- a/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
+++ b/projects/admin/src/app/record/editor/wrappers/user-id/user-id.component.ts
@@ -65,6 +65,7 @@ export class UserIdComponent extends FieldWrapper implements OnInit {
       UserIdEditorComponent,
       {
         class: 'modal-lg',
+        ignoreBackdropClick: true,
         initialState: { userID: this.formControl.value }
       });
     this.user$ = this.modalRef.onHidden.pipe(


### PR DESCRIPTION
Closes rero/rero-ils#2098.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Edit the user information about a patron. This will use the modal user form.
- Try to click outside of the modal. The modal should not closed.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
