### PR TITLE
menu: translation for current loans

### DIFF
--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -202,6 +202,7 @@ _('{{ counter }} hidden holdings');
 // Menu entries
 _('User services');
 _('Catalog');
+_('Current loans');
 _('ILL requests');
 _('Import from the web');
 _('Corporate bodies');


### PR DESCRIPTION
* Adds manual translation for "current loans".

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
