### PR TITLE
documents: allow to show other organisations holdings/items

### DIFF
--- a/projects/admin/src/app/api/holdings-api.service.spec.ts
+++ b/projects/admin/src/app/api/holdings-api.service.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RecordModule, RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+
+import { HoldingsApiService } from './holdings-api.service';
+
+describe('HoldingsApiService', () => {
+  let service: HoldingsApiService;
+
+  const response = {
+    aggregations: {},
+    hits: {
+      total: {
+        relation: 'eq',
+        value: 1
+      },
+      hits: [{
+        metadata: {
+          pid: 1
+        }
+      }]
+    },
+    links: {}
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecords', 'totalHits']);
+  recordServiceSpy.getRecords.and.returnValue(of(response));
+  recordServiceSpy.totalHits.and.returnValue(1);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RecordModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy },
+      ]
+    });
+    service = TestBed.inject(HoldingsApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return the number of results', () => {
+    service.getHoldingsCount('1', '1').subscribe((count: number) => {
+      expect(count).toEqual(1);
+    });
+  });
+
+  it('should return a result list', () => {
+    service.getHoldings('1', '1').subscribe((hits: any[]) => {
+      expect(hits.length).toEqual(1);
+    });
+  });
+});

--- a/projects/admin/src/app/api/holdings-api.service.ts
+++ b/projects/admin/src/app/api/holdings-api.service.ts
@@ -1,0 +1,93 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { Record, RecordService } from '@rero/ng-core';
+import { BaseApi } from '@rero/shared';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HoldingsApiService {
+
+  /** Ressource name */
+  readonly RESOURCE_NAME = 'holdings';
+
+  /** Items per page */
+  readonly ITEMS_PER_PAGE = 10;
+
+  /**
+   * Constructor
+   * @param _recordService - RecordService
+   */
+  constructor(private _recordService: RecordService) { }
+
+  /**
+   *
+   * @param documentPid - Document pid
+   * @param organisationPid - Current organisation pid
+   * @param isCurrentOrganisation - Current organisation flag
+   * @param page - Page
+   * @param itemsPerPage - Item per page
+   * @param order - order
+   * @returns Observable
+   */
+  getHoldings(
+    documentPid: string,
+    organisationPid: string,
+    isCurrentOrganisation: boolean = true,
+    page: number = 1,
+    itemsPerPage: number = 10,
+    order: string = 'organisation_library_location'
+  ): Observable<any> {
+    const query = this._queryOrganisation(documentPid, organisationPid, isCurrentOrganisation);
+    return this._recordService.getRecords(
+      this.RESOURCE_NAME, query, page, itemsPerPage, undefined, undefined, BaseApi.reroJsonheaders, order).pipe(
+      map((result: Record) => result.hits.hits)
+    );
+  }
+
+  /**
+   *
+   * @param documentPid - Document pid
+   * @param organisationPid - Organisation pid
+   * @param isCurrentOrganisation - Is current Organisation
+   * @returns Observable
+   */
+  getHoldingsCount(documentPid: string, organisationPid: string, isCurrentOrganisation: boolean = true): Observable<number> {
+    const query = this._queryOrganisation(documentPid, organisationPid, isCurrentOrganisation);
+    return this._recordService.getRecords(this.RESOURCE_NAME, query, 1, 1).pipe(
+      map((result: Record) => this._recordService.totalHits(result.hits.total))
+    );
+  }
+
+  /**
+   *
+   * @param documentPid - Document pid
+   * @param organisationPid - Organisation pid
+   * @param isCurrentOrganisation - Is current organisation
+   * @returns string
+   */
+  private _queryOrganisation(documentPid: string, organisationPid: string, isCurrentOrganisation: boolean): string {
+    return `
+      document.pid:${documentPid}
+      AND ${isCurrentOrganisation ? '' : 'NOT '}organisation.pid:${organisationPid}
+      AND ((holdings_type:standard AND items_count:[1 TO *])
+        OR holdings_type:serial OR holdings_type:electronic)`;
+  }
+}

--- a/projects/admin/src/app/api/item-api.service.spec.ts
+++ b/projects/admin/src/app/api/item-api.service.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RecordModule, RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+import { ItemApiService } from './item-api.service';
+
+
+describe('ItemApiService', () => {
+  let service: ItemApiService;
+
+  const record = {
+    metadata: {
+      pid: '1'
+    }
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecord']);
+  recordServiceSpy.getRecord.and.returnValue(of(record));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RecordModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy }
+      ]
+    });
+    service = TestBed.inject(ItemApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return a record ', () => {
+    service.getItem('1').subscribe((result: any) => {
+      expect(result.pid).toEqual('1');
+    });
+  });
+});

