### PR TITLE
fix(circulation): no loan info on receive

### DIFF
--- a/projects/admin/src/app/service/items.service.ts
+++ b/projects/admin/src/app/service/items.service.ts
@@ -155,6 +155,9 @@ export class ItemsService {
         if (data.action_applied[ItemAction.checkin]) {
           loan = data.action_applied[ItemAction.checkin];
         }
+        if (data.action_applied[ItemAction.receive]) {
+          loan = data.action_applied[ItemAction.receive];
+        }
         if (data.action_applied[ItemAction.validate]) {
           loan = data.action_applied[ItemAction.validate];
         }


### PR DESCRIPTION
* When performing a receive action on a loan, the ui didn't append the loan info and so the item could be treated as having no loan.
* Closes https://github.com/rero/rero-ils/issues/3612.