### PR TITLE
fix: rename temporary circulation category

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-temporary-item-type/holding-item-temporary-item-type.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holding/holding-item-temporary-item-type/holding-item-temporary-item-type.component.ts
@@ -24,7 +24,7 @@ import { DateTime } from 'luxon';
     @if (hasTemporaryItemType()) {
       <dl class="metadata">
         <dt>
-          <span class="text-warning" translate>Temporary circulation category</span>&nbsp;
+          <span class="text-warning" translate>Temporary item type</span>&nbsp;
           <i class="fa fa-exclamation-triangle text-warning"></i>
         </dt>
         <dd>


### PR DESCRIPTION
The term temporary circulation category is misleading and not used anymore: replaced by "temporary item type".