### PR TITLE
holdings: fix item collapsing

### DIFF
--- a/projects/public-holdings-items/src/index.html
+++ b/projects/public-holdings-items/src/index.html
@@ -40,7 +40,7 @@
     <div class="container">
       <div class="align-self-center justify-content-between row">
         <h4 class="col-12">Document holdings items</h4>
-        <public-search-holdings documentpid="258" viewcode="global" class="col-12"></public-search-holdings>
+        <public-search-holdings documentpid="250" viewcode="global" class="col-12"></public-search-holdings>
       </div>
     </div>
   </body>

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
@@ -54,7 +54,7 @@
       </span>
     </div>
   </div>
-  <!-- SERIAL HOLDING INFORMATIOLNS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <!-- SERIAL HOLDING INFORMATIONS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <dl class="row holdings-data" *ngIf="holding.metadata.holdings_type === 'serial'">
     <!-- CALL NUMBER -->
     <ng-container *ngIf="holding.metadata.call_number">

--- a/projects/public-search/src/app/document-detail/holdings/holdings.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holdings.component.html
@@ -19,7 +19,6 @@
   <public-search-holding *ngFor="let holding of holdings"
                          [holding]="holding"
                          [viewcode]="viewcode"
-                         [collapsable]="holding.metadata.holdings_type !== 'serial'"
                          [collapsed]="holdingsTotal > 1"
                          [attr.id]="holding.metadata.pid | idAttribute : {prefix: 'holding'}"
                          class="card mt-2 w-100">


### PR DESCRIPTION
The carret button is now visible if the holding has at least one  linked item doesn't matter the holding type.

Closes rero/rero-ils#2502.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

 
![image](https://user-images.githubusercontent.com/10031585/155132534-f96872ee-29e3-452c-a59f-e04c9d59c77c.png)


## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
