### PR TITLE
patrons: use link instead of button for circulation link.

### DIFF
--- a/projects/admin/src/app/record/brief-view/patrons-brief-view/patrons-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/patrons-brief-view/patrons-brief-view.component.html
@@ -26,10 +26,10 @@
       {{ role | translate }}
     </small>
     <div *ngIf="record.metadata.patron" class="float-right mb-2 mr-n5">
-      <button class="btn btn-sm btn-outline-primary ml-2" [routerLink]="['/circulation', 'patron', record.metadata.patron.barcode[0]]">
+      <a [routerLink]="['/circulation', 'patron', record.metadata.patron.barcode[0]]" class="btn-link btn btn-sm btn-outline-primary">
         <i class="fa fa-exchange mr-2"></i>
-        <span translate>Circulation</span>
-      </button>
+        {{ 'Circulation' | translate }}
+      </a>
     </div>
   </h5>
   <div class="card-text">

--- a/projects/admin/src/app/scss/styles.scss
+++ b/projects/admin/src/app/scss/styles.scss
@@ -26,20 +26,23 @@
 html [type=button] {
   -webkit-appearance: none;
 }
-button:disabled:hover {
-  cursor: not-allowed;
-}
-
-button.disabled {
-  cursor: not-allowed !important;
-}
-
 body {
   height: 100vh;      // With block page body div to flex-grow-1
 }
-
 header {
   position: relative;
+}
+
+// BUTTONS & BUTTON-LINKS -----------------------
+button:disabled:hover {
+  cursor: not-allowed;
+}
+button.disabled {
+  cursor: not-allowed !important;
+}
+.btn-link.btn-outline-primary:hover {
+  color: #fff !important;
+  text-decoration: none !important;
 }
 
 .label-title:after {


### PR DESCRIPTION
Use a link instead of a button to access circulation screen into the
patron brief view. This allows to open the patron circulation screen
into a new window (right click on the link + open in a new window).

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
