### PR TITLE
fix: remove multiple headers hidden for printing

### DIFF
--- a/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.html
@@ -16,9 +16,7 @@
 -->
 
 @if (record) {
-  <header>
-    <h1>{{ record.metadata.name | translate }}</h1>
-  </header>
+  <h1>{{ record.metadata.name | translate }}</h1>
   <article class="ui:mt-4">
     <!-- DETAILS -->
     <section>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -24,9 +24,7 @@
       [routerLink]="['/records', 'holdings', 'detail', record.metadata.holding.pid]"
       [label]="'Back to parent holding' | translate" />
   }
-  <header>
-    <h1>{{ 'Barcode' | translate }} {{ record.metadata.barcode }}</h1>
-  </header>
+  <h1>{{ 'Barcode' | translate }} {{ record.metadata.barcode }}</h1>
   <section class="ui:mt-4">
     @if (record.metadata._masked) {
       <admin-record-masked [record]="record" [withLabel]="true" />
@@ -142,9 +140,7 @@
   <!-- ISSUE DATA -->
   @if (record.metadata.type === 'issue') {
     <section class="ui:mt-4">
-      <header>
-        <h3 translate>Issue data</h3>
-      </header>
+      <h3 translate>Issue data</h3>
       <dl class="metadata">
         <!-- is regular -->
         <dt translate>Regular issue</dt>

--- a/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/statistics-cfg-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/statistics-cfg-detail-view.component.html
@@ -15,10 +15,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 @if (record) {
-  <header>
-    <h1>{{ record.metadata.name }}</h1>
-    <span [innerHTML]="record.metadata.description | nl2br"></span>
-  </header>
+  <h1>{{ record.metadata.name }}</h1>
+  <span [innerHTML]="record.metadata.description | nl2br"></span>
   <section class="ui:mt-4">
     <dl class="metadata">
       <dt translate>Library</dt>

--- a/projects/public-search/src/app/patron-profile/patron-profile.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile.component.html
@@ -15,9 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 @if (user) { @if (user.isAuthenticated && user.isPatron) {
-<header>
-  <h3>{{ fullname }}</h3>
-</header>
+<h3>{{ fullname }}</h3>
 <section class="ui:mt-2">
   <public-search-patron-profile-menu [patronPid]="patron.pid" />
 </section>


### PR DESCRIPTION
Certain pages had multiple headers which are not semantically useful and caused problems with CSS cibling as the header element is hidden for printing.