--- a/projects/admin/src/app/api/item-api.service.ts
+++ b/projects/admin/src/app/api/item-api.service.ts
@@ -1,0 +1,41 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { RecordService } from '@rero/ng-core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemApiService {
+
+  /** Ressource name */
+  readonly RESOURCE_NAME = 'items';
+
+  /**
+   * Constructor
+   * @param _recordService - RecordService
+   */
+  constructor(private _recordService: RecordService) {}
+
+  getItem(pid: string): Observable<any> {
+    return this._recordService.getRecord(this.RESOURCE_NAME, pid).pipe(
+      map((result: any) => result.metadata)
+    );
+  }
+}

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -31,6 +31,7 @@ import {
   TranslateLoader, TranslateService, TruncateTextPipe
 } from '@rero/ng-core';
 import { ItemHoldingsCallNumberPipe, MainTitlePipe, SharedModule, UserService } from '@rero/shared';
+import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDatepickerModule, BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -170,6 +171,9 @@ import { TypeaheadFactoryService, typeaheadToken } from './service/typeahead-fac
 import { UiRemoteTypeaheadService } from './service/ui-remote-typeahead.service';
 import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/custom-shortcut-help.component';
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
+import {
+  HoldingOrganisationComponent
+} from './record/detail-view/document-detail-view/holding-organisation/holding-organisation.component';
 
 /** Init application factory */
 export function appInitFactory(appInitService: AppInitService) {
@@ -281,10 +285,12 @@ export function appInitFactory(appInitService: AppInitService) {
     OtherEditionComponent,
     DescriptionZoneComponent,
     DocumentProvisionActivityPipe,
-    MainTitleRelationPipe
+    MainTitleRelationPipe,
+    HoldingOrganisationComponent
   ],
   imports: [
     AppRoutingModule,
+    AccordionModule.forRoot(),
     BrowserAnimationsModule,
     BrowserModule,
     BsDatepickerModule.forRoot(),
@@ -423,7 +429,8 @@ export function appInitFactory(appInitService: AppInitService) {
     CustomShortcutHelpComponent,
     ContributionDetailViewComponent,
     OperationLogsComponent,
-    UserIdEditorComponent
+    UserIdEditorComponent,
+    HoldingOrganisationComponent
   ],
   bootstrap: [AppComponent],
   schemas: [

--- a/projects/admin/src/app/guard/can-access.guard.spec.ts
+++ b/projects/admin/src/app/guard/can-access.guard.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { LocalStorageService, RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+import { ErrorPageComponent } from '../error/error-page/error-page.component';
+import { CanAccessGuard } from './can-access.guard';
+import { cloneDeep } from 'lodash-es';
+
+
+describe('CanAccessGuard', () => {
+  let guard: CanAccessGuard;
+  let router: Router;
+  let recordService: RecordService;
+  let localStorageService: LocalStorageService;
+
+  const routes = [
+    {
+      path: 'errors/400',
+      component: ErrorPageComponent
+    },
+    {
+      path: 'errors/403',
+      component: ErrorPageComponent
+    }
+  ];
+
+  const record = {
+    metadata: {
+      pid: 1,
+      organisation: {
+        pid: '1'
+      }
+    }
+  };
+
+  const localStorageData = {
+    currentLibrary: 1,
+    currentOrganisation: 1
+  };
+
+  const activatedRouteSnapshotSpy = jasmine.createSpyObj('ActivatedRouteSnapshot', ['']);
+  activatedRouteSnapshotSpy.params = { type: 'items', pid: '1' };
+
+  const routerStateSnapshotSpy = jasmine.createSpyObj('RouterStateSnapshot', ['']);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes(routes),
+        HttpClientTestingModule,
+        TranslateModule.forRoot()
+      ]
+    });
+    guard = TestBed.inject(CanAccessGuard);
+    router = TestBed.inject(Router);
+    recordService = TestBed.inject(RecordService);
+    localStorageService = TestBed.inject(LocalStorageService);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should return a 400 error if any parameters are missing', fakeAsync(() => {
+    spyOn(localStorageService, 'get').and.returnValue(localStorageData);
+    spyOn(localStorageService, 'has').and.returnValue(true);
+    const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
+    activatedRoute.params = {};
+    spyOn(recordService, 'getRecord').and.returnValue(of(record));
+    guard.canActivate(activatedRoute, routerStateSnapshotSpy);
+    tick();
+    expect(router.url).toBe('/errors/400');
+  }));
+
+  it('should return a 400 error if the user is missing', fakeAsync(() => {
+    spyOn(localStorageService, 'get').and.returnValue(null);
+    spyOn(localStorageService, 'has').and.returnValue(false);
+    spyOn(recordService, 'getRecord').and.returnValue(of(record));
+    guard.canActivate(activatedRouteSnapshotSpy, routerStateSnapshotSpy);
+    tick();
+    expect(router.url).toBe('/errors/400');
+  }));
+
+  it('should return true if the item is part of the same organization', () => {
+    spyOn(localStorageService, 'get').and.returnValue(localStorageData);
+    spyOn(localStorageService, 'has').and.returnValue(true);
+    spyOn(recordService, 'getRecord').and.returnValue(of(record));
+    expect(guard.canActivate(
+      activatedRouteSnapshotSpy, routerStateSnapshotSpy
+    )).toBeTruthy();
+  });
+
+  it('should redirect to error 403 if the item does not belong to the same organization', fakeAsync(() => {
+    spyOn(localStorageService, 'get').and.returnValue(localStorageData);
+    spyOn(localStorageService, 'has').and.returnValue(true);
+    record.metadata.organisation.pid = '2';
+    spyOn(recordService, 'getRecord').and.returnValue(of(record));
+    guard.canActivate(activatedRouteSnapshotSpy, routerStateSnapshotSpy);
+    tick();
+    expect(router.url).toBe('/errors/403');
+  }));
+});

