### PR TITLE
typeahead: custom remote entity typeahead component

### DIFF
--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -184,6 +184,7 @@ import { CurrentLibraryPermissionValidator } from './utils/permissions';
 import { CustomShortcutHelpComponent } from './widgets/custom-shortcut-help/custom-shortcut-help.component';
 import { FrontpageComponent } from './widgets/frontpage/frontpage.component';
 import { UserCurrentLibraryInterceptor } from './interceptor/user-current-library.interceptor';
+import { EntityTypeaheadComponent } from './record/formly/type/entity-typeahead/entity-typeahead.component';
 
 /** Init application factory */
 export function appInitFactory(appInitializerService: AppInitializerService): () => Promise<any> {
@@ -306,7 +307,8 @@ export function appInitFactory(appInitializerService: AppInitializerService): ()
         CirculationStatsComponent,
         ItemSwitchLocationStandaloneComponent,
         ItemSwitchLocationComponent,
-        IssueEmailComponent
+        IssueEmailComponent,
+        EntityTypeaheadComponent
     ],
     imports: [
       AppRoutingModule,
@@ -326,7 +328,8 @@ export function appInitFactory(appInitializerService: AppInitializerService): ()
       FormlyModule.forRoot({
         types: [
           {name: 'cipo-pt-it', component: CipoPatronTypeItemTypeComponent},
-          {name: 'account-select', component: SelectAccountEditorWidgetComponent}
+          {name: 'account-select', component: SelectAccountEditorWidgetComponent},
+          {name: 'entityTypeahead', component: EntityTypeaheadComponent}
         ],
         wrappers: [
           {name: 'user-id', component: UserIdComponent},

--- a/projects/admin/src/app/classes/typeahead/mef-typeahead.ts
+++ b/projects/admin/src/app/classes/typeahead/mef-typeahead.ts
@@ -1,7 +1,7 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2020-2023 RERO
- * Copyright (C) 2020-2023 UCLouvain
+ * Copyright (C) 2019-2023 RERO
+ * Copyright (C) 2019-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -19,46 +19,76 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { SuggestionMetadata } from '@rero/ng-core';
+import { ApiService, RecordService, SuggestionMetadata } from '@rero/ng-core';
 import { AppSettingsService } from '@rero/shared';
-import { Observable, of } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { ITypeahead } from './ITypeahead-interface';
+
 @Injectable({
   providedIn: 'root'
 })
 export class MefTypeahead implements ITypeahead {
 
-  /** Entry point for MEF Api */
-  private _apiSearchEntryPoint = 'api/entities/remote/search';
+  /** Entry point API to get remote entity suggestions. */
+  private _remoteSearchEntrypoint = 'api/remote_entities/search';
+  /** Proxy API to use to get content of remote entity metadata (to avoid CORS javascript errors). */
   private _apiProxyEntryPoint = 'api/proxy';
+  /** Entry point API to get locale entity suggestions. */
+  private _localSearchEntrypoint = 'api/local_entities/search';
 
   /**
    * Constructor
    * @param _http - HttpClient
    * @param _translateService - TranslateService
    * @param _appSettingsService - AppSettingsService
+   * @param _recordService - RecordService
+   * @param _apiService - ApiService
    */
   constructor(
     protected _http: HttpClient,
     protected _translateService: TranslateService,
-    protected _appSettingsService: AppSettingsService
-  ) { }
+    protected _appSettingsService: AppSettingsService,
+    private _recordService: RecordService,
+    private _apiService: ApiService
+  ) {  }
 
   /** Get name of typeahead */
   getName() {
     return 'mef';
   }
 
+  // GET HTML REPRESENTATION ==================================================
   /**
    * Convert the input value (i.e. $ref url) into a template html code.
-   * @param options - remote typeahead options
-   * @param value - formControl value i.e. $ref value
-   * @returns Observable of string - html template representation of the value.
+   *
+   * The value could represent either a remote entity, either a local entity.
+   * A remote entity is an entity where metadata are stored outside the RERO
+   * application system. A local entity is store as a Invenio resource into the
+   * RERO application system.
+   *
+   * @param options: typeahead options
+   * @param value: formControl value i.e. $ref value
+   * @returns Observable on HTML template representation of the value.
    */
   getValueAsHTML(options: any, value: string): Observable<string> {
-    // We need to call the url to get remote metadata. But we can't do that directly because this url could be external.
-    // So we need to call a proxy passing the URL as query string argument.
+    // Determine if value is a local or remote entity ; depending on the
+    // entity type the metadata retrieve method isn't the same
+    return (value.match(/local_entities\/.*$/))
+       ? this._getLocalValueAsHTML(options, value)
+       : this._getRemoteValueAsHTML(options, value);
+  }
+
+  /**
+   * Get HTML representation for a remote entity value.
+   *
+   * @param options: typeahead options
+   * @param value: formControl value i.e. $ref value
+   * @returns Observable on HTML template representation of the value.
+   */
+  private _getRemoteValueAsHTML(options: any, value: string): Observable<string> {
+    // We need to call the url to get remote metadata. But we can't do that directly because this url could be external. So we need to call
+    // a proxy passing the URL as query string argument.
     const source = value.split('/').slice(-2)[0];
     const params = new HttpParams().set('url', value);
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
@@ -81,20 +111,75 @@ export class MefTypeahead implements ITypeahead {
           return data;
         }),
         map((data: any) => {
-          const link = this._get_source_uri(data?.metadata?.identifiedBy, source) || value;
-          const label = data?.metadata?.authorized_access_point;
-          return `
-            <a href="${link}" target="_blank">${label} <i class="fa fa-external-link"></i></a>
-            <small class="badge badge-secondary ml-1">${source.toUpperCase()}</small>
-          `
+          const entity = {
+            uri: this._get_source_uri(data?.metadata?.identifiedBy, source) || value,
+            label: data?.metadata?.authorized_access_point
+          };
+          const badges = [{label: source.toUpperCase()}];
+          return this._buildEntityResolutionResponse(entity, badges);
         }),
-        catchError(e => {
-          console.error(`getValueAsHTML :: Unable to resolve ${value}`, e);
-          return of(`<span class="text-warning"><i class="fa fa-exclamation-triangle mr-1"></i>${value}</span>`);
-        })
+        catchError(e => this._handleEntityResolutionError(e, value))
     );
   }
 
+  /**
+   * Get HTML representation for a local entity value.
+   *
+   * @param options: typeahead options
+   * @param value: formControl value i.e. $ref value
+   * @returns Observable on HTML template representation of the value.
+   */
+  private _getLocalValueAsHTML(options: any, value: string): Observable<string> {
+    const pid = value.split('/').slice(-1)[0];
+    return this._recordService
+      .getRecord('local_entities', pid)
+      .pipe(
+         map((data: any) => {
+           const entity = {
+             label: data.metadata.authorized_access_point,
+             uri:  this._buildLocalEntityDetailViewURI(data.metadata.pid)
+           };
+           const badges = [];
+           if (data.metadata?.source_catalog) {
+             badges.push({label: data.metadata.source_catalog});
+           }
+           return this._buildEntityResolutionResponse(entity, badges);
+         }),
+         catchError(e => this._handleEntityResolutionError(e, value))
+      );
+  }
+
+  /**
+   * Build the HTML representation for an entity.
+   * @param entity: the entity to represent.
+   * @param badges: badges list to append to the entity.
+   * @returns the HTML representation for the entity.
+   */
+  private _buildEntityResolutionResponse(entity: {label:string, uri?: string}, badges: Array<{label: string, type?: string}>): string {
+    let output = (entity?.uri)
+      ? `<a href="${entity.uri}" target="_blank">${entity.label} <i class="fa fa-external-link"></i></a>`
+      : `<span>${entity.label}</span>`;
+    badges.forEach(badge => {
+      const className = (badge?.type)
+        ? `badge-${badge.type}`
+        : 'badge-secondary';
+      output += `<small class="badge ${className} ml-1">${badge.label}</small>`;
+    });
+    return output;
+  }
+
+  /**
+   * Manage entity resolution error.
+   * @param error: the triggered error
+   * @param value: the entity value causing the resolution error.
+   */
+  private _handleEntityResolutionError(error: Error, value: string): Observable<string> {
+    console.error(`getValueAsHTML :: Unable to resolve entity :: ${value}`, error);
+    return of(`<span class="text-warning"><i class="fa fa-exclamation-triangle mr-1"></i>${value}</span>`);
+  }
+
+
+  // GET ENTITY SUGGESTIONS ===================================================
   /**
    * Get the suggestions list given a search query.
    * @param options - remote typeahead options
@@ -111,34 +196,54 @@ export class MefTypeahead implements ITypeahead {
     if (null == options?.filters?.selected) {
       throw Error('Missing filters definition');
     }
-
     const searchCategory = options.filters.selected;
-    // TODO :: Why do I need to add an ending slash to use proxy-config and don't be redirected (308) receiving a CORS errors
-    const url = `${this._apiSearchEntryPoint}/${searchCategory}/${searchTerm}/`;
-    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
 
-    return this._http.get(url, {headers}).pipe(
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    const params = new HttpParams().set('size', numberOfSuggestions);
+    // Build API call to get remote suggestions.
+    const remoteUrl = `${this._remoteSearchEntrypoint}/${searchCategory}/${searchTerm}/`;
+    const remoteSuggestions$ = this._http.get(remoteUrl, {headers, params}).pipe(
       map((results: any) => results?.hits?.total >= 0 ? results.hits.hits : []),
-      map((hits: Array<any>) => {
-        const suggestions = [];
-        hits.map((hit: any) => {
-          for (const source of this._sources()) {
-            if (hit.metadata[source]) {
-              suggestions.push(this._getNameRef(hit.metadata, source));
-            }
-          }
-        });
-        return suggestions;
-      }),
+      map((hits: Array<any>) => this._buildRemoteSuggestions(hits)),
       catchError(e => {
         switch (e.status) {
-          case 400:
-            return of([]);
-          default:
-            throw e;
+          case 400: return of([]);
+          default: throw e;
         }
       })
     );
+    // Build API call to get local entity suggestions.
+    const localUrl = `${this._localSearchEntrypoint}/${searchCategory}/${searchTerm}/`;
+    const localSuggestions$ = this._http.get(localUrl, {headers, params}).pipe(
+      map((hits: Array<any>) => this._buildLocalSuggestions(hits)),
+      catchError(e => {
+        switch (e.status) {
+          case 400: return of([]);
+          default: throw e;
+        }
+      })
+    );
+    // Return the concatenation of both API request.
+    return forkJoin([remoteSuggestions$, localSuggestions$]).pipe(
+      map(([remoteHits, localHits]) => [...remoteHits, ...localHits])
+    );
+  }
+
+  /**
+   * Build suggestions for remote entities proxy response.
+   * @param hits: the hits returned by the API call.
+   * @returns Suggestions corresponding to hits.
+   */
+  private _buildRemoteSuggestions(hits: any): SuggestionMetadata[] {
+    const suggestions = [];
+    hits.map((hit: any) => {
+      for (const source of this._sources()) {
+        if (hit.metadata[source]) {
+          suggestions.push(this._getNameRef(hit.metadata, source));
+        }
+      }
+    });
+    return suggestions;
   }
 
   /**
@@ -154,7 +259,8 @@ export class MefTypeahead implements ITypeahead {
       label: metadata.authorized_access_point,
       externalLink: this._get_source_uri(metadata?.identifiedBy, sourceName),
       value: this._get_source_uri(metadata?.identifiedBy, 'mef'),
-      group: this._translateService.instant('link to authority {{ sourceName }}', { sourceName })
+      group: this._translateService.instant('link to authority {{ sourceName }}', {sourceName}),
+      column: 0
     };
   }
 
@@ -184,5 +290,33 @@ export class MefTypeahead implements ITypeahead {
       : order[key];
     const sources = agentSources.filter((source: string) => source !== 'rero');
     return sources;
+  }
+
+  /**
+   * Build suggestions for local entities API call.
+   * @param hits: the hits returned by the API call.
+   * @returns Suggestions corresponding to hits.
+   */
+  private _buildLocalSuggestions(hits: any): SuggestionMetadata[] {
+    return hits.map(hit => {
+      return {
+        label: hit.authorized_access_point,
+        description: hit?.source_catalog,
+        value: this._apiService.getRefEndpoint('local_entities', hit.pid),
+        externalLink: this._buildLocalEntityDetailViewURI(hit.pid),
+        group: this._translateService.instant('link to local authority'),
+        column: 1,
+      };
+    });
+  }
+
+  /**
+   * Creates a local entity detail view URI
+   * TODO :: find a better/smarter way to build this URI than current static string construction..
+   * @param pid - the entity pid
+   * @returns the entity detail view URI
+   */
+  private _buildLocalEntityDetailViewURI(pid: string): string {
+    return `/records/local_entities/detail/${pid}`;
   }
 }

--- a/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.html
+++ b/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.html
@@ -1,0 +1,81 @@
+<!--
+  RERO angular core
+  Copyright (C) 2019-2023 RERO
+  Copyright (C) 2019-2023 UCLouvain
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div *ngIf="!formControl.value; else metadataTemplate" class="input-group w-100">
+  <!-- Entity type filter selection ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <div *ngIf="entityTypeFilters" class="input-group-prepend">
+    <select class="form-control input-group-text" (change)="selectEntityType($event.target.value)">
+      <option *ngFor="let option of entityTypeFilters"
+              [value]="option.value"
+              [selected]="option.selected"
+      >{{ option.label | translate }}</option>
+    </select>
+  </div>
+  <!-- autocomplete/typeahead ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <input [(ngModel)]="searchTerm"
+         [typeahead]="suggestion$"
+         [typeaheadAsync]="true"
+         [typeaheadMinLength]="2"
+         [typeaheadWaitMs]="250"
+         [typeaheadLatinize]="true"
+         [optionsListTemplate]="customListTemplate"
+         (typeaheadLoading)="isSuggestionsLoading = $event"
+         (typeaheadOnSelect)="typeaheadOnSelect($event)"
+         class="form-control"/>
+  <!-- Icon ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <div class="input-group-append">
+    <span class="input-group-text">
+      <i class="fa fa-search" class="fa" [ngClass]="{
+        'fa-search': !isSuggestionsLoading,
+        'fa-spinner fa-spin': isSuggestionsLoading
+      }"></i>
+    </span>
+  </div>
+</div>
+
+
+<ng-template #customListTemplate let-matches="matches" let-query="query" let-typeaheadTemplateMethods>
+  <div class="d-flex">
+    <div *ngFor="let section of suggestionSections; let idx=index" class="dropdown-column" [style]="{order: idx}">
+      <div *ngFor="let suggestion of section"
+           class="dropdown-item d-flex flex-row"
+           [class.suggestionGroupHeader]="suggestion.isHeader()"
+      >
+        <div (click)="typeaheadTemplateMethods.selectMatch(suggestion, $event)" class="dropdown-item-content">
+          <label>{{ suggestion.value }}</label>
+          <span class="dropdown-item-content-description" *ngIf="suggestion.item.description">{{ suggestion.item.description }}</span>
+        </div>
+        <span class="dropdown-item-actions">
+          <a *ngIf="suggestion.item.externalLink" target="_blank" [href]="suggestion.item.externalLink">
+            <i class="fa fa-external-link"></i>
+          </a>
+        </span>
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+
+<ng-template #metadataTemplate>
+  <div class="py-1" *ngIf="valueAsHTML$ | async as valueAsHTML">
+    <span [innerHTML]="valueAsHTML"></span>
+    <button class="btn btn-link text-secondary btn-sm" type="button" (click)="clear()">
+      <i class="fa fa-trash"></i>
+    </button>
+  </div>
+</ng-template>
+

