### PR TITLE
item operation history: add statistics

### DIFF
--- a/projects/admin/src/app/api/item-api.service.ts
+++ b/projects/admin/src/app/api/item-api.service.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2021 RERO
+ * Copyright (C) 2021-2023 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { RecordService } from '@rero/ng-core';
 import { Observable } from 'rxjs';
@@ -30,12 +31,30 @@ export class ItemApiService {
   /**
    * Constructor
    * @param _recordService - RecordService
+   * @param _http - HttpClient
    */
-  constructor(private _recordService: RecordService) {}
+  constructor(
+    private _recordService: RecordService,
+    private _http: HttpClient
+  ) {}
 
+  /**
+   * Get item
+   * @param pid - the item pid
+   * @returns Observable of the item data
+   */
   getItem(pid: string): Observable<any> {
     return this._recordService.getRecord(this.RESOURCE_NAME, pid).pipe(
       map((result: any) => result.metadata)
     );
+  }
+
+  /**
+   * Get stats of the item
+   * @param itemPid - The item pid
+   * @returns Observable of the stats of item
+   */
+  getStatsByItemPid(itemPid: string) {
+    return this._http.get<any>(`/api/item/${itemPid}/stats`);
   }
 }

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -1,7 +1,7 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019-2022 RERO
- * Copyright (C) 2019-2022 UCLouvain
+ * Copyright (C) 2019-2023 RERO
+ * Copyright (C) 2019-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -181,6 +181,7 @@ import { PatronPermissionsComponent } from './record/detail-view/patron-detail-v
 import { PatronPermissionComponent } from './record/detail-view/patron-detail-view/patron-permissions/patron-permission/patron-permission.component';
 import { CirculationLogLoanComponent } from './record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component';
 import { CirculationLogNotificationComponent } from './record/circulation-logs/circulation-log/circulation-log-notification/circulation-log-notification.component';
+import { CirculationStatsComponent } from './record/circulation-logs/circulation-stats/circulation-stats.component';
 
 /** Init application factory */
 export function appInitFactory(appInitializerService: AppInitializerService): () => Promise<any> {
@@ -300,7 +301,8 @@ export function appInitFactory(appInitializerService: AppInitializerService): ()
         PatronPermissionsComponent,
         PatronPermissionComponent,
         CirculationLogLoanComponent,
-        CirculationLogNotificationComponent
+        CirculationLogNotificationComponent,
+        CirculationStatsComponent
     ],
     imports: [
         AppRoutingModule,

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.html
@@ -25,6 +25,7 @@
         </button>
       </div>
       <div class="modal-body overflow-auto overflow-max-size">
+        <admin-circulation-stats *ngIf="resourceType === 'item'" [itemPid]="this.resourcePid"></admin-circulation-stats>
         <div class="mb-3">
           <span class="float-left label-title mr-2 font-weight-bold" translate>Filter</span>
           <ul class="list-inline mb-0">

--- a/projects/admin/src/app/record/circulation-logs/circulation-stats/circulation-stats.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-stats/circulation-stats.component.html
@@ -1,0 +1,33 @@
+<!--
+  RERO ILS UI
+  Copyright (C) 2021-2023 RERO
+  Copyright (C) 2021-2023 UCLouvain
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div class="row mb-3" *ngIf="stats">
+  <div class="col-6">
+    <span class="font-weight-bold" translate>Past year (last 365 days)</span>
+    <ul class="list-unstyled mb-0">
+      <li>{{ 'checkout' | translate | ucfirst }}: {{ stats.total_year.checkout | default: 0 }}</li>
+      <li>{{ 'renewal' | translate | ucfirst }}: {{ stats.total_year.extend | default: 0 }}</li>
+    </ul>
+  </div>
+  <div class="col-6">
+    <span class="font-weight-bold" translate>Total</span>
+    <ul class="list-unstyled mb-0">
+      <li>{{ 'checkout' | translate | ucfirst }}: {{ stats.total.checkout | default: 0 }}</li>
+      <li>{{ 'renewal' | translate| ucfirst }}: {{ stats.total.extend | default: 0 }}</li>
+    </ul>
+  </div>
+</div>

--- a/projects/admin/src/app/record/circulation-logs/circulation-stats/circulation-stats.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-stats/circulation-stats.component.ts
@@ -1,0 +1,44 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021-2023 RERO
+ * Copyright (C) 2021-2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+import { ItemApiService } from '../../../api/item-api.service';
+
+@Component({
+  selector: 'admin-circulation-stats',
+  templateUrl: './circulation-stats.component.html'
+})
+export class CirculationStatsComponent implements OnInit {
+
+  /** Item record */
+  @Input() itemPid: any;
+
+  /** Computed stats for current item */
+  stats: any;
+
+  /**
+   * Constructor
+   * @param _itemApiService - ItemApiService
+   */
+  constructor(private _itemApiService: ItemApiService) { }
+
+  /** OnInit hook */
+  ngOnInit(): void {
+    this._itemApiService.getStatsByItemPid(this.itemPid)
+      .subscribe((stats: any) => this.stats = stats)
+  }
+}


### PR DESCRIPTION
On the item operation history screen, there are now statistics
on checkout and extend (total and past year)

* Closes rero/rero-ils#2996.

### Dependencies

[item operation history: add statistics (ILS)](https://github.com/rero/rero-ils/pull/3314)

### Display

![stats](https://user-images.githubusercontent.com/48578/232813555-8e071c8a-00a2-459f-9abe-8c4b1f13b1d1.png)
