### PR TITLE
Fees: fix labels for missing data

### DIFF
--- a/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-event-overdue.component.html
+++ b/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-event-overdue.component.html
@@ -20,8 +20,10 @@
   <dl class="row ml-3 mb-0">
     <dt class="label-title col-3" translate>Call number</dt>
     <dd class="col-9">
-      <shared-inherited-call-number [item]="parent.loan.item"></shared-inherited-call-number>
-      (<a [routerLink]="['/records', 'items', 'detail', parent.loan.item.pid]">{{ parent.loan.item.barcode }}</a>)
+      <ng-container *ngIf="parent.loan.item else no_item">
+        <shared-inherited-call-number [item]="parent.loan?.item"></shared-inherited-call-number>
+        (<a [routerLink]="['/records', 'items', 'detail', parent.loan.item.pid]">{{ parent.loan.item.barcode }}</a>)
+      </ng-container>
     </dd>
     <dt class="label-title col-3" translate>Patron</dt>
     <dd class="col-9">
@@ -29,3 +31,7 @@
     </dd>
   </dl>
 </div>
+
+<ng-template #no_item>
+  <span class="no-data raw-data">item_pid:{{ parent.loan.item_pid.value }}</span>
+</ng-template>

--- a/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/pie/payment-data-pie.component.scss
+++ b/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/pie/payment-data-pie.component.scss
@@ -37,6 +37,9 @@
 
   // HACK ngx-charts css classes to display legend as we want.
   .chart-legend {
+
+    display: block;
+
     .legend-labels {
       background: transparent;
     }

--- a/projects/admin/src/app/scss/styles.scss
+++ b/projects/admin/src/app/scss/styles.scss
@@ -50,8 +50,20 @@ button.disabled {
 
 .no-data {
   font-style: italic;
-  font-color: $light;
+  color: $gray-500;
 }
+
+.raw-data {
+  font-size: .75rem;
+  font-family: "Courier New";
+  &:before {
+    content: '[';
+  }
+  &:after {
+    content: ']';
+  }
+}
+
 
 .rero-ils-logo {
   max-height: $navbar-brand-height;


### PR DESCRIPTION
* If some fee related resource doesn't still exists, this will cause an error. Now if data is missing, a label containing the related resource pid is displayed.
* Fix fees pie widget legend display

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test 

![image](https://user-images.githubusercontent.com/10031585/211845127-06dae28e-7a2e-4adc-8af9-c66255a53786.png)

See missing "item:466" (third search result hit)