--- a/projects/admin/src/app/guard/can-access.guard.ts
+++ b/projects/admin/src/app/guard/can-access.guard.ts
@@ -1,0 +1,59 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { extractIdOnRef, RecordService } from '@rero/ng-core';
+import { IUserLocaleStorage, UserService } from '@rero/shared';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CanAccessGuard implements CanActivate {
+
+  constructor(
+    private _recordService: RecordService,
+    private _userService: UserService,
+    private _router: Router
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    const params = route.params;
+    if (params && params.hasOwnProperty('type') && params.hasOwnProperty('pid')) {
+      const userLocale: IUserLocaleStorage = this._userService.getOnLocaleStorage();
+      if (userLocale) {
+        this._recordService.getRecord(params.type, params.pid)
+          .pipe(map((record: any) => record.metadata))
+          .subscribe((record: any) => {
+            /** The record does not belong to the user's organization. */
+            if (userLocale.currentOrganisation !== extractIdOnRef(record.organisation.$ref)) {
+              /** Access forbidden */
+              this._router.navigate(['/errors/403'], { skipLocationChange: true });
+            }
+          });
+      } else {
+        this._router.navigate(['/errors/400'], { skipLocationChange: true });
+      }
+    } else {
+      this._router.navigate(['/errors/400'], { skipLocationChange: true });
+    }
+    return true;
+  }
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -224,8 +224,7 @@
         </ng-template>
         <div class="mt-2">
           <!-- HOLDINGS -->
-          <admin-holdings [holdingType]="holdingType" [document]="record">
-          </admin-holdings>
+          <admin-holding-organisation [document]="record"></admin-holding-organisation>
         </div>
       </tab>
       <!-- END OF GET TAB -->

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
@@ -209,18 +209,6 @@ export class DocumentDetailViewComponent implements DetailRecord, OnInit, OnDest
     }
   }
 
