### PR TITLE
fix(cipo): editor addon wrap display

### DIFF
--- a/projects/admin/src/app/routes/circulation-policies-route.ts
+++ b/projects/admin/src/app/routes/circulation-policies-route.ts
@@ -203,7 +203,7 @@ export class CirculationPoliciesRoute extends BaseRoute implements RouteInterfac
   private _feeAmountSymbol(field: FormlyFieldConfig): FormlyFieldConfig {
     field = this._amountSymbol(field);
     field.props.addonRight = [
-      '/ day'
+      '/day'
     ];
     return field;
   }

--- a/projects/admin/src/manual_translations.ts
+++ b/projects/admin/src/manual_translations.ts
@@ -248,7 +248,7 @@ _('Vol. {{ volume }}');
 _('n°. {{ number }}');
 
 // Circulation policies
-_('/ day');
+_('/day');
 
 // Fiction statement
 _('fiction');


### PR DESCRIPTION
* Fixes wrap of "/ day" cipo editor addon because of brekable space.

![image](https://github.com/user-attachments/assets/34bb403d-701e-4330-be57-4edfc2486997)