### PR TITLE
libraies: add editor validation

### DIFF
--- a/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
@@ -324,12 +324,12 @@ export class LibraryFormService {
    * @param settingType - the notification type
    */
   private _buildSettingsByType(settingType: NotificationType): UntypedFormGroup {
-    const model: NotificationSettings = {
+    const model: any = {
       type: settingType,
-      email: ''
+      email: ['', Validators.email]
     };
     if ([NotificationType.AVAILABILITY].includes(settingType)) {
-      model.delay = 0;
+      model.delay = ['',  Validators.max(720)];
     }
     return this._fb.group(model);
   }

--- a/projects/admin/src/app/routes/statistics-cfg-route.ts
+++ b/projects/admin/src/app/routes/statistics-cfg-route.ts
@@ -93,6 +93,7 @@ export class StatisticsCfgRoute extends BaseRoute implements RouteInterface {
             aggregationsBucketSize: 10,
             aggregationsExpand: ["library", "category", "frequency"],
             aggregationsOrder: ["library", "category", "frequency"],
+            showFacetsIfNoResults: true,
             searchFilters: [
               this.expertSearchFilter(),
               {


### PR DESCRIPTION
* Adds library editor validators for notification settings.
* Display facettes in the stat config editor when no result occurs.