-  /** Get the holding type used to add a new holding. */
-  get holdingType(): 'standard'|'electronic'|'serial' {
-    const data = this.record.metadata;
-    if (data.issuance.main_type === 'rdami:1003') {
-      return 'serial';
-    }
-    if (data.harvested === true && data.type === 'ebook') {
-      return 'electronic';
-    }
-    return 'standard';
-  }
-
   /**
    * Format "part of" numbering for display
    *

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.html
@@ -1,0 +1,31 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ng-container *ngIf="ready; else loaded">
+  <!-- current organisation -->
+  <admin-holdings [holdingType]="holdingType" [document]="document"></admin-holdings>
+
+  <!-- other organisations -->
+  <ng-container *ngIf="otherOrganisationCount > 0">
+    <h5 class="other">Other organisations</h5>
+    <admin-holdings [holdingType]="holdingType" [document]="document" [isCurrentOrganisation]="false"></admin-holdings>
+  </ng-container>
+</ng-container>
+
+<ng-template #loaded>
+  <span class="spinner-grow spinner-grow-sm" role="status"></span>
+  <span class="ml-1" translate>loading in progress...</span>
+</ng-template>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.scss
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.scss
@@ -1,0 +1,26 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import '~bootstrap/scss/_functions';
+@import '~bootstrap/scss/_variables';
+
+.other {
+  margin-top: map-get($spacers, 4);
+  margin-bottom: map-get($spacers, 3);
+  padding-bottom: map-get($spacers, 1);
+  border-bottom: $border-width solid $border-color;
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { UserService } from '@rero/shared';
+import { HoldingsApiService } from 'projects/admin/src/app/api/holdings-api.service';
+import { of } from 'rxjs';
+import { HoldingOrganisationComponent } from './holding-organisation.component';
+
+
+describe('HoldingOrganisationComponent', () => {
+  let component: HoldingOrganisationComponent;
+  let fixture: ComponentFixture<HoldingOrganisationComponent>;
+
+  const data = {
+    metadata: {
+      pid: '1',
+      issuance: {
+        main_type: 'book'
+      }
+    }
+  };
+
+  const holdingApiServiceSpy = jasmine.createSpyObj('HoldingsApiService', ['getHoldingsCount']);
+  holdingApiServiceSpy.getHoldingsCount.and.returnValue(of(1));
+
+  const userServiceSpy = jasmine.createSpyObj('UserService', ['']);
+  userServiceSpy.user = { currentOrganisation: 1 };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HoldingOrganisationComponent ],
+      imports: [
+        HttpClientTestingModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: HoldingsApiService, useValue: holdingApiServiceSpy },
+        { provide: UserService, useValue: userServiceSpy }
+      ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HoldingOrganisationComponent);
+    component = fixture.componentInstance;
+    component.document = data;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding-organisation/holding-organisation.component.ts
@@ -1,0 +1,78 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+import { UserService } from '@rero/shared';
+import { HoldingsApiService } from 'projects/admin/src/app/api/holdings-api.service';
+import { forkJoin } from 'rxjs';
+
+@Component({
+  selector: 'admin-holding-organisation',
+  templateUrl: './holding-organisation.component.html',
+  styleUrls: ['./holding-organisation.component.scss']
+})
+export class HoldingOrganisationComponent implements OnInit {
+
+  /** Document record */
+  @Input() document: any;
+
+  /** All elements is loade */
+  ready = false;
+  /** Holdings count for current organisation */
+  currentOrganisationCount = 0;
+  /** Holdings count for other organisation */
+  otherOrganisationCount = 0;
+
+  /** Get the holding type used to add a new holding. */
+  get holdingType(): 'standard'|'electronic'|'serial' {
+    const data = this.document.metadata;
+    if (data.issuance.main_type === 'rdami:1003') {
+      return 'serial';
+    }
+    if (data.harvested === true && data.type === 'ebook') {
+      return 'electronic';
+    }
+    return 'standard';
+  }
+
+  /**
+   * Constructor
+   * @param _holdingsApiService - HoldingsApiService
+   * @param _userService - UserService
+   */
+  constructor(
+    private _holdingsApiService: HoldingsApiService,
+    private _userService: UserService
+  ) {}
+
+  /** On init hook */
+  ngOnInit(): void {
+    const documentPid = this.document.metadata.pid;
+    const organisationPid = this._userService.user.currentOrganisation;
+    const currentOrganisation = this._holdingsApiService.getHoldingsCount(
+      documentPid, organisationPid);
+    const otherOrganisation = this._holdingsApiService.getHoldingsCount(
+      documentPid, organisationPid, false
+    );
+
+    forkJoin([currentOrganisation, otherOrganisation])
+      .subscribe(([currentCount, otherCount]) => {
+        this.currentOrganisationCount = currentCount;
+        this.otherOrganisationCount = otherCount;
+        this.ready = true;
+      });
+  }
+}

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="container item px-0 mt-1 mb-2" *ngIf="item && permissions">
+<div class="container item px-0 mt-1 mb-2" *ngIf="item">
   <div class="row">
     <!-- METADATA COLUMN -->
     <div class="col-10">
@@ -23,9 +23,13 @@
         <div class="col-4 pl-5 font-weight-bold label-title" translate>Barcode</div>
         <div class="col-8">
           <admin-record-masked *ngIf="item.metadata._masked" [record]="item"></admin-record-masked>
-          <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
-            {{ item.metadata.barcode }}
-          </a>
+          <!-- Remove link if not current organisation -->
+          <ng-container *ngIf="permissions; else barcodeOnly">
+            <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
+              {{ item.metadata.barcode }}
+            </a>
+          </ng-container>
+          <ng-template #barcodeOnly>{{ item.metadata.barcode }}</ng-template>
         </div>
         <!-- Unit -->
         <ng-container *ngIf="item.metadata.enumerationAndChronology">
