### PR TITLE
documents: open aggregation with filters and add more facets for documents search

### DIFF
--- a/projects/admin/src/app/menu/service/menu-user-services.service.ts
+++ b/projects/admin/src/app/menu/service/menu-user-services.service.ts
@@ -151,7 +151,6 @@ export class MenuUserServicesService extends MenuBase {
     // ----- DOCUMENTS
     this._documentsMenu = catalogMenu.addChild('Documents')
     .setRouterLink(['/', 'records', 'documents'])
-    .setQueryParam('organisation', this._userService.user.currentOrganisation)
     .setAttribute('id', 'documents-menu')
     .setExtra('iconClass', 'fa fa-file-o');
     this._translatedName(this._documentsMenu, 'Documents');
@@ -329,8 +328,6 @@ export class MenuUserServicesService extends MenuBase {
       // USER SERVICES: COLLECTIONS, ILL REQUESTS
       this._illRequestsMenu.setQueryParam('library', user.currentLibrary);
       this._collectionsMenu.setQueryParam('library', user.currentLibrary);
-      // CATALOG: DOCUMENTS
-      this._documentsMenu.setQueryParam('organisation', user.currentOrganisation);
       // ACQUISITION:
       this._ordersMenu.setQueryParam('library', user.currentLibrary);
       this._lateIssuesMenu.setQueryParam('library', user.currentLibrary);

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, RouteInterface } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
@@ -25,7 +24,6 @@ import { DocumentEditorComponent } from '../record/custom-editor/document-editor
 import { DocumentDetailViewComponent } from '../record/detail-view/document-detail-view/document-detail-view.component';
 import { DocumentRecordSearchComponent } from '../record/document-record-search/document-record-search.component';
 import { BaseRoute } from './base-route';
-import { RouteToolService } from './route-tool.service';
 
 export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
@@ -34,17 +32,6 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
   /** Record type */
   readonly recordType = 'documents';
-
-  /**
-   * Constructor
-   * @param routeToolService - RouteToolService
-   */
-   constructor(
-    protected _routeToolService: RouteToolService,
-    protected _route: ActivatedRoute
-  ) {
-    super(_routeToolService);
-   }
 
   /**
    * Get Configuration
@@ -76,7 +63,17 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
             component: DocumentsBriefViewComponent,
             detailComponent: DocumentDetailViewComponent,
             searchFilters: [
-              this.expertSearchFilter()
+              this.expertSearchFilter(),
+              {
+                label: _('Online resources'),
+                filter: 'online',
+                value: 'true'
+              },
+              {
+                label: _('Physical resources'),
+                filter: 'not_online',
+                value: 'true'
+              }
             ],
             permissions: (record: any) => this._routeToolService.permissions(record, this.recordType),
             preprocessRecordEditor: (record: any) => {
@@ -87,20 +84,31 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
             aggregations: (aggregations: any) => this._routeToolService
               .aggregationFilter(aggregations),
             aggregationsName: {
-              organisation: _('Library')
+              online: _('Online resources'),
+              not_online: _('Physical resources'),
+              organisation: _('Library'),
+              genreForm: _('Genre, form'),
+              intendedAudience: _('Intended audience'),
+              year: _('Publication year'),
+              subject_fiction: _('Subject (fiction)'),
+              subject_no_fiction: _('Subject (non-fiction)'),
             },
             allowEmptySearch: false,
             aggregationsOrder: [
               'document_type',
-              'author',
               'organisation',
               'language',
-              'subject',
+              'year',
+              'author',
+              'subject_no_fiction',
+              'subject_fiction',
+              'genreForm',
+              'intendedAudience',
               'status'
             ],
             aggregationsExpand: () => {
               const expand = ['document_type'];
-              const queryParams = this._route.snapshot.queryParams;
+              const queryParams = this._routeToolService.activatedRoute.snapshot.queryParams;
               if (queryParams.location || queryParams.library) {
                 expand.push('organisation');
               }

--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { DetailComponent, RouteInterface } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
@@ -24,6 +25,7 @@ import { DocumentEditorComponent } from '../record/custom-editor/document-editor
 import { DocumentDetailViewComponent } from '../record/detail-view/document-detail-view/document-detail-view.component';
 import { DocumentRecordSearchComponent } from '../record/document-record-search/document-record-search.component';
 import { BaseRoute } from './base-route';
+import { RouteToolService } from './route-tool.service';
 
 export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
@@ -32,6 +34,17 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
 
   /** Record type */
   readonly recordType = 'documents';
+
+  /**
+   * Constructor
+   * @param routeToolService - RouteToolService
+   */
+   constructor(
+    protected _routeToolService: RouteToolService,
+    protected _route: ActivatedRoute
+  ) {
+    super(_routeToolService);
+   }
 
   /**
    * Get Configuration
@@ -85,7 +98,14 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               'subject',
               'status'
             ],
-            aggregationsExpand: ['document_type'],
+            aggregationsExpand: () => {
+              const expand = ['document_type'];
+              const queryParams = this._route.snapshot.queryParams;
+              if (queryParams.location || queryParams.library) {
+                expand.push('organisation');
+              }
+              return expand;
+            },
             aggregationsBucketSize: 10,
             itemHeaders: {
               Accept: 'application/rero+json, application/json'

--- a/projects/admin/src/app/routes/route.service.ts
+++ b/projects/admin/src/app/routes/route.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Injectable } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { RouteCollectionService } from '@rero/ng-core';
 import { ReceiptLinesRoute } from '../acquisition/routes/receipt-lines-route';
@@ -61,7 +61,6 @@ export class RouteService {
   constructor(
     private _routeCollectionService: RouteCollectionService,
     private _router: Router,
-    private _route: ActivatedRoute,
     private _routeToolService: RouteToolService,
     private _translateService: TranslateService
   ) { }
@@ -72,7 +71,7 @@ export class RouteService {
   initializeRoutes() {
     this._routeCollectionService
       .addRoute(new CirculationPoliciesRoute(this._routeToolService))
-      .addRoute(new DocumentsRoute(this._routeToolService, this._route))
+      .addRoute(new DocumentsRoute(this._routeToolService))
       .addRoute(new HoldingsRoute(this._routeToolService))
       .addRoute(new ItemsRoute(this._routeToolService))
       .addRoute(new IssuesRoute(this._routeToolService))

--- a/projects/admin/src/app/routes/route.service.ts
+++ b/projects/admin/src/app/routes/route.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { RouteCollectionService } from '@rero/ng-core';
 import { ReceiptLinesRoute } from '../acquisition/routes/receipt-lines-route';
@@ -61,6 +61,7 @@ export class RouteService {
   constructor(
     private _routeCollectionService: RouteCollectionService,
     private _router: Router,
+    private _route: ActivatedRoute,
     private _routeToolService: RouteToolService,
     private _translateService: TranslateService
   ) { }
@@ -71,7 +72,7 @@ export class RouteService {
   initializeRoutes() {
     this._routeCollectionService
       .addRoute(new CirculationPoliciesRoute(this._routeToolService))
-      .addRoute(new DocumentsRoute(this._routeToolService))
+      .addRoute(new DocumentsRoute(this._routeToolService, this._route))
       .addRoute(new HoldingsRoute(this._routeToolService))
       .addRoute(new ItemsRoute(this._routeToolService))
       .addRoute(new IssuesRoute(this._routeToolService))

--- a/projects/public-search/src/app/routes/documents-route.service.spec.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { DocumentsRouteService } from './documents-route.service';
 
@@ -25,7 +26,8 @@ describe('DocumentRouteService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        RouterTestingModule
       ]
     });
     service = TestBed.inject(DocumentsRouteService);

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -53,6 +53,7 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
    * Constructor
    * @param translateService - TranslateService
    * @param appConfigService - AppConfigService
+   * @param _route - ActivatedRoute
    */
   constructor(
     translateService: TranslateService,
@@ -97,18 +98,44 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
               label: _('Documents'),
               aggregations: (aggregations: any) => this.aggFilter(aggregations),
               aggregationsName: {
-                organisation: _('Library')
+                online: _('Online resources'),
+                not_online: _('Physical resources'),
+                organisation: _('Library'),
+                genreForm: _('Genre, form'),
+                intendedAudience: _('Intended audience'),
+                year: _('Publication year'),
+                subject_fiction: _('Subject (fiction)'),
+                subject_no_fiction: _('Subject (non-fiction)'),
               },
+              showFacetsIfNoResults: true,
               aggregationsOrder: this.aggregations(viewcode),
               aggregationsExpand: () => {
                 const expand = ['document_type'];
                 const queryParams = this._route.snapshot.queryParams;
-                if (queryParams.location || queryParams.library) {
-                  expand.push('organisation');
+                if (this.appConfigService.globalViewName === viewcode) {
+                  if (queryParams.location || queryParams.library) {
+                    expand.push('organisation');
+                  }
+                } else {
+                  if (queryParams.location) {
+                    expand.push('library');
+                  }
                 }
                 return expand;
               },
               aggregationsBucketSize: 10,
+              searchFilters: [
+                {
+                  label: _('Online resources'),
+                  filter: 'online',
+                  value: 'true'
+                },
+                {
+                  label: _('Physical resources'),
+                  filter: 'not_online',
+                  value: 'true'
+                }
+              ],
               preFilters: {
                 view: `${viewcode}`,
                 simple: 1
@@ -196,19 +223,27 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
     if (this.appConfigService.globalViewName === viewcode) {
       return [
         _('document_type'),
-        _('author'),
         _('organisation'),
         _('language'),
-        _('subject'),
+        _('year'),
+        _('author'),
+        _('subject_no_fiction'),
+        _('subject_fiction'),
+        _('genreForm'),
+        _('intendedAudience'),
         _('status')
       ];
     } else {
       return [
         _('document_type'),
-        _('author'),
         _('library'),
         _('language'),
-        _('subject'),
+        _('year'),
+        _('author'),
+        _('subject_no_fiction'),
+        _('subject_fiction'),
+        _('genreForm'),
+        _('intendedAudience'),
         _('status')
       ];
     }

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { ContributionBriefComponent } from '@rero/shared';
@@ -55,7 +56,8 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
    */
   constructor(
     translateService: TranslateService,
-    private appConfigService: AppConfigService
+    private appConfigService: AppConfigService,
+    private _route: ActivatedRoute
   ) {
     super(translateService);
   }
@@ -98,7 +100,14 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
                 organisation: _('Library')
               },
               aggregationsOrder: this.aggregations(viewcode),
-              aggregationsExpand: ['document_type'],
+              aggregationsExpand: () => {
+                const expand = ['document_type'];
+                const queryParams = this._route.snapshot.queryParams;
+                if (queryParams.location || queryParams.library) {
+                  expand.push('organisation');
+                }
+                return expand;
+              },
               aggregationsBucketSize: 10,
               preFilters: {
                 view: `${viewcode}`,

--- a/projects/public-search/src/index.html
+++ b/projects/public-search/src/index.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
- Marks the aggregation as open if the url contains a corresponding filter including children filters.
- Adds the ActivatedRoute service for the document route class.

Co-Authored-by: Johnny Mariéthoz [Johnny.Mariethoz@rero.ch](mailto:Johnny.Mariethoz@rero.ch)
Co-Authored-by: Valeria Granata [valeria@chaw.com](mailto:valeria@chaw.com)

## Why are you opening this PR?

US: https://github.com/rero/rero-ils/issues/2763

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#2953
* https://github.com/rero/ng-core/pull/503/
## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
