### PR TITLE
document: fix collection display

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
@@ -253,22 +253,6 @@ export class DocumentDetailViewComponent implements DetailRecord, OnInit, OnDest
     }
   }
 
-  /**
-   * Get short main title
-   * @param titles - document titles
-   * @return - main title to display
-   */
-  getShortMainTitle(titles: any) {
-    const bfTitles: Array<any> = titles.filter((title: any) => title.type === 'bf:Title');
-    for (const bfTitle of bfTitles) {
-      for (const mainTitle of bfTitle.mainTitle) {
-        if (!mainTitle.language) {
-          return mainTitle.value;
-        }
-      }
-    }
-  }
-
   contributionTypeParam(contribution: any) {
     switch (contribution.type) {
       case 'bf:Person':

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.html
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.html
@@ -24,12 +24,12 @@
             <b>{{ getPartOfLabel(hostDocument) }}</b>:
             <ng-container *ngIf="isPublicView; else adminLink">
               <a id="{{ 'doc-part-of-' + i }}" href="/{{ viewcode }}/documents/{{ partOf.document.pid }}">
-                {{ getShortMainTitle(hostDocument.metadata.title) }}
+                {{ hostDocument.metadata.title | mainTitle }}
               </a>
             </ng-container>
             <ng-template #adminLink>
               <a id="{{ 'doc-part-of-' + i }}" [routerLink]="['/records', 'documents', 'detail', partOf.document.pid]">
-                {{ getShortMainTitle(hostDocument.metadata.title) }}
+                {{ hostDocument.metadata.title | mainTitle }}
               </a>
             </ng-template>
             <ng-container *ngIf="partOf.numbering">
@@ -58,12 +58,12 @@
             <div class="row">
               <ng-container *ngIf="isPublicView; else adminLink">
                 <a id="{{ 'doc-part-of-' + i }}" href="/{{ viewcode }}/documents/{{ document.document.pid }}">
-                  {{ getShortMainTitle(hostDocument.metadata.title) }}
+                  {{ hostDocument.metadata.title | mainTitle }}
                 </a>
               </ng-container>
               <ng-template #adminLink>
                 <a id="{{ 'doc-part-of-' + i }}" [routerLink]="['/records', 'documents', 'detail', document.document.pid]">
-                  {{ getShortMainTitle(hostDocument.metadata.title) }}
+                  {{ hostDocument.metadata.title | mainTitle }}
                 </a>
               </ng-template>
               <ng-container *ngIf="document.numbering">

--- a/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
+++ b/projects/shared/src/lib/view/brief/part-of/part-of.component.ts
@@ -63,22 +63,6 @@ export class PartOfComponent {
   }
 
   /**
-   * Get short main title
-   * @param titles - document titles
-   * @return - main title to display
-   */
-  getShortMainTitle(titles: any) {
-    const bfTitles: Array<any> = titles.filter((title: any) => title.type === 'bf:Title');
-    for (const bfTitle of bfTitles) {
-      for (const mainTitle of bfTitle.mainTitle) {
-        if (!mainTitle.language) {
-          return mainTitle.value;
-        }
-      }
-    }
-  }
-
-  /**
    * Format "part of" numbering for display
    *
    * @param num: numbering to format


### PR DESCRIPTION
The `partOf` (collection) fields is now displayed as a main title.

Co-authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## Dependencies

My PR depends on `rero-ils#<xx>`'s PR(s):

* rero/rero-ils#<xx>

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