@@ -69,8 +73,8 @@
           <div class="col-4 pl-5 font-weight-bold label-title" translate>Temporary location</div>
           <div class="col-8">{{ item.metadata.temporary_location.name }}</div>
         </ng-container>
-        <!-- ITEM IN COLLECTION -->
-        <ng-container *ngIf="item.metadata.pid | itemInCollection | async as collections">
+        <!-- ITEM IN COLLECTION (hide if not current organisation) -->
+        <ng-container *ngIf="permissions && item.metadata.pid | itemInCollection | async as collections">
           <div class="col-4 pl-5 font-weight-bold label-title" translate>Exhibition/course</div>
           <div class="col-8">
             <ng-container *ngFor="let collection of collections; let last=last">
@@ -80,49 +84,55 @@
           </div>
         </ng-container>
       </div>
-      <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
-      <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
+      <!-- (hide if not current organisation) -->
+      <ng-container *ngIf="permissions">
+        <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
+        <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
+      </ng-container>
     </div>
     <!-- ACTIONS BUTTONS -->
     <div class="col-2 text-right" name="buttons">
-      <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
-              type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
-              title="{{ 'Item request' | translate }}"
-              name="request">
-        <i class="fa fa-shopping-basket" aria-hidden="true"></i>
-      </button>
-      <ng-template #notRequest>
-        <button type="button" class="btn btn-sm btn-outline-primary disabled"
+      <ng-container *ngIf="permissions; else noAction">
+        <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
+                type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
                 title="{{ 'Item request' | translate }}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
                 name="request">
           <i class="fa fa-shopping-basket" aria-hidden="true"></i>
         </button>
