### PR TITLE
item circulation history: add notification

### DIFF
--- a/projects/admin/src/app/api/notification-api.service.spec.ts
+++ b/projects/admin/src/app/api/notification-api.service.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RecordService } from '@rero/ng-core';
+import { of } from 'rxjs';
+
+import { NotificationApiService } from './notification-api.service';
+
+describe('NotificationApiService', () => {
+  let service: NotificationApiService;
+
+  const notificationRecord = {
+    "created": "2023-03-22T16:00:14.542814+00:00",
+    "id": "34",
+    "links": {
+      "self": "https://localhost:5000/api/notifications/34"
+    },
+    "metadata": {
+      "$schema": "https://bib.rero.ch/schemas/notifications/notification-v0.0.1.json",
+      "context": {
+        "loan": {
+          "$ref": "https://bib.rero.ch/api/loans/69"
+        }
+      },
+      "creation_date": "2023-03-22T16:00:14.527673+00:00",
+      "notification_sent": true,
+      "notification_type": "recall",
+      "pid": "34",
+      "process_date": "2023-03-22T16:00:14.714258",
+      "status": "done"
+    },
+    "updated": "2023-03-22T16:00:14.719610+00:00"
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecord']);
+  recordServiceSpy.getRecord.and.returnValue(of(notificationRecord));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy }
+      ]
+    });
+    service = TestBed.inject(NotificationApiService);
+
+
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return a notification record', () => {
+    service.getNotificationByPid('34').subscribe((record: any) => {
+      expect(record).toEqual(notificationRecord.metadata);
+    });
+  });
+});

--- a/projects/admin/src/app/api/notification-api.service.ts
+++ b/projects/admin/src/app/api/notification-api.service.ts
@@ -1,0 +1,44 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { RecordService } from '@rero/ng-core';
+import { BaseApi } from '@rero/shared';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationApiService extends BaseApi {
+
+  /** Resource name */
+  readonly RESOURCE_NAME = 'notifications';
+
+  /**
+   * Constructor
+   * @param _recordService - RecordService
+   */
+  constructor(private _recordService: RecordService) {
+    super();
+  }
+
+  getNotificationByPid(pid: string): any {
+    return this._recordService.getRecord(this.RESOURCE_NAME, pid).pipe(
+      map((result: any) => result.metadata)
+    );
+  }
+}

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -179,6 +179,8 @@ import { PaymentsDataTableComponent } from './record/search-view/patron-transact
 import { PaymentDataPieComponent } from './record/search-view/patron-transaction-event-search-view/payments-data/pie/payment-data-pie.component';
 import { PatronPermissionsComponent } from './record/detail-view/patron-detail-view/patron-permissions/patron-permissions.component';
 import { PatronPermissionComponent } from './record/detail-view/patron-detail-view/patron-permissions/patron-permission/patron-permission.component';
