### PR TITLE
libraries: add rollover settings

### DIFF
--- a/projects/admin/src/app/classes/library.ts
+++ b/projects/admin/src/app/classes/library.ts
@@ -80,6 +80,10 @@ export interface Address {
   country: string;
 }
 
+export interface RolloverSettings {
+  account_transfer: string
+}
+
 export class Library {
 
   // CLASS ATTRIBUTES ================================================
@@ -95,6 +99,7 @@ export class Library {
   notification_settings?: Array<NotificationSettings>;
   acquisition_settings?: AcquisitionInformations;
   organisation: Organisation;
+  rollover_settings: RolloverSettings;
 
   // GETTER & SETTER ================================================
   /** Allow to get all opening days for the library */

--- a/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019 RERO
+ * Copyright (C) 2019-2022 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { RecordService, TimeValidator } from '@rero/ng-core';
 import { forkJoin, Subject } from 'rxjs';
-import { AcquisitionInformations, Library, NotificationSettings } from '../../../classes/library';
+import { AcquisitionInformations, Library, NotificationSettings, RolloverSettings } from '../../../classes/library';
 import { NotificationType } from '../../../classes/notification';
 import { WeekDays } from '../../../classes/week-days';
 
@@ -40,6 +40,10 @@ export class LibraryFormService {
   private countryList = [];
   /** Observable for build event */
   private buildEvent = new Subject();
+  /** Rollover account transfer */
+  private rolloverAccountTransferOptions = [];
+  /** Default account transfer */
+  private accountDefaultTransfertOption = 'rollover_no_transfer';
 
   // GETTER & SETTER ==========================================================
   get name(): AbstractControl { return this.form.get('name'); }
@@ -51,6 +55,8 @@ export class LibraryFormService {
   get communication_language(): AbstractControl { return this.form.get('communication_language'); }
   get available_communication_languages() { return this.availableCommunicationLanguages; }
   get countries_iso_codes() { return this.countryList; }
+  get rollover_settings(): AbstractControl { return this.form.get('rollover_settings'); }
+  get account_transfer_options() { return this.rolloverAccountTransferOptions; }
 
   // SERVICE CONSTRUCTOR & HOOKS ==============================================
   /** Constructor
@@ -77,6 +83,9 @@ export class LibraryFormService {
       acquisition_settings: this._fb.group({
         shipping_informations: this._buildAcqInformation(),
         billing_informations: this._buildAcqInformation()
+      }),
+      rollover_settings: this._fb.group({
+        account_transfer: [this.accountDefaultTransfertOption, [Validators.required]]
       })
     });
     this._initializeOpeningHours();
@@ -97,6 +106,8 @@ export class LibraryFormService {
       this.notificationTypes = notifSchema.schema.properties.notification_type.enum;
       this.countryList = libSchema.schema.properties.acquisition_settings.properties.shipping_informations.
         properties.address.properties.country.enum;
+      this.rolloverAccountTransferOptions = libSchema.schema.properties.rollover_settings.properties.
+        account_transfer.enum;
       this.build();
       this.buildEvent.next(true);
     });
@@ -117,6 +128,7 @@ export class LibraryFormService {
     this._setOpeningHours(library.opening_hours);
     this._setNotificationSettings(library.notification_settings);
     this._setAcquisitionSettings(library.acquisition_settings);
+    this._setRolloverSettings(library.rollover_settings);
   }
 
   /** Get the values stored in the form */
@@ -322,5 +334,14 @@ export class LibraryFormService {
         }
       }
     }
+  }
+
+  /**
+   * Set values from rollover
+   * @param settings - rollover settings
+   */
+  private _setRolloverSettings(settings: RolloverSettings): void {
+    const rolloverSettings = this.form.get('rollover_settings');
+    rolloverSettings.get('account_transfer').setValue(settings.account_transfer);
   }
 }

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.html
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.html
@@ -1,18 +1,18 @@
 <!--
   RERO ILS UI
-   Copyright (C) 2019 RERO
+  Copyright (C) 2019-2022 RERO
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published by
-   the Free Software Foundation, version 3 of the License.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div class="container">
   <ng-container *ngIf="libForm">
@@ -349,6 +349,25 @@
                   <div class="col input-group">
                     <div class="input-group-prepend"><span class="input-group-text"><i class="fa fa-sticky-note-o"></i></span></div>
                     <input formControlName="extra" id="billing-extra" class="form-control">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-3">
