### PR TITLE
document: loading items for the holding display

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.html
@@ -1,6 +1,7 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2019 RERO
+  Copyright (C) 2019-2023 RERO
+  Copyright (C) 2019-2023 UCLouvain
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -19,7 +20,7 @@
     <div class="col-6 pl-2 d-flex">
       <button type="button" class="btn-show-more"
               [ngClass]="{'btn-expanded': !isItemsCollapsed, 'btn-collapsed': isItemsCollapsed}"
-              (click)="isItemsCollapsed = !isItemsCollapsed"
+              (click)="isItemsCollapsed = !isItemsCollapsed; loadItems()"
               [attr.aria-expanded]="!isItemsCollapsed" aria-controls="collapse">
       </button>
       <admin-record-masked *ngIf="holding.metadata._masked" [record]="holding"></admin-record-masked>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding.component.ts
@@ -1,6 +1,7 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019 RERO
+ * Copyright (C) 2019-2023 RERO
+ * Copyright (C) 2019-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -87,7 +88,7 @@ export class HoldingComponent implements OnInit, OnDestroy {
   /** onInit hook */
   ngOnInit() {
     this.holdingType = this.holding.metadata.holdings_type;
-    if (this.holdingType !== 'electronic') {
+    if (!this.isItemsCollapsed && this.holdingType !== 'electronic') {
       this._loadItems();
     }
     if (this.isCurrentOrganisation) {
@@ -99,6 +100,13 @@ export class HoldingComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     if (this.itemsRef != null) {
       this.itemsRef.unsubscribe();
+    }
+  }
+
+  /** load items */
+  loadItems(): void {
+    if (!this.items && !this.isItemsCollapsed && this.holdingType !== 'electronic') {
+      this._loadItems();
     }
   }
 


### PR DESCRIPTION
Items are loaded only when we open the holdings section.

* Closes rero/rero-ils#3400.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Cypress tests successful?
