### PR TITLE
holdings: fix detailed view for issue items.

### DIFF
--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.html
@@ -49,13 +49,16 @@
           <dd class="col-8">
             <i class="fa pr-2" [class]="getIcon(true)"></i>
             {{ issue.metadata.issue.status | translate }}
+            <span class="small pl-2 text-secondary">
+              ({{ 'Assigned on' | translate }} {{ issue.metadata.issue.status_date | dateTranslate }})
+            </span>
           </dd>
-          <dt class="offset-1 col-3 label-title" translate>Excepted date</dt>
+          <dt class="offset-1 col-3 label-title" translate>Expected date</dt>
           <dd class="col-8">{{ issue.metadata.issue.expected_date | dateTranslate }}</dd>
-          <dt class="offset-1 col-3 label-title" translate>Received date</dt>
-          <dd class="col-8">{{ issue.metadata.issue.received_date | dateTranslate }}</dd>
-          <dt class="offset-1 col-3 label-title" translate>Last action</dt>
-          <dd class="col-8">{{ issue.metadata.issue.status_date | dateTranslate }}</dd>
+          <ng-container *ngIf="issue.metadata.issue.status === issueItemStatusRef.RECEIVED">
+            <dt class="offset-1 col-3 label-title" translate>Received date</dt>
+            <dd class="col-8">{{ issue.metadata.issue.received_date | dateTranslate }}</dd>
+          </ng-container>
         </dl>
       </div>
     </div>

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.ts
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.ts
@@ -18,6 +18,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { RecordUiService } from '@rero/ng-core';
+import { IssueItemStatus } from '@rero/shared';
 import { HoldingsService } from 'projects/admin/src/app/service/holdings.service';
 import { RecordPermissionService } from 'projects/admin/src/app/service/record-permission.service';
 
@@ -38,6 +39,8 @@ export class ReceivedIssueComponent {
 
   /** is the issue detail is collapsed or not */
   isCollapsed = true;
+  /** IssueItemStatus reference */
+  issueItemStatusRef = IssueItemStatus;
 
   // GETTER & SETTER ==========================================================
 

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -17,6 +17,7 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { DetailComponent, EditorComponent, JSONSchema7, Record, RecordSearchPageComponent, RecordService, RouteInterface } from '@rero/ng-core';
+import { IssueItemStatus } from '@rero/shared';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ItemType } from '../classes/items';
@@ -101,10 +102,15 @@ export class ItemsRoute extends BaseRoute implements RouteInterface {
               return data;
             },
             postprocessRecordEditor: (record: any) => {
-              // As 'issue' is part of the JSON propertiesOrder. The record should always contain this property ;
-              // But this property is only necessary for 'issue' item type.
-              if (record.type !== 'issue' && record.hasOwnProperty('issue')) {
-                delete record.issue;
+              // * As 'issue' is part of the JSON propertiesOrder. The record should always contain this property ;
+              //   But this property is only necessary for 'issue' item type.
+              // * Keep 'received_date' information only if the issue has the correct status.
+              if (record.issue) {
+                if (record.type !== 'issue') {
+                  delete record.issue;
+                } else if (record.issue.status !== IssueItemStatus.RECEIVED && record.issue.received_date) {
+                  delete record.issue.received_date;
+                }
               }
               // If we try to save an item with without any notes, then remove the empty array notes array from record
               if (record.notes && record.notes.length === 0) {


### PR DESCRIPTION
* Displays 'reception date' only if issue has the 'received' status.
* Displays the 'status date' just after the status when an issue is not
  collapsed.
* Cleans data before sent them to server.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Dependencies 

https://github.com/rero/rero-ils/pull/2721


## How to test?

![image](https://user-images.githubusercontent.com/10031585/155145976-90c33f3f-b7e9-4e6b-9f83-f819333fd72a.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
