### PR TITLE
feat(circulation): add message on alert

### DIFF
--- a/projects/admin/src/app/circulation/patron/cancel-request-button.component.ts
+++ b/projects/admin/src/app/circulation/patron/cancel-request-button.component.ts
@@ -79,10 +79,16 @@ export class CancelRequestButtonComponent {
           this.loan.metadata.item.pid,
           this.loan.metadata.pid,
           this.userService.user.currentLibrary
-        ).subscribe(() => {
+        ).subscribe((item: any) => {
+          let message = this.translateService.instant("The request has been cancelled.");
+          if (item?.pending_loans?.length > 0) {
+            message += "<br>";
+            message += this.translateService.instant("The item contains requests.");
+          }
           this.toastrService.warning(
-            this.translateService.instant('The request has been cancelled.'),
-            this.translateService.instant('Request')
+            message,
+            this.translateService.instant('Request'),
+            { enableHtml: true }
           );
           this.cancelRequestEvent.emit(this.loan.id);
         });


### PR DESCRIPTION
When we cancel a request, if another request is active on the item, an additional message is added to the dialog.

* Closes rero/rero-ils#3571.