### PR TITLE
fix: advanced search type disabled if only one type

### DIFF
--- a/projects/admin/src/app/record/editor/type/repeat-section.type.ts
+++ b/projects/admin/src/app/record/editor/type/repeat-section.type.ts
@@ -21,7 +21,7 @@ import { FieldArrayType } from '@ngx-formly/core';
     selector: 'admin-repeat-section',
     template: `
     @for (field of field.fieldGroup; track $index; let i = $index) {
-      <div class="ui:grid ui:grid-cols-12 ui:gap-4">
+      <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:mt-2">
         <div class="ui:col-span-11">
           <formly-field [field]="field"></formly-field>
         </div>

--- a/projects/admin/src/app/record/search-view/document-advanced-search-form/document-advanced-search-form.component.ts
+++ b/projects/admin/src/app/record/search-view/document-advanced-search-form/document-advanced-search-form.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019-2024 RERO
+ * Copyright (C) 2019-2025 RERO
  * Copyright (C) 2021-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
@@ -158,6 +158,7 @@ export class DocumentAdvancedSearchFormComponent implements OnInit {
       field.props.class = "ui:w-full";
       field.props.styleClass = "ui:w-full";
       field.props.filter = true,
+      field.props.required = true;
       field.type = 'select';
       field.props.options.next(this.fieldDataConfig[fieldParentKey]);
     } else {
@@ -179,7 +180,7 @@ export class DocumentAdvancedSearchFormComponent implements OnInit {
   private initFieldSearchType(field: any, fieldParentKey: string): void {
     if (Object.keys(this.fieldsSearchTypeConfig).some(key => key === fieldParentKey)) {
       field.props.sort = false;
-      field.props.readonly = this.fieldsSearchTypeConfig[fieldParentKey].length < 2;
+      field.props.disabled = this.fieldsSearchTypeConfig[fieldParentKey].length < 2;
       field.props.options.next(this.fieldsSearchTypeConfig[fieldParentKey]);
       const fieldSearchTypeValue = this.fieldsSearchTypeConfig[fieldParentKey][0].value;
       if (
@@ -232,6 +233,7 @@ export class DocumentAdvancedSearchFormComponent implements OnInit {
                 key: 'searchType',
                 defaultValue: false,
                 props: {
+                  required: true,
                   hideLabelSelectOption: true,
                   options: new BehaviorSubject([]),
                   appendTo: 'body'
@@ -301,6 +303,7 @@ export class DocumentAdvancedSearchFormComponent implements OnInit {
                   key: 'searchType',
                   defaultValue: false,
                   props: {
+                    required: true,
                     hideLabelSelectOption: true,
                     options: new BehaviorSubject([]),
                     appendTo: 'body'


### PR DESCRIPTION
* Fixes the disabled type if only one value on select.
* Removes the clear action on select if value is required.

Deps: https://github.com/rero/ng-core/pull/721