### PR TITLE
style(library): enhance exception dates

### DIFF
--- a/projects/admin/src/app/classes/library.ts
+++ b/projects/admin/src/app/classes/library.ts
@@ -136,7 +136,7 @@ export class Library {
       }
       return exception;
     });
-    this.exception_dates = this.exception_dates.sort((a, b) => DateTime.fromISO(a.start_date) - DateTime.fromISO(b.start_date));
+    this.exception_dates = this.exception_dates.sort((a, b) => DateTime.fromISO(b.start_date) - DateTime.fromISO(a.start_date));
   }
 
   /**

--- a/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.html
+++ b/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.html
@@ -22,8 +22,8 @@
     </label>
     <div class="ui:col-span-10">
       <input
-        class="ui:w-full"
         pInputText
+        fluid="true"
         formControlName="title"
         [placeholder]="'Please insert a title' | translate"
       />
@@ -49,9 +49,11 @@
       <div class="ui:col-span-10">
         <p-datepicker
           appendTo="body"
+          dateFormat="dd.mm.yy"
+          fluid="true"
+          panelStyleClass="ui:!min-w-0"
           formControlName="date"
-          [readonlyInput]="true"
-          styleClass="ui:w-full"
+          [readonlyInput]="false"
           [showIcon]="true"
         />
         @if (date.invalid && (date.dirty || date.touched)) {
@@ -73,11 +75,13 @@
       </label>
       <div class="ui:col-span-10">
         <p-datepicker
-          styleClass="ui:w-full"
+          fluid="true"
+          dateFormat="dd.mm.yy"
+          panelStyleClass="ui:!min-w-0"
+          [readonlyInput]="false"
           appendTo="body"
           formControlName="dates"
           selectionMode="range"
-          [readonlyInput]="true"
           numberOfMonths="2"
           [showIcon]="true"
         />

--- a/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.html
@@ -15,7 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 @if (exception) {
-  <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:mx-2 ui:my-1" [ngClass]="{'ui:text-muted-color ui:line-through': isOver(exception)}">
+  <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:mx-2 ui:my-1" [ngClass]="{'ui:text-muted-color': isOver(exception)}">
     <i class="fa ui:col-span-1" aria-hidden="true" [ngClass]="{
       'fa-circle text-success': exception.is_open,
       'fa-ban text-error': !exception.is_open


### PR DESCRIPTION
Reverse the sorting of the exception dates so that more recent dates are displayed first for better usability.
Fix the datepickers by allowing manual editing, making the panel smaller, and changing the displayed date format.