### PR TITLE
fix(files): upload, label change

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
@@ -87,7 +87,7 @@ export class UploadFilesComponent implements OnInit {
       return;
     }
     this.fileService
-      .updateMetadata(this.parentRecord.id, file.key, { ...file.metadata, label:label })
+      .updateMetadata(this.parentRecord.id, file.key, { ...file.metadata, metadata: { label:label }})
       .subscribe((res) => {
         const newLabel = res.metadata.label;
         file.label = newLabel;

--- a/projects/admin/src/app/service/resources-files.service.ts
+++ b/projects/admin/src/app/service/resources-files.service.ts
@@ -159,7 +159,7 @@ export class ResourcesFilesService {
     fileKey = fileKey.replaceAll('%', '');
     // create the bucket
     return this.httpService
-      .post(`${this.baseUrl}/${parentRecordId}/files`, [{ key: fileKey, label: fileData.label }])
+      .post(`${this.baseUrl}/${parentRecordId}/files`, [{ key: fileKey, metadata: { label: fileData.label }}])
       .pipe(
         switchMap((res: any) =>
           // set the file content


### PR DESCRIPTION
* Adapts files upload service to new structure of `invenio_record_files`. `Label` is now in `metadata`.
* Closes https://github.com/rero/rero-ils/issues/3936.