### PR TITLE
request: display the request time

### DIFF
--- a/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
+++ b/projects/admin/src/app/circulation/main-request/requested-item/requested-item.component.html
@@ -62,7 +62,7 @@
   <div name="call-number" class="col-2">
     <shared-inherited-call-number [item]="item"></shared-inherited-call-number>
   </div>
-  <div name="transaction-date" class="col-2">{{ item.loan.transaction_date | dateTranslate :'medium' }}</div>
+  <div name="transaction-date" class="col-2">{{ item.loan.creation_date | dateTranslate :'medium' }}</div>
   <!-- NEXT-ROWS :: request detail -->
   <div class="col-12 mt-2" *ngIf="!isCollapsed">
     <dl class="row">

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-transaction/item-transaction.component.html
@@ -54,7 +54,7 @@
           </div>
         </ng-template>
         <div class="col-3">
-          {{ transaction.metadata.transaction_date | dateTranslate:'longDate' }}
+          {{ transaction.created | dateTranslate:'medium' }}
         </div>
         <div class="col-1 text-right">
           <ng-container *ngIf="canCancelRequest(); else noCancel">


### PR DESCRIPTION
Add the request time to the request date into the `requestedBy` box. At
this time, only the date was displayed : it was not precise enough.
Closes rero/rero-ils#1704.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

![image](https://user-images.githubusercontent.com/10031585/150148640-525a6e4c-54b5-4d29-a22a-52e17d950ca7.png)

## Dependencies 

https://github.com/rero/rero-ils/pull/2646


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
