### PR TITLE
fix: expand more documents facets

### DIFF
--- a/projects/admin/src/app/routes/documents-route.ts
+++ b/projects/admin/src/app/routes/documents-route.ts
@@ -132,14 +132,14 @@ export class DocumentsRoute extends BaseRoute implements RouteInterface {
               'acquisition',
               'status',
             ],
-            aggregationsExpand: () => {
-              const expand = ['document_type'];
-              const { queryParams } = this._routeToolService.activatedRoute.snapshot;
-              if (queryParams.location || queryParams.library) {
-                expand.push('organisation');
-              }
-              return expand;
-            },
+            aggregationsExpand: [
+              'document_type',
+              'organisation',
+              'language',
+              'year',
+              'author',
+              'subject',
+            ],
             aggregationsBucketSize: 10,
             itemHeaders: {
               Accept: 'application/rero+json, application/json'

--- a/projects/public-search/src/app/routes/documents-route.service.ts
+++ b/projects/public-search/src/app/routes/documents-route.service.ts
@@ -111,20 +111,15 @@ export class DocumentsRouteService extends BaseRoute implements ResourceRouteInt
               },
               showFacetsIfNoResults: true,
               aggregationsOrder: this.aggregations(viewcode),
-              aggregationsExpand: () => {
-                const expand = ['document_type'];
-                const queryParams = this._route.snapshot.queryParams;
-                if (this.appConfigService.globalViewName === viewcode) {
-                  if (queryParams.location || queryParams.library) {
-                    expand.push('organisation');
-                  }
-                } else {
-                  if (queryParams.location) {
-                    expand.push('library');
-                  }
-                }
-                return expand;
-              },
+              aggregationsExpand: [
+                'document_type',
+                'organisation',
+                'library',
+                'language',
+                'year',
+                'author',
+                'subject',
+              ],
               aggregationsBucketSize: 10,
               searchFilters: [
                 {


### PR DESCRIPTION
* Most facets in the document search were not expanded by default. Expands most used facets by default and delete useless function for expanded facets.