### PR TITLE
feat(circulation): automatic renewals

### DIFF
--- a/projects/admin/src/app/classes/notification.ts
+++ b/projects/admin/src/app/classes/notification.ts
@@ -30,7 +30,9 @@ export enum NotificationType {
   RECALL = 'recall',
   REQUEST = 'request',
   TRANSIT_NOTICE = 'transit_notice',
-  ACQUISITION_ORDER = 'acquisition_order'
+  ACQUISITION_ORDER = 'acquisition_order',
+  CLAIM_ISSUE = 'claim_issue',
+  AUTO_EXTEND = 'auto_extend'
 }
 
 export class Notification {
@@ -39,7 +41,8 @@ export class Notification {
       NotificationType.AVAILABILITY,
       NotificationType.DUE_SOON,
       NotificationType.OVERDUE,
-      NotificationType.RECALL
+      NotificationType.RECALL,
+      NotificationType.AUTO_EXTEND
     ],
     library: [
       NotificationType.AT_DESK,

--- a/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.html
+++ b/projects/admin/src/app/record/circulation-logs/circulation-log/circulation-log-loan/circulation-log-loan.component.html
@@ -77,7 +77,12 @@
     </dd>
 
     <!-- Operator -->
-    <dt class="col-4 label-title font-weight-bold fa-icon-operator"translate>Operator</dt>
-    <dd class="col-8">{{ record.metadata.user_name }}</dd>
+    <dt class="col-4 label-title font-weight-bold fa-icon-operator" translate>Operator</dt>
+    <dd class="col-8">
+      {{ record.metadata.user_name }}
+      @if (record.metadata.loan.auto_extend) {
+        ({{ 'automatic renewal' | translate }})
+      }
+    </dd>
   </dl>
 </admin-circulation-log>

--- a/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
@@ -112,16 +112,17 @@ export class LibraryFormService {
       this.rolloverAccountTransferOptions = libSchema.schema.properties.rollover_settings.properties.
         account_transfer.enum;
 
-      // DEV NOTES :: Why remove `acquisition_order`
+      // DEV NOTES :: Why remove `acquisition_order` an `claim_issue`
       //   `this.notificationTypes` is used to build the notification setting form ;
-      //   but we need to remove `acquisition_order` from this list because the email
+      //   but we need to remove `acquisition_order` and `claim_issue` from this list because the email
       //   used to send this kind of notification is selected by manager when it confirms
       //   and order. Then the email used is either :
       //      - related vendor email
-      //      - library acquisition setting email
+      //      - library (serial) acquisition setting email
       //      - custom email
       this.notificationTypes = notifSchema.schema.properties.notification_type.enum
-        .filter(type => type != NotificationType.ACQUISITION_ORDER);
+        .filter(type => type != NotificationType.ACQUISITION_ORDER)
+        .filter(type => type != NotificationType.CLAIM_ISSUE);
 
       this.build();
       this.buildEvent.next(true);

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -129,6 +129,7 @@ _('at_desk');
 _('booking');
 _('request');
 _('claim_issue');
+_('auto_extend');
 //  - loan state
 _('CREATED');
 _('PENDING');


### PR DESCRIPTION
* Depends on https://github.com/rero/rero-ils/pull/3691.
* Adds the info for auto_extends in the circulation log.
* Adds new notification type so that it can be displayed in the
library editor.
* Fixes the notification type `claim_issue` being wrongly displayed in
the library editor.