### PR TITLE
search: open aggregation with filters

### DIFF
--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, RouteInterface } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
@@ -24,6 +25,7 @@ import { DocumentEditorComponent } from '../record/custom-editor/document-editor
 import { DocumentDetailViewComponent } from '../record/detail-view/document-detail-view/document-detail-view.component';
 import { DocumentRecordSearchComponent } from '../record/document-record-search/document-record-search.component';
 import { BaseRoute } from './base-route';
+import { RouteToolService } from './route-tool.service';
 
 export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
@@ -32,6 +34,18 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
   /** Record type */
   readonly recordType = 'documents';
+
+  /**
+   * Constructor
+   * @param routeToolService - RouteToolService
+   * @param route - ActivatedRoute
+   */
+   constructor(
+    protected _routeToolService: RouteToolService,
+    protected _route: ActivatedRoute
+  ) {
+    super(_routeToolService);
+   }
 
   /**
    * Get Configuration
@@ -85,7 +99,14 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               'subject',
               'status'
             ],
-            aggregationsExpand: ['document_type'],
+            aggregationsExpand: () => {
+              const expand = ['document_type'];
+              const queryParams = this._route.snapshot.queryParams;
+              if (queryParams.location || queryParams.library) {
+                expand.push('organisation');
+              }
+              return expand;
+            },
             aggregationsBucketSize: 10,
             itemHeaders: {
               Accept: 'application/rero+json, application/json'

--- a/projects/admin/src/app/routes/route.service.ts
+++ b/projects/admin/src/app/routes/route.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { RouteCollectionService } from '@rero/ng-core';
 import { ReceiptLinesRoute } from '../acquisition/routes/receipt-lines-route';
@@ -61,6 +61,7 @@ export class RouteService {
   constructor(
     private _routeCollectionService: RouteCollectionService,
     private _router: Router,
+    private _route: ActivatedRoute,
     private _routeToolService: RouteToolService,
     private _translateService: TranslateService
   ) { }
@@ -71,7 +72,7 @@ export class RouteService {
   initializeRoutes() {
     this._routeCollectionService
       .addRoute(new CirculationPoliciesRoute(this._routeToolService))
-      .addRoute(new DocumentsRoute(this._routeToolService))
+      .addRoute(new DocumentsRoute(this._routeToolService, this._route))
       .addRoute(new HoldingsRoute(this._routeToolService))
       .addRoute(new ItemsRoute(this._routeToolService))
       .addRoute(new IssuesRoute(this._routeToolService))

--- a/projects/public-search/src/app/routes/documents-route.service.spec.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { DocumentsRouteService } from './documents-route.service';
 
@@ -25,7 +26,8 @@ describe('DocumentRouteService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        RouterTestingModule
       ]
     });
     service = TestBed.inject(DocumentsRouteService);

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { ContributionBriefComponent } from '@rero/shared';
@@ -52,10 +53,12 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
    * Constructor
    * @param translateService - TranslateService
    * @param appConfigService - AppConfigService
+   * @param route - ActivatedRoute
    */
   constructor(
     translateService: TranslateService,
-    private appConfigService: AppConfigService
+    private appConfigService: AppConfigService,
+    private route: ActivatedRoute
   ) {
     super(translateService);
   }
@@ -98,7 +101,14 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
                 organisation: _('Library')
               },
               aggregationsOrder: this.aggregations(viewcode),
-              aggregationsExpand: ['document_type'],
+              aggregationsExpand: () => {
+                const expand = ['document_type'];
+                const queryParams = this.route.snapshot.queryParams;
+                if (queryParams.location || queryParams.library) {
+                  expand.push('organisation');
+                }
+                return expand;
+              },
               aggregationsBucketSize: 10,
               preFilters: {
                 view: `${viewcode}`,


### PR DESCRIPTION
This PR is replaced by PR #867.

* Marks the aggregation as open if the url contains a corresponding filter including children filters.
* Adds the ActivatedRoute service for the document route class.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on PR(s):

* [rero/ng-core#501](https://github.com/rero/ng-core/pull/501/)

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
