### PR TITLE
feat(documents): hide related entities tab

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -229,7 +229,7 @@
       </tab>
       <!-- END OF DESCRIPTION TAB -->
       <!-- ENTITIES RELATED -->
-      <tab id="documents-entities-tab" tabOrder="3" [active]="!record.metadata.pid">
+      <tab *ngIf="!record.metadata.harvested && record.metadata.pid" id="documents-entities-tab" tabOrder="3">
         <ng-template tabHeading>
           <i class="fa fa-cubes mr-1"></i> {{ 'Related Entities' | translate }}
         </ng-template>


### PR DESCRIPTION
In the case of import, we hide the related entities tab.