### PR TITLE
patron_type: display of unpaid subscription limit

### DIFF
--- a/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
@@ -105,6 +105,14 @@
             <dd class="col">{{ record.metadata.limits.overdue_items_limits.default_value }}</dd>
           </dl>
         </div>
+        <!-- unpaid subscription restriction -->
+        <div class="card-header">
+          <i class="fa" [ngClass]="{
+            'fa-circle text-success': record.metadata.limits.unpaid_subscription,
+            'fa-circle-thin': !record.metadata.limits.unpaid_subscription
+          }"></i>
+          <span class="pl-3" translate>Limit to unpaid subscription</span>
+        </div>
       </div>
     </section>
   </dl>

--- a/projects/admin/src/app/routes/patron-types-route.ts
+++ b/projects/admin/src/app/routes/patron-types-route.ts
@@ -66,6 +66,14 @@ export class PatronTypesRoute extends BaseRoute implements RouteInterface {
               };
               return data;
             },
+            postprocessRecordEditor: (record: any) => {
+              console.log(record);
+              // Remove the possible unpaid limit if subscription amount isn't present or if subscription amount <= 0
+              if (record.subscription_amount && record.subscription_amount <= 0 && record.limits && record.limits.unpaid_subscription) {
+                delete record.limits.unpaid_subscription;
+              }
+              return record;
+            },
             sortOptions: [
               {
                 label: _('Relevance'),


### PR DESCRIPTION
Display the new restriction limit for "unpaid subscription" into the
patron_type detailed view.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

![image](https://user-images.githubusercontent.com/10031585/150156426-f2dc7ff0-c8d8-4cd4-a9b3-8489db1c8910.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
