### PR TITLE
patron: fix the display of the badges on brief view

### DIFF
--- a/projects/admin/src/app/record/brief-view/patrons-brief-view/patrons-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/patrons-brief-view/patrons-brief-view.component.html
@@ -22,9 +22,6 @@
     <a [routerLink]="[detailUrl.link]">
       {{ record.metadata.last_name }}<ng-container *ngIf="record.metadata.first_name">, {{ record.metadata.first_name }}</ng-container>
     </a>
-    <small class="badge badge-pill" [class]="getRoleBadgeColor(role)" *ngFor="let role of record.metadata.roles">
-      {{ role | translate }}
-    </small>
     <div *ngIf="circulationAccess && record.metadata.patron" class="action-buttons">
       <a [routerLink]="['/circulation', 'patron', record.metadata.patron.barcode[0]]" class="btn-link btn btn-sm btn-outline-primary">
         <i class="fa fa-exchange mr-2"></i>
@@ -33,6 +30,11 @@
     </div>
   </h5>
   <div class="card-text">
+    <p>
+      <small class="badge badge-pill mr-1" [class]="getRoleBadgeColor(role)" *ngFor="let role of record.metadata.roles">
+        {{ role | translate }}
+      </small>
+    </p>
     <p>{{ record.metadata.birth_date | dateTranslate:'mediumDate' }} &mdash; {{ record.metadata.city }}</p>
   </div>
 </div>


### PR DESCRIPTION
## Display

### before
<img width="893" alt="badge" src="https://user-images.githubusercontent.com/48578/226370814-0379d61b-4f73-4d17-8d84-ed2d277116b2.png">

## after
<img width="894" alt="badge-after" src="https://user-images.githubusercontent.com/48578/226370907-f2274683-5bc1-4cda-969f-59a6e59a8dc3.png">

