### PR TITLE
migration: add reject action

### DIFF
--- a/projects/admin/src/app/migration/deduplication/record/brief-view/migration-data-deduplication/migration-data-deduplication.component.html
+++ b/projects/admin/src/app/migration/deduplication/record/brief-view/migration-data-deduplication/migration-data-deduplication.component.html
@@ -18,64 +18,92 @@
 @if (record()) {
 <div class="flex w-100 justify-content-between mb-2">
   <div class="flex align-items-center justify-content-center">
-    <p-inplace #inplace [active]="isInplaceActive">
+    <p-inplace #inplace>
       <ng-template pTemplate="display">
-        <strong>ILS pid:</strong> {{ ilsPid }}&nbsp;<i
-          class="pi pi-pencil"
-        ></i>
+        <strong>ILS pid:</strong> {{ ilsPid }}&nbsp;<i class="pi pi-pencil"></i>
       </ng-template>
-      <ng-template #test pTemplate="content">
+      <ng-template pTemplate="content">
         <input
           [ngModel]="ilsPid"
           (keyup.enter)="saveIlsPid($event); inplace.deactivate()"
           (keydown.escape)="inplace.deactivate()"
           type="text"
           pInputText
-          autofocus
           onFocus="this.setSelectionRange(0, this.value.length)"
+          pAutoFocus
+          [autofocus]="true"
         />
       </ng-template>
     </p-inplace>
-    </div>
+  </div>
   <div class="flex align-items-center justify-content-center">
     <p-button
-      type="button"
       icon="pi pi-chevron-left"
       (click)="previousCandidate()"
       [disabled]="!hasPrevious()"
-      styleClass="p-button-text"
+      [text]="true"
     />
-    <small>{{currentCandidateIndex+1}}&nbsp;/&nbsp;{{candidates.length}}</small>
+    <small>
+      {{ currentCandidateIndex + 1 }}&nbsp;/&nbsp;{{
+        candidates.length
+      }}
+    </small
+    >
     <p-button
-      type="button"
       icon="pi pi-chevron-right"
       (click)="nextCandidate()"
       [disabled]="!hasNext()"
-      styleClass="p-button-text"
+      [text]="true"
     />
   </div>
-  <div class="flex align-items-center justify-content-center">
-    <p-button size="small" [label]="'Validate' | translate" (click)="save()" />
+  <div class="flex align-items-center gap-2 justify-content-center">
+    <p-button
+      size="small"
+      [outlined]="true"
+      [label]="'Validate' | translate"
+      (click)="save()"
+      icon="pi pi-check"
+    />
+    <p-button
+      [outlined]="true"
+      size="small"
+      [label]="'Reject' | translate"
+      (click)="reject()"
+      icon="pi pi-trash"
+      severity="danger"
+    />
   </div>
 </div>
 
 @if (messages) {
 <div>
-  <p-messages [value]="messages()" [escape]="false" [enableService]="false" [closable]="false" />
+  <p-messages
+    [value]="messages()"
+    [escape]="false"
+    [enableService]="false"
+    [closable]="false"
+  />
 </div>
 }
 
 <div class="flex justify-content-between mb-1">
   <div class="flex align-items-center justify-content-center">
     <p-tag
-      [severity]="status() === 'match' ? 'success': (status().endsWith('check') ? 'warning': 'secondary')"
+      [severity]="
+        status() === 'match'
+          ? 'success'
+          : status().endsWith('check')
+          ? 'warning'
+          : 'secondary'
+      "
       [value]="record().metadata.deduplication.status | translate"
     />
     @if (record()?.metadata?.deduplication?.modified_by) {
     <small class="ml-2"
       >({{ record()?.metadata?.deduplication?.modified_by }} /
       {{
-        record()?.metadata?.deduplication?.modified_at | dateTranslate : "medium"
+        record()?.metadata?.deduplication?.modified_at
+          | dateTranslate : "medium"
       }})</small
     >
     }

--- a/projects/admin/src/app/migration/deduplication/record/brief-view/migration-data-deduplication/migration-data-deduplication.component.ts
+++ b/projects/admin/src/app/migration/deduplication/record/brief-view/migration-data-deduplication/migration-data-deduplication.component.ts
@@ -38,9 +38,6 @@ export class MigrationDataDeduplicationBriefComponent implements OnInit {
   // current ILS pid
   ilsPid = null;
 
-  // toggle in place edit ils pid
-  isInplaceActive = false;
-
   // current candidate
   currentCandidate = null;
 
@@ -54,11 +51,15 @@ export class MigrationDataDeduplicationBriefComponent implements OnInit {
   ngOnInit(): void {
     let ilsPid = this.record()?.metadata?.deduplication?.ils_pid;
     // get value from the backend if it exists
-    if (ilsPid == null && this.candidates.length > 0) {
+    if (ilsPid == null && this.candidates.length > 0 && this.status() !== 'no match') {
       ilsPid = this.candidates[0].json.pid;
     }
     // display the current candidate if exists
     this.updateCurrentCandidate(ilsPid);
+    if (this.status() == 'no match') {
+      this.currentCandidateIndex = -1;
+      this.currentCandidate = null;
+    }
   }
 
   /**
@@ -189,6 +190,14 @@ export class MigrationDataDeduplicationBriefComponent implements OnInit {
   saveIlsPid(event): void {
     const ilsPid = event.target.value != '' ? event.target.value : null;
     this.updateCurrentCandidate(ilsPid);
+  }
+
+  /**
+   * Reject the candidates and set the status to "no match".
+   */
+  reject() {
+    this.ilsPid = null;
+    this.save();
   }
 
   /**

--- a/projects/admin/src/app/migration/migration.module.ts
+++ b/projects/admin/src/app/migration/migration.module.ts
@@ -16,6 +16,7 @@
  */
 
 import { NgModule } from '@angular/core';
+import { AutoFocusModule } from 'primeng/autofocus';
 
 import { RecordModule } from '@rero/ng-core';
 import { SharedModule } from '@rero/shared';
@@ -57,6 +58,7 @@ import { MigrationDetailComponent } from './record/brief-view/migration/migratio
     InplaceModule,
     ToastModule,
     PaginationModule,
+    AutoFocusModule
   ],
   exports: [],
   providers: [MessageService],


### PR DESCRIPTION
* Adds a "reject" button to speed up the user action.
* Fixes the ILS Pid focus.
* Do not display the first candidate for a "no match" deduplication status.