### PR TITLE
documents: formatting of the title variant

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-description/document-description.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-description/document-description.component.ts
@@ -151,7 +151,24 @@ export class DocumentDescriptionComponent {
         if ('subtitle' in title) {
           result.push(title.subtitle[0].value);
         }
-        variants[title.type].push(result.join(': '));
+        let variantTitle = result.join(': ');
+        const variantData = [];
+        if ('part' in title) {
+          title.part.forEach((part: any) => {
+            const variantNumberData = [];
+            if ('partNumber' in part) {
+              variantNumberData.push(part.partNumber[0].value);
+            }
+            if ('partName' in part) {
+              variantNumberData.push(part.partName[0].value);
+            }
+            variantData.push(variantNumberData.join(', '));
+          });
+        }
+        if (variantData.length > 0) {
+          variantTitle += `. ${variantData.join('. ')}`;
+        }
+        variants[title.type].push(variantTitle);
       });
     }
     return variants;


### PR DESCRIPTION
* Adds number and name fields in the title variant.
* Closes rero/rero-ils#2906 (part 2).

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

### Display

<img width="1207" alt="variant" src="https://user-images.githubusercontent.com/48578/189087402-a3f18ed1-af4e-4d03-b57f-7481139a6a73.png">

