### PR TITLE
fix(babeltheque): display "more info" after loading the ng app

### DIFF
--- a/projects/public-holdings-items/src/index.html
+++ b/projects/public-holdings-items/src/index.html
@@ -33,7 +33,7 @@
         <h4>Document holdings items</h4>
         <div class="rero-ils-ui">
           <public-search-document showinfo="true" documentpid="258" viewcode="global">
-            <more-info>For babeltec.</more-info>
+            <more-info style="display:none">For babeltec.</more-info>
           </public-search-document>
         </div>
       </div>

--- a/projects/public-search/src/app/document-detail/document-detail-view/document-detail-view.component.html
+++ b/projects/public-search/src/app/document-detail/document-detail-view/document-detail-view.component.html
@@ -38,7 +38,7 @@
         <shared-document-description [record]="document" />
       </p-tabpanel>
       @if (showinfo !== 'false') {
-        <p-tabpanel value="more">
+        <p-tabpanel value="more" class="ui:[&_more-info]:!block">
           <ng-content select="more-info" />
         </p-tabpanel>
       }


### PR DESCRIPTION
Linked to https://github.com/rero/rero-ils/pull/3871.