### PR TITLE
documents: Improved display of the request button on the holdings

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/item-request/item-request.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/item-request/item-request.component.ts
@@ -239,7 +239,7 @@ export class ItemRequestComponent implements OnInit {
         if (this.recordType === 'holding') {
           this.formFields.push({
             key: 'description',
-            type: 'textarea',
+            type: 'input',
             templateOptions: {
               label: this._translateService.instant('Collection or item year, volume, number, pages'),
               placeholder: this._translateService.instant('Year / Volume / Number / Pages'),

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.html
@@ -21,10 +21,8 @@
       <a href="#"
         class="collapse-link float-left"
         data-toggle="collapse" aria-expanded="false"
-        *ngIf="collapsable"
         (click)="$event.preventDefault(); collapsed = !collapsed">
         <i [ngClass]="{ 'fa-caret-down': !collapsed, 'fa-caret-right': collapsed }"
-          [hidden]="holding.metadata.public_items_count === 0"
           class="fa fa-lg" aria-hidden="true">
         </i>
       </a>
@@ -40,7 +38,7 @@
       </span>
     </div>
     <div id="holding-available-{{ holding.metadata.pid }}" class="col-sm-12 col-md-3">
-      <span [hidden]="!collapsed && collapsable">
+      <span [hidden]="!collapsed">
         <ng-container *ngIf="holding.metadata.holdings_type === 'serial'; else available">
           <i class="fa fa-circle text-warning"></i>
           {{ 'see collections and items' | translate }}
@@ -52,14 +50,6 @@
           {{ (holding.metadata.available ? 'available' : 'not available') | translate }}
         </ng-template>
       </span>
-    </div>
-    <!-- request dialog -->
-    <div id="holding-request-{{ holding.metadata.pid }}"
-        [ngClass]="requestDialog ? 'row col-12' : 'col-sm-12 col-md-2'">
-        <public-search-request
-        [record]="holding" recordType="holding"
-        (requestDialogEvent)="getRequestDialogValue($event)"
-        [viewcode]="viewcode" class="w-100"></public-search-request>
     </div>
   </div>
   <!-- SERIAL HOLDING INFORMATIOLNS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
@@ -109,7 +99,14 @@
     </ng-container>
   </dl>
 </div>
-<public-search-items [holding]="holding"
-                     [viewcode]="viewcode"
-                     [hidden]="collapsed || !collapsable"
-></public-search-items>
+<ng-container *ngIf="!collapsed">
+  <public-search-items *ngIf="holding.metadata.public_items_count > 0" [holding]="holding" [viewcode]="viewcode"></public-search-items>
+  <public-search-request
+    [record]="holding"
+    recordType="holding"
+    [viewcode]="viewcode"
+    [holdingsItemsCount]="holding.metadata.public_items_count"
+    class="w-100"
+    [ngClass]="{'mt-2': holding.metadata.public_items_count === 0}"
+  ></public-search-request>
+</ng-container>

--- a/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/holding/holding.component.ts
@@ -28,12 +28,12 @@ export class HoldingComponent {
   // COMPONENT ATTRIBUTES =====================================================
   /** Holdings record */
   @Input() holding: any;
+
   /** View code */
   @Input() viewcode: string;
+
   /** Is collapsed holdings */
   @Input() collapsed = true;
-  /** Is collapsable holdings */
-  @Input() collapsable = true;
 
   /** Authorized types of note */
   noteAuthorizedTypes: string[] = [HoldingsNoteType.GENERAL, HoldingsNoteType.ACCESS];
@@ -53,9 +53,4 @@ export class HoldingComponent {
    * @param _translateService - TranslateService
    */
   constructor(private _translateService: TranslateService) {}
-
-  getRequestDialogValue($event) {
-    this.requestDialog = $event;
-  }
-
 }

--- a/projects/public-search/src/app/document-detail/holdings/items/items.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/items/items.component.html
@@ -14,25 +14,24 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ng-container *ngIf="!hidden">
-  <div class="card-body p-2">
-      <ng-container *ngIf="items.length > 0; else noItems">
-        <public-search-item
-          *ngFor="let item of items; let index = index"
-          context="holding"
-          [item]="item"
-          [viewcode]="viewcode"
-          [index]="index"
-        ></public-search-item>
-        <ng-container *ngIf="isLinkShowMore">
-          <button type="button" class="btn btn-link pr-1" (click)="showMore()">
-            <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
-          </button>
-          <small>({{ hiddenItems }})</small>
-        </ng-container>
+
+<div class="card-body p-2">
+    <ng-container *ngIf="items.length > 0; else noItems">
+      <public-search-item
+        *ngFor="let item of items; let index = index"
+        context="holding"
+        [item]="item"
+        [viewcode]="viewcode"
+        [index]="index"
+      ></public-search-item>
+      <ng-container *ngIf="isLinkShowMore">
+        <button type="button" class="btn btn-link pr-1" (click)="showMore()">
+          <i class="fa fa-plus-square-o"></i> {{ 'Show more' | translate }}
+        </button>
+        <small>({{ hiddenItems }})</small>
       </ng-container>
-  </div>
-</ng-container>
+    </ng-container>
+</div>
 
 <ng-template #noItems>
   <div class="card-body pl-4" translate>No item received.</div>

--- a/projects/public-search/src/app/document-detail/holdings/items/items.component.ts
+++ b/projects/public-search/src/app/document-detail/holdings/items/items.component.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { ItemApiService } from '../../../api/item-api.service';
@@ -24,7 +24,7 @@ import { QueryResponse } from '../../../record';
   selector: 'public-search-items',
   templateUrl: './items.component.html'
 })
-export class ItemsComponent {
+export class ItemsComponent implements OnInit {
 
   // COMPONENT ATTRIBUTES =====================================================
   /** Holding */
@@ -41,22 +41,8 @@ export class ItemsComponent {
 
   /** Items per page */
   private itemsPerPage = 10;
-  /** Is items are hidden */
-  private _hidden = true;
-
 
   // GETTER & SETTER ========================================================
-
-  /** Handler to detect change on input `hidden` property */
-  @Input() set hidden(value: boolean) {
-    this._hidden = value;
-    if (!this._hidden && this.items.length === 0) {
-      this._loadItems();
-    }
-  }
-  get hidden(): boolean {
-    return this._hidden;
-  }
 
   /**
    * Is the link `show more items` must be displayed
@@ -91,6 +77,10 @@ export class ItemsComponent {
     private _itemApiService: ItemApiService,
     private _translateService: TranslateService
   ) { }
+
+  ngOnInit(): void {
+    this._loadItems();
+  }
 
   // COMPONENT FUNCTIONS ==================================================
   /** Handler when 'show more items' link is clicked. */

--- a/projects/public-search/src/app/document-detail/item/item.component.html
+++ b/projects/public-search/src/app/document-detail/item/item.component.html
@@ -102,5 +102,5 @@
   </dl>
 
   <!-- REQUEST DIALOG -->
-  <public-search-request [record]="item" recordType="item" [viewcode]="viewcode" class="col-12"></public-search-request>
+  <public-search-request [record]="item" recordType="item" [viewcode]="viewcode" class="w-100 mb-2"></public-search-request>
 </div>

--- a/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.html
+++ b/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.html
@@ -15,38 +15,43 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="fields.length > 0 && showForm">
-  <div id="pickup-location-{{ record.metadata.pid }}" class="row pl-4 col-12">
-    <dt class="mb-0 col-lg-2 col-sm-3">&nbsp;</dt>
-    <dd class="mb-0 col-lg-10 col-sm-9">
-      <form class="my-2" [formGroup]="form" (ngSubmit)="submit()">
-        <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
-        <button
-          id="pickup-location-{{ record.metadata.pid }}-cancel-button"
-          *ngIf="!requestInProgress"
-          class="btn btn-sm btn-outline-secondary mr-2"
-          (click)="closeDialog()"
-          translate
-        >Cancel</button>
-        <button id="pickup-location-{{ record.metadata.pid }}-confirm-button" type="submit" class="btn btn-sm btn-primary" [disabled]="!form.valid || requestInProgress">
-          <ng-container *ngIf="!requestInProgress; else inProcess">
-            {{ 'Confirm your request' | translate }}
-          </ng-container>
-        </button>
-        <ng-template #inProcess>
-          <span class="spinner-border spinner-border-sm mr-1" role="status"></span>
-          {{ 'Request in progress' | translate }}
-        </ng-template>
-      </form>
-    </dd>
+  <div id="pickup-location-{{ record.metadata.pid }}" class="row pl-4" [ngClass]="{'mb-4': recordType === 'holding' }">
+    <div class="col-12 pl-0">
+      <dd class="mb-0 pl-0">
+        <ng-container *ngIf="recordType === 'holding' && itemCount > 0">
+          <div class="alert alert-warning my-4" translate>Please make sure that your requested issue is not listed above.</div>
+        </ng-container>
+        <form class="my-2 w-100" [formGroup]="form" (ngSubmit)="submit()">
+          <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
+          <button
+            id="pickup-location-{{ record.metadata.pid }}-cancel-button"
+            *ngIf="!requestInProgress"
+            class="btn btn-sm btn-outline-secondary mr-2"
+            (click)="closeDialog()"
+            translate
+          >Cancel</button>
+          <button id="pickup-location-{{ record.metadata.pid }}-confirm-button" type="submit" class="btn btn-sm btn-primary" [disabled]="!form.valid || requestInProgress">
+            <ng-container *ngIf="!requestInProgress; else inProcess">
+              {{ 'Confirm your request' | translate }}
+            </ng-container>
+          </button>
+          <ng-template #inProcess>
+            <span class="spinner-border spinner-border-sm mr-1" role="status"></span>
+            {{ 'Request in progress' | translate }}
+          </ng-template>
+        </form>
+      </dd>
+    </div>
   </div>
 </ng-container>
 <ng-container *ngIf="requested && !showForm">
-  <div class="row pl-4 col-12">
-    <dt class="mb-0 col-lg-2 col-sm-3" translate>&nbsp;</dt>
-    <dd class="mb-0 col-lg-10 col-sm-9 pl-0">
-      <div class="alert ml-0 mt-2" [ngClass]="{'alert-success': requestMessage.success, 'alert-danger': !requestMessage.success}" role="alert">
-        {{ requestMessage.message }}
-      </div>
-    </dd>
+  <div class="row pl-4" [ngClass]="{'mb-4': recordType === 'holding' }">
+    <div class="col-12 mpl-0">
+      <dd class="mb-0 pl-0">
+        <div class="alert ml-0 mt-2" [ngClass]="{'alert-success': requestMessage.success, 'alert-danger': !requestMessage.success}" role="alert">
+          {{ requestMessage.message }}
+        </div>
+      </dd>
+    </div>
   </div>
 </ng-container>

--- a/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.ts
+++ b/projects/public-search/src/app/document-detail/request/pickup-location/pickup-location.component.ts
@@ -38,6 +38,9 @@ export class PickupLocationComponent implements OnInit {
   /** View code */
   @Input() viewcode: string;
 
+  /** Item count */
+  @Input() itemCount = 0;
+
   /** Close request dialog event */
   @Output() closeEvent = new EventEmitter<boolean>();
 

--- a/projects/public-search/src/app/document-detail/request/request.component.html
+++ b/projects/public-search/src/app/document-detail/request/request.component.html
@@ -17,26 +17,44 @@
 <ng-container *ngIf="patron">
   <ng-container *ngIf="!requestDialog; else requestPickupDialog">
     <ng-container *ngIf="canRequest">
-      <div *ngIf="canRequest.can" id="record-request-{{ record.metadata.pid }}" [ngClass]="recordType == 'item' ? 'row pl-4' : ''" >
-        <dt *ngIf="recordType !== 'holding'" class="my-2 col-lg-2 col-sm-3">&nbsp;</dt>
-        <dd class="my-2 col-lg-9 col-sm-8">
+      <dl *ngIf="canRequest.can" id="record-request-{{ record.metadata.pid }}" class="row" [ngClass]="{'row pl-4': recordType === 'item', 'mb-3': recordType === 'holding'}">
+        <dt *ngIf="recordType !== 'holding'" class="mt-2 mb-3 col-lg-2 col-sm-3">&nbsp;</dt>
+        <dd class="mt-2 mb-3 col-lg-9 col-sm-8">
           <button
             id="record-{{ record.metadata.pid }}-request-button"
-            class="btn btn-sm btn-primary"
+            class="btn btn-sm"
+            [ngClass]="{'btn-primary': recordType === 'item', 'btn-outline-primary': recordType === 'holding'}"
             (click)="showRequestDialog()"
-            translate
-          >Request</button>
+          >
+            <ng-container *ngIf="recordType === 'item'; else holdingsButton">
+              {{ 'Request' | translate }}
+            </ng-container>
+            <ng-template #holdingsButton>
+              <ng-container *ngIf="holdingsItemsCount > 0; else holdingsNoItems">
+                {{ 'Request another issue' | translate }}
+              </ng-container>
+              <ng-template #holdingsNoItems>
+                {{ 'Request an issue' | translate }}
+              </ng-template>
+            </ng-template>
+          </button>
         </dd>
-      </div>
+      </dl>
     </ng-container>
   </ng-container>
   <ng-template #requestPickupDialog>
-    <public-search-pickup-location
-      [record]="record"
-      recordType="{{ recordType }}"
-      [viewcode]="viewcode"
-      (closeEvent)="closeDialog()"
-      class="row pl-4"
-    ></public-search-pickup-location>
+    <dl class="m-0 ml-4 py-2 row">
+      <dt *ngIf="recordType !== 'holding'" class="my-2 col-lg-2 col-sm-3">&nbsp;</dt>
+      <dd class="pl-0 mt-0 mb-3" [ngClass]="{'col-lg-10 col-sm-9': recordType !== 'holding', 'col-lg-12': recordType === 'holding' }">
+        <public-search-pickup-location
+          [record]="record"
+          [itemCount]="holdingsItemsCount"
+          recordType="{{ recordType }}"
+          [viewcode]="viewcode"
+          (closeEvent)="closeDialog()"
+          class="w-100"
+        ></public-search-pickup-location>
+      </dd>
+    </dl>
   </ng-template>
 </ng-container>

--- a/projects/public-search/src/app/document-detail/request/request.component.ts
+++ b/projects/public-search/src/app/document-detail/request/request.component.ts
@@ -34,6 +34,9 @@ export class RequestComponent implements OnInit {
   /** View code */
   @Input() viewcode: string;
 
+  /** Holdings item count */
+  @Input() holdingsItemsCount: number;
+
   /** Item Can request with reason(s) */
   canRequest: {
     can: false,


### PR DESCRIPTION
The holdings request button has been removed from the holdings block.
This button now appears at the end of the items list.

* Closes rero/rero-ils#2943.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
