### PR TITLE
feat(acquistions): add receipt editor

### DIFF
--- a/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-form.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-form.ts
@@ -179,6 +179,9 @@ export class OrderReceiptForm {
       {
         key: 'reference',
         type: 'string',
+        expressions: {
+          "props.disabled": "model.pid !=null"
+        },
         props: {
           label: _('Reference'),
         },
@@ -190,11 +193,17 @@ export class OrderReceiptForm {
           type: 'date',
           label: _('Reception date'),
           required: true
-        }
+        },
+        expressions: {
+          "props.disabled": "model?.receiveLines?.length < 1"
+        },
       },
       {
         key: 'receiveLines',
         type: 'repeat',
+        expressions: {
+          "props.disabled": "model.length < 1"
+        },
         props: {
           className: 'ui:font-bold',
           label: _('Order line(s)'),

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-view.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-view.component.html
@@ -31,7 +31,7 @@
       <p-button
         type="submit"
         size="small"
-        [disabled]="!form.valid || orderSend"
+        [disabled]="!form.valid"
         [icon]="orderSend ? 'fa fa-spinner fa-pulse' : 'fa fa-save'"
         [label]="'Save' | translate"
       />

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-form/order-receipt-view.component.ts
@@ -63,20 +63,7 @@ export class OrderReceiptViewComponent implements OnInit {
   knownDataCollapsed = true;
 
   /** Form fields */
-  private _fields: FormlyFieldConfig[];
-
-  // GETTER & SETTER ==========================================================
-
-  /** Get formly fields to use to render the form */
-  get fields(): FormlyFieldConfig[] {
-    // If the model contains a PID, we would set the `reference` field in readonly.
-    // The reference field should be enabled only for `AcqReceipt` creation, not for update.
-    // To update this field, user must use the classic resource editor.
-    if (this.model.pid) {
-      this._fields.find(field => field.key === 'reference').props.readonly = true;
-    }
-    return this._fields;
-  }
+  fields: FormlyFieldConfig[];
 
   /** OnInit hook */
   ngOnInit(): void {
@@ -123,11 +110,11 @@ export class OrderReceiptViewComponent implements OnInit {
     // Try to load the receipt depending of the url argument
     const receiptPid = this.route.snapshot.queryParams.receipt;
     if (receiptPid) {
+      this.model.pid = receiptPid;
       this.acqReceiptApiService
         .getReceipt(receiptPid)
         .subscribe((receipt: IAcqReceipt) => {
           this.receiptRecord = receipt;
-          this.model.pid = receiptPid;
           this.model.reference = receipt.reference;
           this.model.notes = receipt.notes;
           if (receipt.amount_adjustments) {
@@ -148,7 +135,7 @@ export class OrderReceiptViewComponent implements OnInit {
       .subscribe((loaded: boolean) => {
         this.orderRecord = this.orderReceiptForm.getOrderRecord();
         this.model = this.orderReceiptForm.getModel();
-        this._fields = this.orderReceiptForm.getConfig();
+        this.fields = this.orderReceiptForm.getConfig();
         this.loaded = loaded;
       });
   }

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-list/receipt-list.component.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-list/receipt-list.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { RecordPermissionService } from '@app/admin/service/record-permission.service';
 import { CurrentLibraryPermissionValidator } from '@app/admin/utils/permissions';
 import { Subscription } from 'rxjs';
@@ -30,7 +30,7 @@ import { ReceivedOrderPermissionValidator } from '../../../utils/permissions';
     templateUrl: './receipt-list.component.html',
     standalone: false
 })
-export class ReceiptListComponent implements OnInit, OnChanges, OnDestroy {
+export class ReceiptListComponent implements OnChanges, OnDestroy {
 
   private acqReceiptApiService: AcqReceiptApiService = inject(AcqReceiptApiService);
   private recordPermissionService: RecordPermissionService = inject(RecordPermissionService);
@@ -69,20 +69,10 @@ export class ReceiptListComponent implements OnInit, OnChanges, OnDestroy {
     return (this.receipts) ? this.receipts.length : 0;
   }
 
-  /** OnInit hook */
-  ngOnInit(): void {
-    this.loadPermissions();
-    this._loadReceipts();
-    this.subscriptions.add(
-      this.acqReceiptApiService.deletedReceiptSubject$.subscribe((deletedReceipt: IAcqReceipt) => {
-        this.receipts = this.receipts.filter((receipt: IAcqReceipt) => receipt.pid !== deletedReceipt.pid);
-      })
-    );
-  }
-
   /** OnChanges hook */
   ngOnChanges(changes: SimpleChanges) {
     if (changes.hasOwnProperty('order')) {
+      this.loadPermissions();
       this._loadReceipts();
     }
   }

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
@@ -104,6 +104,13 @@
     <!-- ACTION BUTTON COLUMN -->
     @if (recordPermissions && allowActions) {
       <div class="ui:col-span-2 ui:flex ui:flex-wrap ui:gap-1 ui:justify-end">
+         <shared-action-button
+          icon="fa fa-edit"
+          [title]="'Edit' | translate"
+          severity="primary"
+          [routerLink]="['/', 'acquisition', 'records', 'acq_orders', 'receive', receipt.acq_order.pid]"
+          [queryParams]="{ receipt: receipt.pid }"
+        />
         <shared-action-button
           icon="fa fa-trash"
           [title]="'Delete' | translate"

--- a/projects/admin/src/app/acquisition/formly/type/repeat-section.type.ts
+++ b/projects/admin/src/app/acquisition/formly/type/repeat-section.type.ts
@@ -34,11 +34,13 @@ import { FieldArrayType } from '@ngx-formly/core';
                 <p-button
                   [outlined]="true"
                   size="small"
+                  [disabled]="props.disabled"
                   (onClick)="field.props.selectUnselect($event, 'select', field.fieldGroup)"
                   [label]="'Select all' | translate"
                 />
                 <p-button
                   [outlined]="true"
+                  [disabled]="props.disabled"
                   size="small"
                   (onClick)="field.props.selectUnselect($event, 'unselect', field.fieldGroup)"
                   translate

--- a/projects/admin/src/app/acquisition/routes/guards/can-order-receipt.guard.spec.ts
+++ b/projects/admin/src/app/acquisition/routes/guards/can-order-receipt.guard.spec.ts
@@ -142,9 +142,8 @@ describe('CanOrderReceiptGuard', () => {
     const orderReceived = cloneDeep(order);
     orderReceived.status = AcqOrderStatus.RECEIVED;
     spyOn(acqOrderApiService, 'getOrder').and.returnValue(of(orderReceived));
-    guard.canActivate(activatedRouteSnapshotSpy).subscribe(() => {
-      tick();
-      expect(router.url).toBe('/errors/403');
+    guard.canActivate(activatedRouteSnapshotSpy).subscribe((access: boolean) => {
+      expect(access).toBeTruthy();
     });
   }));
 

--- a/projects/admin/src/app/acquisition/routes/guards/can-order-receipt.guard.ts
+++ b/projects/admin/src/app/acquisition/routes/guards/can-order-receipt.guard.ts
@@ -91,7 +91,7 @@ export class CanOrderReceiptGuard  {
           if (!order.is_current_budget) {
             return false;
           }
-          const validStatuses = [AcqOrderStatus.ORDERED, AcqOrderStatus.PARTIALLY_RECEIVED];
+          const validStatuses = [AcqOrderStatus.ORDERED, AcqOrderStatus.PARTIALLY_RECEIVED, AcqOrderStatus.RECEIVED];
           return validStatuses.some((key: string) => key === order.status);
         }),
         catchError(() => of(false))

--- a/projects/admin/src/app/acquisition/utils/permissions.ts
+++ b/projects/admin/src/app/acquisition/utils/permissions.ts
@@ -30,7 +30,6 @@ export class ReceivedOrderPermissionValidator {
    * @param order: the order to analyze.
    */
   validate(permissions: RecordPermissions, order: IAcqOrder): RecordPermissions {
-    setTimeout(() => {}, 0);
     if (order.status === AcqOrderStatus.RECEIVED) {
       permissions.create = {
         can: false,


### PR DESCRIPTION
An acquisition receipt should be editable as long as it is in the active budget.