--- a/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.scss
+++ b/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.scss
@@ -1,0 +1,73 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019-2023 RERO
+ * Copyright (C) 2019-2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import 'bootstrap/scss/bootstrap';
+
+.dropdown-column + .dropdown-column {
+  @extend .border-left;
+}
+
+.dropdown-item {
+  white-space: normal;
+
+  &.suggestionGroupHeader {
+    @extend .disabled;
+    @extend .font-weight-bold;
+    @extend .pl-2;
+    font-variant: small-caps;
+    font-size: .75rem;
+  }
+
+  .dropdown-item-content {
+    @extend .mr-2;
+    flex-grow: 1;
+
+    .dropdown-item-content-description {
+      @extend .d-block;
+      @extend .text-secondary;
+      @extend .ml-2;
+      @extend .font-italic;
+      font-size: .75rem;
+
+      &:before {
+        content: '[';
+      }
+      &:after {
+        content: ']';
+      }
+    }
+  }
+
+  .dropdown-item-actions {
+    min-width: 1rem;
+    a {
+      @extend .text-primary;
+      display: none;
+    }
+  }
+
+  &:hover {
+    * {
+      cursor: pointer;
+    }
+    * a {
+      display: block;
+    }
+  }
+
+}

--- a/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.ts
+++ b/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.component.ts
@@ -1,0 +1,177 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019-2023 RERO
+ * Copyright (C) 2019-2023 UCLouvain
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, OnInit } from '@angular/core';
+import { MefTypeahead } from '@app/admin/classes/typeahead/mef-typeahead';
+import { EntityTypeFilter } from '@app/admin/record/formly/type/entity-typeahead/entity-typeahead.interface';
+import { FieldType } from '@ngx-formly/core';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
+import { Observable, Observer } from 'rxjs';
+import { SuggestionMetadata } from '@rero/ng-core';
+import { map, switchMap } from 'rxjs/operators';
+
+@Component({
+  selector: 'admin-entity-typeahead',
+  templateUrl: './entity-typeahead.component.html',
+  styleUrls: ['./entity-typeahead.component.scss']
+})
+export class EntityTypeaheadComponent extends FieldType implements OnInit {
+
+  // COMPONENT ATTRIBUTES =====================================================
+  /** searched term */
+  searchTerm: string = null;
+  /** entity type filter options */
+  entityTypeFilters: EntityTypeFilter[] = [];
+  /** is the suggestions are loading ? */
+  isSuggestionsLoading: boolean = false;
+
+  /** observable on entity suggestions */
+  suggestion$: Observable<(SuggestionMetadata | string)[][]>;
+  /** observable on representation of the formControl value. */
+  valueAsHTML$: Observable<string>;
+  /** suggestions data from remote typeahead service */
+  suggestionSections: TypeaheadMatch[][] = [];
+
+
+  /** the number of suggestions to retrieve from suggestion service */
+  private _numberOfSuggestions: number = 10;
+
+  // CONSTRUCTOR & HOOKS ======================================================
+  /**
+   * Constructor
+   * @param _remoteTypeahead: MefTypeahead
+   */
+  constructor(
+    private _remoteTypeahead: MefTypeahead
+  ) {
+    super();
+  }
+
+  /** OnInit hook. */
+  ngOnInit() {
+   this._buildEntityTypeFilters();
+
+   this.suggestion$ = new Observable((observer: Observer<string>) => observer.next(this.searchTerm)).pipe(
+     switchMap((query: string) => {
+       const selectedEntityType = this.entityTypeFilters.find(entity => entity.selected) || this.entityTypeFilters[0];
+       const options = {filters: {selected: selectedEntityType.value}};
+       return this._remoteTypeahead
+         .getSuggestions(options, query, this._numberOfSuggestions)
+         .pipe(
+           map((suggestions: any) => {
+             let tmpSuggestions = this._splitSuggestionsByColumn(suggestions);
+             tmpSuggestions = this._orderSuggestions(tmpSuggestions);
+             this.suggestionSections = this._createSuggestionGroupHeader(tmpSuggestions);
+             return suggestions;
+           })
+         );
+     })
+   );
+
+   // get the template version of the formControl value
+   this.valueAsHTML$ = new Observable((observer: Observer<string>) => observer.next(this.formControl.value)).pipe(
+       switchMap((value: string) => {
+         const selectedEntityType = this.entityTypeFilters.find(entity => entity.selected) || this.entityTypeFilters[0];
+         const options = {filters: {selected: selectedEntityType.value}};
+         return this._remoteTypeahead.getValueAsHTML(options, value);
+       })
+     );
+
+  }
+
+  // PUBLIC COMPONENT FUNCTIONS ===============================================
+  /**
+   * Handler when entity type filter change.
+   * @param entityType: the selected filter on select menu
+   */
+  selectEntityType(entityType: string): void {
+    this.searchTerm = null;
+    this.entityTypeFilters.forEach(option => option.selected = option.value === entityType);
+  }
+
+  /**
+   * Set the field value with the selected suggestion.
+   * @param event: the clicked suggestion.
+   */
+  typeaheadOnSelect(event: TypeaheadMatch): void {
+    if (event.item.value != null) {
+      this.formControl.setValue(event.item.value);
+    } else {
+      this.formControl.get('$ref').reset();
+    }
+    this.searchTerm = null;
+  }
+
+  /** Clear current value */
+  clear(): void {
+    this.searchTerm = null;
+    this.formControl.reset();
+    this.field.focus = true;
+  }
+
+  // PRIVATE COMPONENT FUNCTIONS ==============================================
+  /** Build the entity type filters based on `templateOptions` field section. */
+  private _buildEntityTypeFilters(): void {
+    this.to?.filters?.options.map(option => this.entityTypeFilters.push({
+      ...option,
+      ...{selected: option.value === this.to?.filters?.default}
+    }));
+  }
+
+  /** Split suggestion from typeahead service by column. */
+  private _splitSuggestionsByColumn(suggestions: SuggestionMetadata[]): SuggestionMetadata[][] {
+    const sections = [];
+    suggestions.forEach(suggestion => {
+      if (typeof(suggestion) === 'string'){
+        return;
+      }
+      const columnIdx = suggestion?.column || 0;
+      if (!sections[columnIdx]) {
+        sections[columnIdx] = [];
+      }
+      delete suggestion?.column;
+      sections[columnIdx].push(suggestion);
+    });
+    return sections.filter(section => section);  // remove empty slot/column from array
+  }
+
+  /** Order each suggestion for each section. */
+  private _orderSuggestions(suggestionSections: SuggestionMetadata[][]): SuggestionMetadata[][] {
+    return suggestionSections.map(section =>
+      section.sort((a, b) =>
+        (a.group === b.group)
+          ? a.label.localeCompare(b.label)
+          : a.group.localeCompare(b.group))
+    );
+  }
+
+  /** Create group header for each suggestion sections. */
+  private _createSuggestionGroupHeader(suggestionSections: SuggestionMetadata[][]): TypeaheadMatch[][] {
+    return suggestionSections.map(section => {
+      const newSectionSuggestions = [];
+      let lastGroup = '';
+      section.forEach(suggestion => {
+        if (suggestion?.group && suggestion.group !== lastGroup){
+          lastGroup = suggestion.group;
+          newSectionSuggestions.push(new TypeaheadMatch(suggestion.group, suggestion.group, true));
+        }
+        newSectionSuggestions.push(new TypeaheadMatch(suggestion, suggestion.label, false));
+      });
+      return newSectionSuggestions;
+    })
+  }
+}

