### PR TITLE
Transactions: fix transactions total amount calculation

### DIFF
--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
@@ -143,11 +143,11 @@ export class PatronTransactionEventFormComponent implements OnInit {
   }
 
   /**
-   * compute the total amount of the current event
-   * @return totalAmount as number
+   * Compute the total amount of the current event
+   * @return totalAmount as number with maximum 2 decimals.
    */
   private _computeTotalAmount() {
-    return this.transactions.reduce((acc, t) => acc + t.total_amount, 0);
+    return this.transactions.reduce((acc, t) => parseFloat((acc + t.total_amount).toFixed(2)), 0);
   }
 
   /**
@@ -176,7 +176,11 @@ export class PatronTransactionEventFormComponent implements OnInit {
           ? transaction.total_amount
           : residualAmount;
         this._patronTransactionService.payPatronTransaction(transaction, transactionAmount, formValues.method);
-        residualAmount -= transactionAmount;
+        // DEV NOTES : We use the below syntax to avoid floating-number precision drift.
+        //   on each iteration we 'round' the residual amount to a float with 2 decimals precision.
+        //   --> with this syntax : (7.8 - 2 - 2 - 2) = 1.8
+        //   --> without this syntax : (7.8 - 2 - 2 - 2) = 1.7999999999999998
+        residualAmount = parseFloat((residualAmount - transactionAmount).toFixed(2));
         if (residualAmount <= 0) {
           break;
         }

--- a/projects/admin/src/app/circulation/services/patron-transaction.service.ts
+++ b/projects/admin/src/app/circulation/services/patron-transaction.service.ts
@@ -156,13 +156,12 @@ export class PatronTransactionService {
    * @returns total amount of open transactions
    */
   computeTotalTransactionsAmount(transactions: Array<any>): number {
-    let total = 0;
-    for (const transaction of transactions) {
-      if (transaction.status === PatronTransactionStatus.OPEN) {
-        total += transaction.total_amount;
-      }
-    }
-    return total;
+    return transactions.reduce((accumulator, transaction) => {
+      return (transaction.status === PatronTransactionStatus.OPEN)
+        ? parseFloat((accumulator + transaction.total_amount).toFixed(2))
+        : accumulator;
+    }, 0);
+
   }
 
 
@@ -243,7 +242,6 @@ export class PatronTransactionService {
         this._toastService.success(this._translateService.instant('{{ type }} registered', {type: translateType}));
       },
       (error) => {
-        console.error(error, error.toString());
         const errorMessage = (error.hasOwnProperty('message') && error.message().hasOwnProperty('message'))
           ? error.message.message
           : 'Server error :: ' + (error.title || error.toString());


### PR DESCRIPTION
* When a librarian will pay for multiple transactions, it was possible that the calculated total amount had more than 2 decimals. This is due to floating-point decimal precision with float numbers in Javascript. This PR ensure than all amount/calculation about fees are maximum 2 decimals.
* Closes rero/rero-ils#2961.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
