### PR TITLE
acquisition: fix receipt date in order brief view

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
@@ -56,8 +56,8 @@ export class OrderBriefViewComponent implements ResultItem, OnInit {
   /** get reception date (based on orderLine reception date) */
   get receptionDate(): string | null {
     return this.record.metadata.receipts
-      .filter(line => line.hasOwnProperty('receipt_date'))
-      .map(line => line.receipt_date.toString())
+      .filter(line => line.hasOwnProperty('receipt_date') && Array.isArray(line.receipt_date) && line.receipt_date.length > 0)
+      .map(line => line.receipt_date[0])
       .shift();
   }
 


### PR DESCRIPTION
When an order has multiple reception date, take the first one as display
value.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
