### PR TITLE
documents: display electronic holdings

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -58,8 +58,8 @@
 
         <!-- ELECTRONIC HOLDING ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
         <div class="row" *ngSwitchCase="'electronic'">
-            <div class="offset-sm-1 col-sm-11 " *ngFor="let elocation of holding.metadata.electronic_location">
-              <a href="{{ elocation.uri | translate }}">{{ elocation.source | translate }}</a>
+            <div class="col" *ngFor="let elocation of holding.metadata.electronic_location">
+              <a class="rero-ils-external-link" [href]="elocation.uri">{{ elocation.source }}</a>
             </div>
         </div>
 

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
@@ -98,7 +98,8 @@ export class HoldingsComponent implements OnInit {
     this.canAdd = (!('harvested' in this.document.metadata));
     const orgPid = this._userService.user.currentOrganisation;
     this.query = `document.pid:${this.document.metadata.pid} AND organisation.pid:${orgPid}
-    AND ((holdings_type:standard AND items_count:[1 TO *]) OR holdings_type:serial)`;
+    AND ((holdings_type:standard AND items_count:[1 TO *])
+    OR holdings_type:serial OR holdings_type:electronic)`;
     const holdingsRecords = this._holdingsQuery(1, this.query);
     const holdingsCount = this._holdingsCountQuery(this.query);
     const permissionsRef = this._recordPermissionService.getPermission('holdings');


### PR DESCRIPTION
* Displays holdings of all types in the document detailed view.
* Adjust the display to be the same as the public interface.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>


## Public view screenshot (for comparison)
![image](https://user-images.githubusercontent.com/127249/138675938-77557a12-2af2-45be-bf76-828b8327b4b4.png)

## Admin view screenshot (the new one)
![image](https://user-images.githubusercontent.com/127249/138676102-2d866311-8592-414e-993d-e2e3a2b62c40.png)

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
