### PR TITLE
document: filter on the remote typeahead

### DIFF
--- a/projects/admin/src/app/classes/typeahead/documents-typeahead.ts
+++ b/projects/admin/src/app/classes/typeahead/documents-typeahead.ts
@@ -80,10 +80,15 @@ export class DocumentsTypeahead implements ITypeahead {
     if (!query) {
       return of([]);
     }
+
+    let queryString = `((autocomplete_title:${query})^2 OR ${query})`;
+    if (options.filter) {
+      queryString += ` AND ${options.filter}`;
+    }
     return this._recordService
       .getRecords(
         'documents',
-        `(autocomplete_title:${query})^2 OR ${query}`,
+        queryString,
         1,
         numberOfSuggestions
       ).pipe(


### PR DESCRIPTION
The filter option has been added to the document query. This allows to customize the query by specifying it in the json schema.

* Closes rero/rero-ils#3018.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

### Linked to
[document: add filter on the remoteTypeahead](https://github.com/rero/rero-ils/pull/3114)