### PR TITLE
fix(document): language facet translation

### DIFF
--- a/projects/public-search/src/app/service/bucket-name.service.ts
+++ b/projects/public-search/src/app/service/bucket-name.service.ts
@@ -42,6 +42,8 @@ export class BucketNameService implements IBucketNameService {
    */
   transform(aggregationKey: string, value: string): Observable<string> {
     switch (aggregationKey) {
+      case 'language':
+        return of(this.translateService.instant('lang_' + value));
       case 'fiction':
         const fiction_label = Boolean(value)? _('Fiction') : _('No fiction');
         return of(this.translateService.instant(fiction_label));


### PR DESCRIPTION
The language facet was not translated correctly,
as the key starts with `lang_'.