+            <div class="card" formGroupName="rollover_settings">
+              <div class="card-header">
+                <i class="fa fa-wrench"></i>
+                {{ 'Rollover settings' | translate }}
+              </div>
+              <div class="card-body container">
+                <!-- account transfer -->
+                <div class="form-group form-row">
+                  <label for="shipping-street" class="col-3 col-form-label" translate>Account transfer</label>
+                  <div class="col-9">
+                    <select formControlName="account_transfer" class="form-control" id="account-transfer">
+                      <option [ngValue]="option" *ngFor="let option of rollover_account_transfer_options">{{ option | translate }}</option>
+                    </select>
                   </div>
                 </div>
               </div>

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019 RERO
+ * Copyright (C) 2019-2022 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -69,6 +69,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
   get notificationSettings() { return this.libraryForm.notification_settings as FormArray; }
   /** Available communication languages */
   get availableCommunicationLanguages() { return this.libraryForm.available_communication_languages; }
+  /** Rollover settings */
+  get rolloverSettings() { return this.libraryForm.rollover_settings; }
+  /** Rollover account transfer options */
+  get rollover_account_transfer_options() { return this.libraryForm.account_transfer_options; }
 
 
   // CONSTRUCTOR & HOOKS ======================================================

--- a/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.html
@@ -44,13 +44,15 @@
   </section>
 
   <tabset>
-    <tab><!-- OPENING HOURS TABS -->
+    <tab>
+      <!-- OPENING HOURS TABS -->
       <ng-template tabHeading>
         <i class="fa fa-clock-o mr-2"></i>{{ 'Opening Hours' | translate }}
       </ng-template>
       <admin-day-opening-hours [day]="day" *ngFor="let day of record.opening_hours"></admin-day-opening-hours>
     </tab>
-    <tab><!-- EXCEPTIONS DATES -->
+    <tab>
+      <!-- EXCEPTIONS DATES -->
       <ng-template tabHeading>
         <i class="fa fa-exclamation-triangle mr-2"></i>{{ 'Exceptions (holidays, etc.)' | translate }}
       </ng-template>
@@ -58,7 +60,8 @@
         <admin-exception-date [exception]="exception" *ngFor="let exception of record.exception_dates"></admin-exception-date>
       </ng-container>
     </tab>
-    <tab><!-- NOTIFICATIONS SETTINGS -->
+    <tab>
+      <!-- NOTIFICATIONS SETTINGS -->
       <ng-template tabHeading>
         <i class="fa fa-envelope-o mr-2"></i>{{ 'Notification settings' | translate }}
       </ng-template>
@@ -75,7 +78,8 @@
         </ng-container>
       </dl>
     </tab>
-    <tab> <!-- ACQUISITION SETTINGS -->
+    <tab>
+      <!-- ACQUISITION SETTINGS -->
       <ng-template tabHeading>
         <i class="fa fa-university mr-2"></i>{{ 'Acquisition settings' | translate }}
       </ng-template>
@@ -88,6 +92,17 @@
                       [ngTemplateOutlet]="address_block"
                       [ngTemplateOutletContext]="{ label: 'Billing informations' | translate, data: acqInfos}"
         ></ng-container>
+      </dl>
+
+      <!-- ROLLOVER SETTINGS -->
+      <dl class="row">
+        <dt class="col-3 label-title" translate>Rollover settings</dt>
+        <div class="col-9 card container py-2 mb-2">
+          <dl class="row">
+            <dt class="col-3 label-title" translate>Account transfer</dt>
+            <dd class="col-7">{{ record.rollover_settings.account_transfer | translate }}</dd>
+          </dl>
+        </div>
       </dl>
     </tab>
   </tabset>


### PR DESCRIPTION
* Adds new rollover settings form on acquisitions tab.
* Adds rollover settings on the library detailed view.

**Library form**
![rollover_edit](https://user-images.githubusercontent.com/48578/188678157-d10abe8e-fc22-43cc-91f5-5dd89c22e5e8.png)

**Library detailed view**
![rollover_show](https://user-images.githubusercontent.com/48578/188678179-4b01e30c-68a7-4ae0-bea9-d77dc2793fd7.png)


Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