--- a/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.interface.ts
+++ b/projects/admin/src/app/record/formly/type/entity-typeahead/entity-typeahead.interface.ts
@@ -1,0 +1,5 @@
+export interface EntityTypeFilter {
+  label: string,
+  value: string,
+  selected?: boolean;
+}

--- a/projects/admin/src/app/scss/styles.scss
+++ b/projects/admin/src/app/scss/styles.scss
@@ -1,4 +1,3 @@
-/* You can add global styles to this file, and also import other style files */
 /*
  * RERO ILS UI
  * Copyright (C) 2019 RERO

--- a/projects/admin/src/app/service/ui-remote-typeahead.service.ts
+++ b/projects/admin/src/app/service/ui-remote-typeahead.service.ts
@@ -32,8 +32,6 @@ export class UiRemoteTypeaheadService extends RemoteTypeaheadService {
    * Constructor
    * @param _recordService - RecordService
    * @param _apiService - APIService
-   * @param _injector - Injector, use of the injector to enable retrieval
-   *                    of class by name in Dependency injection
    */
   constructor(
     protected _recordService: RecordService,
@@ -75,7 +73,7 @@ export class UiRemoteTypeaheadService extends RemoteTypeaheadService {
    */
   getSuggestions(options: any, query: string, numberOfSuggestions: number, currentPid: string): Observable<Array<SuggestionMetadata>> {
     return (options.hasOwnProperty('type') && options.type in this._typeaheadTypes)
-    ? this._typeaheadTypes[options.type].getSuggestions(options, query, numberOfSuggestions)
-    : super.getSuggestions(options, query, numberOfSuggestions, currentPid);
+      ? this._typeaheadTypes[options.type].getSuggestions(options, query, numberOfSuggestions)
+      : super.getSuggestions(options, query, numberOfSuggestions, currentPid);
   }
 }


### PR DESCRIPTION
Creates a remote typeahead component that allows to split suggestions
into several column. Suggestions box includes a button to create a new
local entity if current logged user has permissions to create it.

Co-Authored-By: Renaud Michotte <renaud.michotte@gmail.com>

## requirements

https://github.com/rero/ng-core/pull/558

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