-        <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
-      </ng-template>
-      <button *ngIf="permissions.update && permissions.update.can"
-              type="button" class="btn btn-sm btn-outline-primary ml-1"
-              title="{{ 'Edit' | translate }}"
-              [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
-              name="edit">
-        <i class="fa fa-pencil"></i>
-      </button>
-      <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
-              type="button" class="btn btn-outline-danger btn-sm ml-1"
-              title="{{ 'Delete' | translate }}"
-              (click)="delete(item.metadata.pid)"
-              name="delete">
-        <i class="fa fa-trash"></i>
-      </button>
-      <ng-template #deleteInfo>
-        <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
+        <ng-template #notRequest>
+          <button type="button" class="btn btn-sm btn-outline-primary disabled"
+                  title="{{ 'Item request' | translate }}"
+                  [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+                  name="request">
+            <i class="fa fa-shopping-basket" aria-hidden="true"></i>
+          </button>
+          <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
+        </ng-template>
+        <button *ngIf="permissions.update && permissions.update.can"
+                type="button" class="btn btn-sm btn-outline-primary ml-1"
+                title="{{ 'Edit' | translate }}"
+                [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
+                name="edit">
+          <i class="fa fa-pencil"></i>
+        </button>
+        <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
+                type="button" class="btn btn-outline-danger btn-sm ml-1"
                 title="{{ 'Delete' | translate }}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+                (click)="delete(item.metadata.pid)"
                 name="delete">
           <i class="fa fa-trash"></i>
         </button>
-        <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
-      </ng-template>
+        <ng-template #deleteInfo>
+          <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
+                  title="{{ 'Delete' | translate }}"
+                  [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+                  name="delete">
+            <i class="fa fa-trash"></i>
+          </button>
+          <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
+        </ng-template>
+      </ng-container>
+      <ng-template #noAction>&nbsp;</ng-template>
     </div>
   </div>
 </div>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/default-holding-item/default-holding-item.component.ts
@@ -39,6 +39,8 @@ export class DefaultHoldingItemComponent implements OnInit {
   @Input() item: any;
   /** Event for delete Item */
   @Output() deleteItem = new EventEmitter();
+  /** Restrict the functionality of interface */
+  @Input() isCurrentOrganisation = true;
 
   /** Item permissions */
   permissions: any;
@@ -69,7 +71,9 @@ export class DefaultHoldingItemComponent implements OnInit {
 
   /** OnInit hook */
   ngOnInit(): void {
-    this._getPermissions();
+    if (this.isCurrentOrganisation) {
+      this._getPermissions();
+    }
   }
 
 

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -26,30 +26,32 @@
         </a>
         <admin-record-masked *ngIf="holding.metadata._masked" [record]="holding"></admin-record-masked>
         <ng-container *ngIf="holding.metadata.location.pid | getRecord: 'locations' | async as location" class="col-sm-5">
-          {{ location.metadata.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}:
-          {{ location.metadata.name }}
+          {{ holding.metadata.library.name }}: {{ location.metadata.name }}
         </ng-container>
       </div>
       <div class="col-sm-2 mt-1">
         {{ holding.metadata.circulation_category.circulation_information | getTranslatedLabel : language }}
       </div>
       <div *ngIf="holdingType === 'serial'" class="col-sm-4 text-right">
-        <!-- HOLDING VIEW -->
-        <button [routerLink]="['/', 'records', 'holdings', 'detail', holding.metadata.pid]"
-                class="btn btn-outline-primary btn-sm ml-1">
-          <i class="fa fa-file-text-o"></i>
-        </button>
-        <!-- EDIT BUTTON -->
-        <button *ngIf="permissions && permissions.update && permissions.update.can"
-                [routerLink]="['/', 'records', 'holdings', 'edit', holding.metadata.pid]"
-                class="btn btn-outline-primary btn-sm ml-1">
-          <i class="fa fa-pencil"></i>
-        </button>
-        <!-- DELETE BUTTON -->
-        <button *ngIf="permissions && permissions.delete && permissions.delete.can; else deleteInfo" type="button"
-          class="btn btn-outline-danger btn-sm ml-1" (click)="delete()">
-          <i class="fa fa-trash"></i>
-        </button>
+        <ng-container *ngIf="permissions; else noAction">
+          <!-- HOLDING VIEW -->
+          <button [routerLink]="['/', 'records', 'holdings', 'detail', holding.metadata.pid]"
+                  class="btn btn-outline-primary btn-sm ml-1">
+            <i class="fa fa-file-text-o"></i>
+          </button>
+          <!-- EDIT BUTTON -->
+          <button *ngIf="permissions.update && permissions.update.can"
+                  [routerLink]="['/', 'records', 'holdings', 'edit', holding.metadata.pid]"
+                  class="btn btn-outline-primary btn-sm ml-1">
+            <i class="fa fa-pencil"></i>
+          </button>
+          <!-- DELETE BUTTON -->
+          <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo" type="button"
+            class="btn btn-outline-danger btn-sm ml-1" (click)="delete()">
+            <i class="fa fa-trash"></i>
+          </button>
+        </ng-container>
+        <ng-template #noAction></ng-template>
       </div>
       <admin-holding-detail *ngIf="holdingType === 'serial'" context="document" [holding]="holding" class="col-sm-12"></admin-holding-detail>
     </div>
@@ -76,6 +78,7 @@
                 *ngFor="let item of items | slice:0: displayItemsCounter"
                 [holding]="holding"
                 [item]="item"
+                [isCurrentOrganisation]="isCurrentOrganisation"
                 (deleteItem)="deleteItem($event)"
                 [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
             ></admin-serial-holding-item>
@@ -101,6 +104,7 @@
               <admin-default-holding-item
                   [holding]="holding"
                   [item]="item"
+                  [isCurrentOrganisation]="isCurrentOrganisation"
                   (deleteItem)="deleteItem($event)"
                   [attr.id]="item.metadata.barcode | idAttribute:{prefix: 'item'}">
               </admin-default-holding-item>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
@@ -38,6 +38,8 @@ export class HoldingComponent implements OnInit, OnDestroy {
   @Output() deleteHolding = new EventEmitter();
   /** Items collapsed */
   @Input() isItemsCollapsed = true;
+  /** Restrict the functionality of interface */
+  @Input() isCurrentOrganisation = true;
 
   /** shortcut for holding type */
   holdingType: 'electronic' | 'serial' | 'standard';
@@ -81,7 +83,9 @@ export class HoldingComponent implements OnInit, OnDestroy {
     if (this.holdingType !== 'electronic') {
       this._loadItems();
     }
-    this._getPermissions();
+    if (this.isCurrentOrganisation) {
+      this._getPermissions();
+    }
   }
 
   /** onDestroy hook */

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/serial-holding-item/serial-holding-item.component.html
@@ -14,13 +14,16 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="container px-0 mt-1 mb-2" *ngIf="item && permissions && item.metadata.issue.status !== itemIssueStatus.DELETED">
+<div class="container px-0 mt-1 mb-2" *ngIf="item && item.metadata.issue.status !== itemIssueStatus.DELETED">
   <div class="row">  <!-- First row :: item detail -->
     <div class="col-sm-3">
       <admin-record-masked *ngIf="item.metadata._masked" [record]="item"></admin-record-masked>
-      <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
-        {{ item.metadata.barcode }}
-      </a>
+      <ng-container *ngIf="permissions; else barcodeOnly">
+        <a [routerLink]="['/records', 'items', 'detail', item.metadata.pid]" name="barcode">
+          {{ item.metadata.barcode }}
+        </a>
+      </ng-container>
+      <ng-template #barcodeOnly>{{ item.metadata.barcode }}</ng-template>
     </div>
     <div class="col-sm-2" name="status">{{ item.metadata.status | translate }}</div>
     <div class="col-sm-3" name="issue">{{ item.metadata.enumerationAndChronology }}</div>
@@ -28,50 +31,55 @@
       <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
     </div>
     <div class="col-sm-2 text-right" name="buttons">
-      <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
-              type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
-              title="{{ 'Item request' | translate }}"
-              name="request">
-        <i class="fa fa-shopping-basket" aria-hidden="true"></i>
-      </button>
-      <ng-template #notRequest>
-        <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
-                title="{{ 'Item request' | translate }}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
-                name="request">
+      <ng-container *ngIf="permissions; else noAction">
+        <button *ngIf="permissions.canRequest && permissions.canRequest.can; else notRequest"
+          type="button" class="btn btn-sm btn-outline-primary " (click)="addRequest(item.metadata.pid)"
+          title="{{ 'Item request' | translate }}"
+          name="request">
           <i class="fa fa-shopping-basket" aria-hidden="true"></i>
         </button>
-        <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
-      </ng-template>
-      <button *ngIf="permissions.update && permissions.update.can"
-              type="button" class="btn btn-sm btn-outline-primary ml-1"
-              title="{{ 'Edit' | translate }}"
-              [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
-              name="edit">
-        <i class="fa fa-pencil"></i>
-      </button>
-      <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
-              type="button" class="btn btn-outline-danger btn-sm ml-1"
-              title="{{ 'Delete' | translate }}"
-              (click)="delete(item.metadata.pid)"
-              name="delete">
-        <i class="fa fa-trash"></i>
-      </button>
-      <ng-template #deleteInfo>
-        <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
-                title="{{ 'Delete' | translate }}"
-                [popover]="tolTemplate" triggers="mouseenter:mouseleave"
-                name="delete">
+        <ng-template #notRequest>
+          <button type="buttton" class="btn btn-sm btn-outline-primary disabled"
+            title="{{ 'Item request' | translate }}"
+            [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+            name="request">
+            <i class="fa fa-shopping-basket" aria-hidden="true"></i>
+          </button>
+          <ng-template #tolTemplate><div [innerHtml]="cannotRequestInfoMessage | nl2br"></div></ng-template>
+        </ng-template>
+        <button *ngIf="permissions.update && permissions.update.can"
+          type="button" class="btn btn-sm btn-outline-primary ml-1"
+          title="{{ 'Edit' | translate }}"
+          [routerLink]="['/records', 'items', 'edit', item.metadata.pid]"
+          name="edit">
+          <i class="fa fa-pencil"></i>
+        </button>
+        <button *ngIf="permissions.delete && permissions.delete.can; else deleteInfo"
+          type="button" class="btn btn-outline-danger btn-sm ml-1"
+          title="{{ 'Delete' | translate }}"
+          (click)="delete(item.metadata.pid)"
+          name="delete">
           <i class="fa fa-trash"></i>
         </button>
-        <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
-      </ng-template>
+        <ng-template #deleteInfo>
+          <button type="button" class="btn btn-sm btn-outline-danger ml-1 disabled"
+            title="{{ 'Delete' | translate }}"
+            [popover]="tolTemplate" triggers="mouseenter:mouseleave"
+            name="delete">
+            <i class="fa fa-trash"></i>
+          </button>
+          <ng-template #tolTemplate><div [innerHtml]="deleteInfoMessage | nl2br"></div></ng-template>
+        </ng-template>
+      </ng-container>
+      <ng-template #noAction>&nbsp;</ng-template>
     </div>
   </div>
-  <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
-  <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
+  <ng-container *ngIf="permissions">
+    <admin-holding-item-note [note]="note" *ngFor="let note of item.metadata.notes"></admin-holding-item-note>
+    <admin-holding-item-temporary-item-type [record]="item"></admin-holding-item-temporary-item-type>
+  </ng-container>
   <!-- TEMPORARY LOCATION -->
-  <ng-container *ngIf="item.metadata.temporary_location">
+  <ng-container *ngIf="permissions && item.metadata.temporary_location">
     <div class="row">
       <div class="col-4 pl-5">
         <i class="fa fa-long-arrow-right pr-1"></i>
@@ -83,7 +91,7 @@
     </div>
   </ng-container>
   <!-- ITEM IN COLLECTION -->
-  <ng-container *ngIf="item.metadata.pid | itemInCollection | async as collections">
+  <ng-container *ngIf="permissions && item.metadata.pid | itemInCollection | async as collections">
     <div class="row">
       <div class="col-4 pl-5">
         <i class="fa fa-long-arrow-right pr-1"></i>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
@@ -54,10 +54,12 @@
 </div>
 
 <ng-container *ngIf="holdings">
-  <admin-document-holding *ngFor="let holding of holdings"
-                          [holding]="holding"
-                          [isItemsCollapsed]="holdingsTotal > 1"
-                          (deleteHolding)="deleteHolding($event)"
+  <admin-document-holding
+    *ngFor="let holding of holdings"
+    [holding]="holding"
+    [isItemsCollapsed]="holdingsTotal > 1"
+    [isCurrentOrganisation]="isCurrentOrganisation"
+    (deleteHolding)="deleteHolding($event)"
   >
   </admin-document-holding>
   <ng-container *ngIf="isLinkShowMore">

--- a/projects/admin/src/app/routes/holdings-route.ts
+++ b/projects/admin/src/app/routes/holdings-route.ts
@@ -18,6 +18,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { DetailComponent, JSONSchema7, Record, RecordService, RouteInterface } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { CanAccessGuard } from '../guard/can-access.guard';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { HoldingEditorComponent } from '../record/custom-editor/holding-editor/holding-editor.component';
 import { HoldingDetailViewComponent } from '../record/detail-view/holding-detail-view/holding-detail-view.component';
@@ -40,8 +41,8 @@ export class HoldingsRoute extends BaseRoute implements RouteInterface {
     return {
       matcher: (url: any) => this.routeMatcher(url, this.name),
       children: [
-        { path: 'detail/:pid', component: DetailComponent },
-        { path: 'edit/:pid', component: HoldingEditorComponent, canActivate: [ CanUpdateGuard ] },
+        { path: 'detail/:pid', component: DetailComponent, canActivate: [ CanAccessGuard ] },
+        { path: 'edit/:pid', component: HoldingEditorComponent, canActivate: [ CanAccessGuard, CanUpdateGuard ] },
         { path: 'new', component: HoldingEditorComponent }
       ],
       data: {

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -20,6 +20,7 @@ import { DetailComponent, EditorComponent, JSONSchema7, Record, RecordSearchPage
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ItemType } from '../classes/items';
+import { CanAccessGuard } from '../guard/can-access.guard';
 import { CanUpdateGuard } from '../guard/can-update.guard';
 import { ItemsBriefViewComponent } from '../record/brief-view/items-brief-view/items-brief-view.component';
 import { ItemDetailViewComponent } from '../record/detail-view/item-detail-view/item-detail-view.component';
@@ -41,10 +42,9 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
     return {
       matcher: (url: any) => this.routeMatcher(url, this.name),
       children: [
-        // TODO: add guards
         { path: '', component: RecordSearchPageComponent },
-        { path: 'detail/:pid', component: DetailComponent },
-        { path: 'edit/:pid', component: EditorComponent, canActivate: [ CanUpdateGuard ] },
+        { path: 'detail/:pid', component: DetailComponent, canActivate: [ CanAccessGuard ] },
+        { path: 'edit/:pid', component: EditorComponent, canActivate: [ CanAccessGuard, CanUpdateGuard ] },
         { path: 'new', component: EditorComponent }
       ],
       data: {

--- a/projects/shared/src/lib/shared.module.ts
+++ b/projects/shared/src/lib/shared.module.ts
@@ -40,7 +40,7 @@ import { PersonBriefComponent } from './view/brief/person-brief/person-brief.com
 import { InheritedCallNumberComponent } from './view/inherited-call-number/inherited-call-number.component';
 import { ThumbnailComponent } from './view/thumbnail/thumbnail.component';
 import { GetTranslatedLabelPipe } from './pipe/get-translated-label.pipe';
-import { ContributionFilterPipe } from '../public-api';
+import { ContributionFilterPipe } from './pipe/contribution-filter.pipe';
 
 @NgModule({
   declarations: [


### PR DESCRIPTION
Display of other organizations' holdings/items in the document detail view.

* Closes rero/rero-ils#1945.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