+import { CirculationLogLoanComponent } from './record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component';
+import { CirculationLogNotificationComponent } from './record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component';
 
 /** Init application factory */
 export function appInitFactory(appInitializerService: AppInitializerService): () => Promise<any> {
@@ -296,7 +298,9 @@ export function appInitFactory(appInitializerService: AppInitializerService): ()
         PaymentsDataTableComponent,
         PaymentDataPieComponent,
         PatronPermissionsComponent,
-        PatronPermissionComponent
+        PatronPermissionComponent,
+        CirculationLogLoanComponent,
+        CirculationLogNotificationComponent
     ],
     imports: [
         AppRoutingModule,

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.html
@@ -1,0 +1,87 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021-2023 RERO
+  Copyright (C) 2023 UCLouvain
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<admin-circulation-log
+  [record]="record"
+  [isHighlight]="isHighlight"
+  [separator]="separator"
+>
+  <span badge class="badge badge-pill badge-primary">{{ record.metadata.loan.trigger | translate }}</span>
+  <div collapsedContent class="row">
+    <!-- Location -->
+    <div class="col-8 transaction-library">
+      <ng-container *ngIf="record.metadata.loan.transaction_location; else noLibrary">
+        <ng-container *ngIf="record.metadata.loan.transaction_location.pid | getRecord : 'locations' | async as location">
+          {{ location.metadata.library.pid | getRecord : 'libraries' : 'field' : 'name' | async }}
+        </ng-container>
+      </ng-container>
+      <ng-template #noLibrary>
+        <span class="no-data">---</span>
+      </ng-template>
+    </div>
+    <!-- Patron -->
+    <div class="col-4 transaction-patron">
+      <ng-container *ngIf="record.metadata.loan.patron.pid; else anonymous">
+        <ng-container *ngIf="record.metadata.loan.patron.pid | getRecord : 'patrons' | async as patron">
+          <a [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode[0]]"  (click)="closeDialog()">
+            {{ patron.metadata.last_name }}, {{ patron.metadata.first_name }}
+          </a>
+        </ng-container>
+      </ng-container>
+      <ng-template #anonymous>
+        {{ 'Patron type' | translate }}: {{ record.metadata.loan.patron.type }}
+      </ng-template>
+    </div>
+  </div>
+  <dl class="row" expandedContent>
+    <!-- Library -->
+    <dt class="col-4 label-title font-weight-bold transaction-library" translate>Library</dt>
+    <dd class="col-8">
+      <ng-container *ngIf="record.metadata.loan.transaction_location; else noLibrary">
+        <ng-container *ngIf="record.metadata.loan.transaction_location.pid | getRecord : 'locations' | async as location">
+          {{ location.metadata.library.pid | getRecord : 'libraries' : 'field' : 'name' | async }}
+        </ng-container>
+      </ng-container>
+      <ng-template #noLibrary>
+        <span class="no-data">---</span>
+      </ng-template>
+    </dd>
+
+    <!-- Location -->
+    <dt class="col-4 label-title font-weight-bold transaction-location" translate>Location</dt>
+    <dd class="col-8">{{ record.metadata.loan.pickup_location.name }}</dd>
+
+    <!-- Patron -->
+    <dt class="col-4 label-title font-weight-bold transaction-patron" translate>Patron</dt>
+    <dd class="col-8">
+      <ng-container *ngIf="record.metadata.loan.patron.pid; else anonymous">
+        <ng-container *ngIf="record.metadata.loan.patron.pid | getRecord : 'patrons' | async as patron">
+          <a [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode[0]]"  (click)="closeDialog()">
+            {{ patron.metadata.last_name }}, {{ patron.metadata.first_name }}
+          </a>
+        </ng-container>
+      </ng-container>
+      <ng-template #anonymous>
+        {{ 'Patron type' | translate }}: {{ record.metadata.loan.patron.type }}
+      </ng-template>
+    </dd>
+
+    <!-- Operator -->
+    <dt class="col-4 label-title font-weight-bold transaction-operator"translate>Operator</dt>
+    <dd class="col-8">{{ record.metadata.user_name }}</dd>
+  </dl>
+</admin-circulation-log>

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.scss
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.scss
@@ -1,0 +1,39 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+*[class^='transaction-'], *[class*=' transaction-'] {
+  &:before {
+    font-family: 'FontAwesome';
+    font-weight: 100;
+    display: inline-block;
+    min-width: 20px;
+  }
+}
+
+.transaction-library:before {
+  content: "\f0ac";
+}
+.transaction-location:before {
+  content: "\f041";
+}
+.transaction-patron:before {
+  content: "\f007";
+}
+.transaction-operator:before {
+  content: "\f2be";
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.ts
@@ -1,7 +1,7 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2021-2023 RERO
- * Copyright (C) 2021-2023 UCLouvain
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,14 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { PermissionsService } from '@rero/shared';
 
 @Component({
-  selector: 'admin-circulation-log',
-  templateUrl: './circulation-log.component.html',
-  styleUrls: ['./circulation-log.component.scss']
+  selector: 'admin-circulation-log-loan',
+  templateUrl: './circulation-log-loan.component.html',
+  styleUrls: ['./circulation-log-loan.component.scss']
 })
-export class CirculationLogComponent {
+export class CirculationLogLoanComponent {
 
   // COMPONENT ATTRIBUTES =====================================================
   /** Operation log record */
@@ -34,43 +33,11 @@ export class CirculationLogComponent {
   @Input() separator = false;
 
   /** Event for close dialog */
-  @Output() closeDialogEvent = new EventEmitter();
-
-  /** Event for is collapsed */
-  @Output() isCollapsedEvent = new EventEmitter();
-
-  /** Circulation information's is collapsed */
-  isCollapsed = true;
-
-  /** debugMode */
-  debugMode = false;
-
-  // GETTER & SETTER ==========================================================
-  /**
-   * Is the debug mode could be activated ?
-   * @returns True if the debug mode can be enabled and switched
-   */
-  get canUseDebugMode(): boolean {
-    return this._permissionsService.canAccessDebugMode();
-  }
-
-  // CONSTRUCTOR & HOOKS ======================================================
-  /**
-   * Constructor
-   * @param _userService - UserService
-   */
-  constructor(
-    private _permissionsService: PermissionsService
-  ) {  }
+  @Output() closeDialogEvent  = new EventEmitter();
 
   // COMPONENT FUNCTIONS ======================================================
   /** Close dialog */
   closeDialog(): void {
     this.closeDialogEvent.emit(null);
-  }
-
-  /** Toggle collapsed */
-  toggleCollapsed(): void {
-    this.isCollapsedEvent.emit(this.isCollapsed);
   }
 }

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.html
@@ -1,0 +1,81 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021-2023 RERO
+  Copyright (C) 2023 UCLouvain
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<admin-circulation-log
+  [record]="record"
+  [isHighlight]="isHighlight"
+  [separator]="separator"
+  (isCollapsedEvent)="loadData($event)"
+>
+  <span badge class="badge badge-pill badge-primary" translate>Notification</span>
+  <div collapsedContent class="row">
+    <!-- Library -->
+    <div class="col-8 transaction-library">
+      <ng-container *ngIf="record.metadata.notification.sender_library_pid; else noLibrary">
+        {{ record.metadata.notification.sender_library_pid | getRecord : 'libraries'  : 'field' : 'name' | async }}
+      </ng-container>
+      <ng-template #noLibrary>
+        <span class="no-data">---</span>
+      </ng-template>
+    </div>
+    <!-- Type of notification -->
+    <div class="col-4">
+      <span class="badge badge-pill badge-secondary">{{ record.metadata.notification.type | translate }}</span>
+    </div>
+  </div>
+  <dl class="row" expandedContent>
+    <!-- Library -->
+    <dt class="col-3 label-title font-weight-bold transaction-library" translate>Library</dt>
+    <dd class="col-9">
+      <ng-container *ngIf="record.metadata.notification.sender_library_pid; else noLibrary">
+        {{ record.metadata.notification.sender_library_pid | getRecord : 'libraries'  : 'field' : 'name' | async }}
+      </ng-container>
+      <ng-template #noLibrary>
+        <span class="no-data">---</span>
+      </ng-template>
+    </dd>
+
+    <!-- Type of notification -->
+    <dt class="col-3 label-title font-weight-bold transaction-type" translate>Type</dt>
+    <dd class="col-9">{{ record.metadata.notification.type | translate }}</dd>
+
+    <!-- Recipients -->
+    <dt class="col-3 label-title font-weight-bold transaction-email" translate>Recipients</dt>
+    <dd class="col-9">
+      <ul class="list-unstyled mb-0">
+        <li *ngFor="let recipient of record.metadata.notification.recipients">{{ recipient }}</li>
+      </ul>
+    </dd>
+
+    <ng-container *ngIf="notificationRecord">
+      <!-- Process date -->
+      <dt class="col-3 label-title font-weight-bold transaction-date" translate>Process date</dt>
+      <dd class="col-9">{{ notificationRecord.process_date  | dateTranslate :'medium' }}</dd>
+
+      <!-- Status -->
+      <dt class="col-3 label-title font-weight-bold transaction-status" translate>Status</dt>
+      <dd class="col-9">
+        <ng-container *ngIf="notificationRecord.notification_sent; else notSend">
+          <i class="fa fa-circle text-success"></i> {{ 'message sent' | translate }}
+        </ng-container>
+        <ng-template #notSend>
+          <i class="fa fa-circle text-danger"></i> {{ 'message not sent' | translate }}
+        </ng-template>
+      </dd>
+    </ng-container>
+  </dl>
+</admin-circulation-log>

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.scss
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.scss
@@ -1,0 +1,42 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+*[class^='transaction-'], *[class*=' transaction-'] {
+  &:before {
+    font-family: 'FontAwesome';
+    font-weight: 100;
+    display: inline-block;
+    min-width: 20px;
+  }
+}
+
+.transaction-library:before {
+  content: "\f0ac";
+}
+.transaction-type:before {
+  content: "\f024";
+}
+.transaction-date:before {
+  content: "\f133";
+}
+.transaction-status:before {
+  content: "\f06e";
+}
+.transaction-email:before {
+  content: "\f0e0";
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component.ts
@@ -1,0 +1,57 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ * Copyright (C) 2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { NotificationApiService } from '@app/admin/api/notification-api.service';
+
+@Component({
+  selector: 'admin-circulation-log-notification',
+  templateUrl: './circulation-log-notification.component.html',
+  styleUrls: ['./circulation-log-notification.component.scss']
+})
+export class CirculationLogNotificationComponent {
+
+  // COMPONENT ATTRIBUTES =====================================================
+  /** Operation log record */
+  @Input() record: any;
+  /** Is the log should be highlighted */
+  @Input() isHighlight = false;
+  /** Is the transaction must be separated from sibling elements */
+  @Input() separator = false;
+
+  /** Notification record */
+  notificationRecord: any;
+
+  /**
+   * Constructor
+   * @param _NotificationApiService - NotificationApiService
+   */
+  constructor(private _NotificationApiService: NotificationApiService) {}
+
+  /**
+   * Load notification record
+   * @param isCollapsed - Is the element collapsed
+   */
+  loadData(isCollapsed: boolean): void {
+    if (!isCollapsed && this.notificationRecord === undefined) {
+      this._NotificationApiService.getNotificationByPid(this.record.metadata.notification.pid)
+      .subscribe((record: any) => {
+        this.notificationRecord = record;
+      })
+    }
+  }
+}

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.html
@@ -1,6 +1,7 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2021 RERO
+  Copyright (C) 2021-2023 RERO
+  Copyright (C) 2021-2023 UCLouvain
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -17,58 +18,27 @@
 <div class="transaction-log pt-2 pb-1 position-relative" [class.highlight]="isHighlight" [class.border-top]="separator">
   <button type="button" class="btn-show-more"
           [ngClass]="{'btn-expanded': !isCollapsed, 'btn-collapsed': isCollapsed}"
-          (click)="isCollapsed = !isCollapsed"
+          (click)="isCollapsed = !isCollapsed; toggleCollapsed();"
           [attr.aria-expanded]="!isCollapsed" aria-controls="collapse">
   </button>
   <div class="container-fluid pl-0">
     <dl class="row my-0 text-muted">
-    <dd class="col-2 small">
-      <div class="transaction-date">{{ record.metadata.date | dateTranslate :'shortDate' }}</div>
-      <div class="transaction-time">{{ record.metadata.date | dateTranslate :'mediumTime' }}</div>
-    </dd>
-    <dd class="col-2 transaction-trigger">
-      <span class="badge badge-pill badge-primary">{{ record.metadata.loan.trigger | translate }}</span>
-    </dd>
-    <!-- transaction library -->
-    <dt class="col-2 label-title font-weight-bold transaction-library" [collapse]="isCollapsed" translate>Library</dt>
-    <dd [ngClass]="{
-      'col-6': !isCollapsed,
-      'col-5 transaction-library': isCollapsed
-    }">
-      <ng-container *ngIf="record.metadata.loan.transaction_location; else noLibrary">
-        <ng-container *ngIf="record.metadata.loan.transaction_location.pid | getRecord : 'locations' | async as location">
-          {{ location.metadata.library.pid | getRecord : 'libraries' : 'field' : 'name' | async }}
-        </ng-container>
-      </ng-container>
-      <ng-template #noLibrary>
-        <span class="no-data">---</span>
-      </ng-template>
-    </dd>
-    <!-- pickup location -->
-    <dt class="offset-4 col-2 label-title font-weight-bold transaction-location" [collapse]="isCollapsed" translate>Location</dt>
-    <dd class="col-6" [collapse]="isCollapsed">{{ record.metadata.loan.pickup_location.name }}</dd>
-    <!-- related patron -->
-    <dt class="offset-4 col-2 label-title font-weight-bold transaction-patron" [collapse]="isCollapsed" translate>Patron</dt>
-    <dd [ngClass]="{
-      'col-6': !isCollapsed,
-      'col-3 transaction-patron': isCollapsed
-    }">
-      <ng-container *ngIf="record.metadata.loan.patron.pid; else anonymous">
-        <ng-container *ngIf="record.metadata.loan.patron.pid | getRecord : 'patrons' | async as patron">
-          <a [routerLink]="['/circulation', 'patron', patron.metadata.patron.barcode[0]]" (click)="closeDialog()">
-            {{ patron.metadata.last_name }}, {{ patron.metadata.first_name }}
-          </a>
-        </ng-container>
-      </ng-container>
-      <ng-template #anonymous>
-        {{ 'Patron type' | translate }}: {{ record.metadata.loan.patron.type }}
-      </ng-template>
-    </dd>
-    <!-- operator -->
-    <dt class="offset-4 col-2 label-title font-weight-bold transaction-operator" [collapse]="isCollapsed" translate>Operator</dt>
-    <dd class="col-6" [collapse]="isCollapsed">{{ record.metadata.user_name }}</dd>
-    <!-- debug information -->
-    <pre class="offset-4 col-8" [hidden]="!debugMode">{{ record | json }}</pre>
+      <!-- transaction date -->
+      <dd class="col-2 small">
+        <div class="transaction-date">{{ record.metadata.date | dateTranslate :'shortDate' }}</div>
+        <div class="transaction-time">{{ record.metadata.date | dateTranslate :'mediumTime' }}</div>
+      </dd>
+      <!-- transaction badge -->
+      <dd class="col-2 transaction-trigger">
+        <ng-content select="[badge]"></ng-content>
+      </dd>
+      <!-- content -->
+      <dd class="col-8">
+        <ng-content select="[collapsedContent]" *ngIf="isCollapsed"></ng-content>
+        <ng-content select="[expandedContent]" *ngIf="!isCollapsed"></ng-content>
+      </dd>
+      <!-- debug information -->
+      <pre class="offset-4 col-8" [hidden]="!debugMode">{{ record | json }}</pre>
     </dl>
   </div>
   <!-- debug mode button -->

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.scss
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.scss
@@ -1,7 +1,7 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2021 RERO
- * Copyright (C) 2022 UCLouvain
+ * Copyright (C) 2021-2023 RERO
+ * Copyright (C) 2022-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -66,18 +66,6 @@
   }
   .transaction-trigger {
     font-variant: small-caps;
-  }
-  .transaction-library:before {
-    content: "\f0ac";
-  }
-  .transaction-location:before {
-    content: "\f041";
-  }
-  .transaction-patron:before {
-    content: "\f007";
-  }
-  .transaction-operator:before {
-    content: "\f2be";
   }
 
   .debug-button{

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.spec.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log.component.spec.ts
@@ -1,6 +1,7 @@
 /*
  * RERO ILS UI
  * Copyright (C) 2021 RERO
+ * Copyright (C) 2021 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
@@ -1,6 +1,7 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2021 RERO
+  Copyright (C) 2021-2023 RERO
+  Copyright (C) 2023 UCLouvain
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -24,22 +25,42 @@
         </button>
       </div>
       <div class="modal-body overflow-auto overflow-max-size">
+        <div class="mb-3">
+          <span class="float-left label-title mr-2 font-weight-bold" translate>Filter</span>
+          <ul class="list-inline mb-0">
+            <li class="list-inline-item mr-2" *ngFor="let filter of filterTypes | keyvalue">
+              <div class="custom-control custom-switch mb-0">
+                <input type="checkbox" class="custom-control-input mt-1" [id]="filter.key" [checked]="filter.value" (click)="filterCheck(filter.key)">
+                <label class="custom-control-label" [for]="filter.key">{{ ('op_filter_' + filter.key) | translate }}</label>
+              </div>
+            </li>
+          </ul>
+        </div>
         <ng-container *ngIf="loadedRecord; else loaded">
-          <ul *ngIf="recordTotals > 0; else noRecord" class="list-unstyled mx-2 mb-0">
+          <ng-container *ngIf="recordTotals > 0; else noRecord">
             <ng-container *ngFor="let record of records; first as isFirst; let idx = index">
               <div class="transactionDate" *ngIf="isFirst || !isSamePeriod(record, records[idx-1])">
                 {{ record.metadata.date | dateTranslate :'MMMM Y' | titlecase }}
               </div>
-              <admin-circulation-log
-                [record]="record"
-                [isHighlight]="record.metadata.loan.pid === highligthedLoanPid"
-                [separator]="!isSamePeriod(record, records[idx-1], 'day')"
-                (closeDialogEvent)="closeDialog()"
-                (mouseenter)="mouseEventTransaction(record, $event)"
-                (mouseleave)="highligthedLoanPid=null"
-              ></admin-circulation-log>
+              <ng-container [ngSwitch]="getRecordType(record)">
+                <admin-circulation-log-notification *ngSwitchCase="'notification'"
+                  [record]="record"
+                  [isHighlight]="record.metadata.loan.pid === highlightedLoanPid"
+                  [separator]="!isSamePeriod(record, records[idx-1], 'day')"
+                  (mouseenter)="mouseEventTransaction(record, $event)"
+                  (mouseleave)="highlightedLoanPid=null"
+                ></admin-circulation-log-notification>
+                <admin-circulation-log-loan *ngSwitchCase="'circulation'"
+                  [record]="record"
+                  [isHighlight]="record.metadata.loan.pid === highlightedLoanPid"
+                  [separator]="!isSamePeriod(record, records[idx-1], 'day')"
+                  (closeDialogEvent)="closeDialog()"
+                  (mouseenter)="mouseEventTransaction(record, $event)"
+                  (mouseleave)="highlightedLoanPid=null"
+                ></admin-circulation-log-loan>
+              </ng-container>
             </ng-container>
-          </ul>
+          </ng-container>
         </ng-container>
       </div>
       <div class="modal-footer py-1 justify-content-start">

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -217,3 +217,7 @@ _('Logout');
 
 _('Masked');
 _('No masked');
+
+// Operation log filter (circulation)
+_('op_filter_loan');
+_('op_filter_notif');


### PR DESCRIPTION
Circulation related notifications are now visible in the operation logs. There are also filters to select a type.

* Closes rero/rero-ils#2639.

## Display

![filter-history](https://user-images.githubusercontent.com/48578/228244313-d7981163-b6e6-4c95-a535-35773527aaed.png)


