### PR TITLE
document: dynamic loading for items informations

### DIFF
--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
@@ -20,7 +20,7 @@
       <a href="#" class="collapse-link float-left h-100" data-toggle="collapse" aria-expanded="false"
          (click)="$event.preventDefault(); isCollapsed = !isCollapsed">
         <i [ngClass]="{ 'fa-caret-down': !isCollapsed, 'fa-caret-right': isCollapsed }"
-           [hidden]="itemsCount==0"
+           [hidden]="holding.metadata.items_count === 0"
            class="fa fa-lg" aria-hidden="true">
         </i>
       </a>
@@ -30,9 +30,9 @@
       {{ holding.metadata.circulation_category.circulation_information | getTranslatedLabel : language }}
     </div>
     <div class="col-sm-2">
-      <span [hidden]="itemsCount == 0">
-        {{ itemsCount }}
-        {{ itemsCount | i18nPlural: { '=0': 'item', '=1': 'item', 'other': 'items' } | translate }}
+      <span [hidden]="holding.metadata.items_count === 0">
+        {{ holding.metadata.items_count }}
+        {{ holding.metadata.items_count | i18nPlural: { '=0': 'item', '=1': 'item', 'other': 'items' } | translate }}
       </span>
     </div>
     <div id="holding-available-{{ holding.metadata.pid }}" class="col-sm-3">
@@ -95,6 +95,7 @@
     </div>
   </div>
 </div>
-<div class="card-body p-2" [hidden]="isCollapsed">
-  <public-search-items [holding]="holding" [viewcode]="viewcode" (eItemsCount)="eItemsCount($event)"></public-search-items>
-</div>
+<public-search-items [holding]="holding"
+                     [viewcode]="viewcode"
+                     [hidden]="isCollapsed"
+></public-search-items>

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.spec.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.spec.ts
@@ -41,6 +41,7 @@ describe('HoldingComponent', () => {
           { label: 'default', language: 'en'}
         ]
       },
+      items_count: 5,
       holdings_type: 'serial',
       available: true,
       call_number: 'F123456',
@@ -73,7 +74,6 @@ describe('HoldingComponent', () => {
     fixture = TestBed.createComponent(HoldingComponent);
     component = fixture.componentInstance;
     component.holding = record;
-    component.itemsCount = 5;
     fixture.detectChanges();
   });
 

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
@@ -32,8 +32,6 @@ export class HoldingComponent {
   /** Is collapsed holdings */
   @Input() isCollapsed = true;
 
-  /** Items count */
-  itemsCount = 0;
   /** Authorized types of note */
   noteAuthorizedTypes: string[] = ['general_note'];
 
@@ -49,16 +47,5 @@ export class HoldingComponent {
    * @param _translateService - TranslateService
    */
   constructor(private _translateService: TranslateService) {}
-
-
-  // COMPONENT FUNCTIONS ======================================================
-  /**
-   * Handler to manage event items count emitter
-   * @param event - number : the number of items for this holding
-   */
-  eItemsCount(event: number): void {
-    this.itemsCount = event;
-  }
-
 
 }

--- a/projects/public-search/src/app/document-detail/holdings/items/items.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/items/items.component.html
@@ -14,24 +14,33 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ng-container *ngIf="items.length > 0; else noItems">
-  <public-search-item *ngFor="let item of items; let index = index"
-                      context="holding"
-                      [item]="item"
-                      [viewcode]="viewcode"
-                      [index]="index">
-
-  </public-search-item>
-  <ng-container *ngIf="isLinkShowMore">
-    <button type="button" class="btn btn-link pr-1" (click)="showMore()">
-      <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
-    </button>
-    <small>({{ hiddenItems }})</small>
-  </ng-container>
+<ng-container *ngIf="!hidden">
+  <div class="card-body p-2">
+    <ng-container *ngIf="!isLoading; else loading">
+      <ng-container *ngIf="items.length > 0; else noItems">
+        <public-search-item
+          *ngFor="let item of items; let index = index"
+          context="holding"
+          [item]="item"
+          [viewcode]="viewcode"
+          [index]="index"
+        ></public-search-item>
+        <ng-container *ngIf="isLinkShowMore">
+          <button type="button" class="btn btn-link pr-1" (click)="showMore()">
+            <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
+          </button>
+          <small>({{ hiddenItems }})</small>
+        </ng-container>
+      </ng-container>
+    </ng-container>
+  </div>
 </ng-container>
 
+<ng-template #loading>
+  <div class="pl-4"><i class="fa fa-spin fa-spinner"></i></div>
+</ng-template>
+
+
 <ng-template #noItems>
-  <div class="row">
-    <div class="col-12 pl-2" translate>No item received.</div>
-  </div>
+  <div class="card-body pl-4" translate>No item received.</div>
 </ng-template>


### PR DESCRIPTION
When displaying the document detail view, items metadata are loaded for
each holdings causing a backend call even if the holding is collapsed.
Now, the items metadata are loaded only if user expand holding;

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
