### PR TITLE
document: `identifiedBy` duplicate check.

### DIFF
--- a/projects/admin/src/app/classes/identifiers.ts
+++ b/projects/admin/src/app/classes/identifiers.ts
@@ -1,0 +1,44 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* tslint:disable */
+// required as json properties is not lowerCamelCase
+
+export enum IdentifierTypes {
+  AUDIO_ISSUE_NUMBER = 'bf:AudioIssueNumber',
+  DOI = 'bf:Doi',
+  EAN = 'bf:Ean',
+  GTIN_14 = 'bf:Gtin14Number',
+  IDENTIFIER = 'bf:Identifier',
+  ISAN = 'bf:Isan',
+  ISBN = 'bf:Isbn',
+  ISMN = 'bf:Ismn',
+  ISRC = 'bf:Isrc',
+  ISSN = 'bf:Issn',
+  L_ISSN = 'bf:IssnL',
+  LCCN = 'bf:Lccn',
+  LOCAL = 'bf:Local',
+  MATRIX_NUMBER = 'bf:MatrixNumber',
+  MUSIC_DISTRIBUTOR_NUMBER = 'bf:MusicDistributorNumber',
+  MUSIC_PLATE = 'bf:MusicPlate',
+  MUSIC_PUBLISHER_NUMBER = 'bf:MusicPublisherNumber',
+  PUBLISHER_NUMBER = 'bf:PublisherNumber',
+  UPC = 'bf:Upc',
+  URN = 'bf:Urn',
+  VIDEO_RECORDING_NUMBER = 'bf:VideoRecordingNumber',
+  URI = 'uri'
+}

--- a/projects/admin/src/app/classes/typeahead/documents-typeahead.ts
+++ b/projects/admin/src/app/classes/typeahead/documents-typeahead.ts
@@ -142,9 +142,9 @@ export class DocumentsTypeahead implements ITypeahead {
   }
 
   /**
-   * Extract identifers of identifiedBy field
-   * @param identifiers - identifiedBy field
-   * @returns Object
+   * Extract specific identifiers from identifiedBy field
+   * @param identifiers - the identifiedBy field from document metadata
+   * @returns The list of identifier types and values for each of them.
    */
   private _extractIdentifier(identifiers: any) {
     const availableIdentifiers = {
@@ -154,21 +154,23 @@ export class DocumentsTypeahead implements ITypeahead {
       'bf:IssnL': 'ISSN'
     };
     const keys = Object.keys(availableIdentifiers);
-    const result = {};
-    identifiers.filter(
-      (identifier: any) => keys.includes(identifier.type)
-    ).forEach((element: any) => {
-      let data = element.value;
-      const key = availableIdentifiers[element.type];
-      if (!(key in result)) {
-        result[key] = [];
-      }
-      if ('qualifier' in element) {
-        data += ` (${element.qualifier})`;
-      }
-      result[key].push(data);
-    });
-
+    const result: Record<string, any> = {};
+    identifiers
+      .filter((identifier: any) => keys.includes(identifier.type))
+      .forEach((element: any) => {
+        let data = element.value;
+        const key = availableIdentifiers[element.type];
+        if (!(key in result)) {
+          result[key] = new Set();
+        }
+        if ('qualifier' in element) {
+          data += ` (${element.qualifier})`;
+        }
+        result[key].add(data);
+      });
+    for (const [key, value] of Object.entries(result)) {
+      result[key] = Array.from(value);  // convert set to list
+    }
     return result;
   }
 }


### PR DESCRIPTION
When encoding a identifier for a document, check if another document
already hold this identifier (or an alternative to this identifier).
Closes rero/rero-ils#1893.

## Dependencies

https://github.com/rero/rero-ils/pull/2909

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
