### PR TITLE
acquisitions: fix message info on order line edit button

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
@@ -62,7 +62,7 @@ export class OrderLineComponent implements OnInit, OnDestroy {
       : null;
   }
   get editInfoMessage(): string {
-    return (!this.permissions.delete.can)
+    return (!this.permissions.update.can)
       ? this._recordPermissionService.generateTooltipMessage(this.permissions.update.reasons, 'update')
       : null;
   }

--- a/projects/admin/src/app/service/record-permission.service.ts
+++ b/projects/admin/src/app/service/record-permission.service.ts
@@ -170,9 +170,17 @@ export class RecordPermissionService {
         '=1': this._translateService.instant('has 1 acquisition order attached'),
         other: this._translateService.instant('has # acquisition orders attached')
       },
+      acq_receipt_lines: {
+        '=1': this._translateService.instant('has 1 acquisition receipt line attached'),
+        other: this._translateService.instant('has # acquisition receipts lines attached')
+      },
+      acq_receipt: {
+        '=1': this._translateService.instant('has 1 acquisition receipt attached'),
+        other: this._translateService.instant('has # acquisition receipts attached')
+      },
       acq_accounts: {
         '=1': this._translateService.instant('has 1 acquisition account attached'),
-        other: this._translateService.instant('has # acquisition account attached')
+        other: this._translateService.instant('has # acquisition accounts attached')
       },
       budgets: {
         '=1': this._translateService.instant('has 1 budget attached'),


### PR DESCRIPTION
In the Order detail view, the order line button actions were not
displayed correctly.

* Adds plural links messages.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
