### PR TITLE
http: add current_library parameter on api call

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -182,6 +182,7 @@ import { UiRemoteTypeaheadService } from './service/ui-remote-typeahead.service'
 import { CurrentLibraryPermissionValidator } from './utils/permissions';
 import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/custom-shortcut-help.component';
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
+import { UserCurrentLibraryInterceptor } from './interceptor/user-current-library.interceptor';
 
 /** Init application factory */
 export function appInitFactory(appInitializerService: AppInitializerService): () => Promise<any> {
@@ -369,6 +370,11 @@ export function appInitFactory(appInitializerService: AppInitializerService): ()
             provide: HTTP_INTERCEPTORS,
             useClass: NoCacheHeaderInterceptor,
             multi: true
+        },
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: UserCurrentLibraryInterceptor,
+          multi: true
         },
         { provide: RemoteTypeaheadService, useExisting: UiRemoteTypeaheadService },
         // Use the "multi" parameter to allow the recovery of several services in the injector.

--- a/projects/admin/src/app/interceptor/user-current-library.interceptor.ts
+++ b/projects/admin/src/app/interceptor/user-current-library.interceptor.ts
@@ -1,0 +1,53 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2023 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { UserService } from '@rero/shared';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class UserCurrentLibraryInterceptor implements HttpInterceptor {
+
+  /**
+   * Constructor
+   * @param _userService - UserService
+   */
+  constructor(private _userService: UserService) {}
+
+  /**
+   * Intercept http request
+   * Add current library of the logged user.
+   * @param request - HttpRequest
+   * @param next - HttpHandler
+   * @returns Handle of request
+   */
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (this._userService.user && this._userService.user.currentLibrary) {
+      request = request.clone({
+        setParams: {
+          'current_library': String(this._userService.user.currentLibrary)
+        }
+      });
+    }
+    return next.handle(request);
+  }
+}


### PR DESCRIPTION
Administration: `current_library` parameter added to all http requests to identify the user's library.

## Dependencies

- https://github.com/rero/rero-ils/pull/3372

