### PR TITLE
feat: handle deleted documents linked to acq lines

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
@@ -1,6 +1,6 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2021-2024 RERO
+  Copyright (C) 2021-2026 RERO
   Copyright (C) 2021-2023 UCLouvain
 
   This program is free software: you can redistribute it and/or modify
@@ -33,8 +33,10 @@
         <div class="ui:flex ui:items-start ui:flex-col ui:w-full">
           <div class="ui:flex ui:w-full ui:justify-between">
             <div class="ui:flex">
-              @if (orderLine.document.pid | getRecord: 'documents' | async; as document) {
-                <shared-document-brief-view [record]="$any(document).metadata" />
+              @if (document) {
+                <shared-document-brief-view [record]="document.metadata" />
+              } @else if (document === null) {
+                <span class="ui:text-muted-color"><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ "Unknown document" | translate }} (pid {{ orderLine.document.pid }})</span>
               }
             </div>
             <div class="ui:flex ui:pt-2 ui:gap-2">

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2021-2025 RERO
+ * Copyright (C) 2021-2026 RERO
  * Copyright (C) 2021 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,8 +20,8 @@ import { RecordPermissions } from '@app/admin/classes/permissions';
 import { RecordPermissionService } from '@app/admin/service/record-permission.service';
 import { CurrentLibraryPermissionValidator } from '@app/admin/utils/permissions';
 import { RecordService } from '@rero/ng-core';
-import { forkJoin, Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { forkJoin, of, Subscription } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { AcqOrderApiService } from '../../../../api/acq-order-api.service';
 import { AcqOrderLineStatus, IAcqOrderLine } from '../../../../classes/order';
 
@@ -42,8 +42,10 @@ export class OrderLineComponent implements OnInit, OnDestroy {
   /** parent order */
   @Input() order: any;
 
-  /** order line relate account */
+  /** order line related account */
   account: any;
+  /** order line related document record */
+  document: any;
   /** Is the line is collapsed */
   isCollapsed = true;
   /** reference to AcqOrderLineStatus */
@@ -70,9 +72,13 @@ export class OrderLineComponent implements OnInit, OnDestroy {
     const permissions$ = this.recordPermissionService
       .getPermission('acq_order_lines', this.orderLine.pid)
       .pipe(map((permissions) => this.permissionValidator.validate(permissions, this.order.library.pid)));
-    forkJoin([permissions$, account$]).subscribe(([permissions, account]) => {
+    const document$ = this.recordService.getRecord('documents', this.orderLine.document.pid).pipe(
+      catchError(() => of(null))
+    );
+    forkJoin([permissions$, account$, document$]).subscribe(([permissions, account, document]) => {
       this.recordPermissions = permissions;
       this.account = account;
+      this.document = document;
     });
   }
 

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.html
@@ -1,6 +1,6 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2021-2025 RERO
+  Copyright (C) 2021-2026 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -19,8 +19,10 @@
   <div class="ui:col-span-7 ui:flex ui:gap-2 ui:flex-wrap">
     <strong>{{ line().quantity }}</strong>&nbsp;x
     <div>
-      @if (line().document.pid | getRecord: 'documents' | async; as document) {
-      <shared-document-brief-view [record]="$any(document).metadata" />
+      @if (document().record; as doc) {
+        <shared-document-brief-view [record]="doc.metadata" />
+      } @else if (document().notFound) {
+        <span class="ui:text-muted-color"><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ "Unknown document" | translate }} (pid {{ line().document?.pid }})</span>
       }
       @if ($any(line()).acq_account.pid | getRecord: 'acq_accounts' | async; as account) {
       <span class="ui:font-bold ui:text-muted-color ui:text-sm">[{{ $any(account).metadata.number }}]</span>

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2021-2025 RERO
+ * Copyright (C) 2021-2026 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -23,7 +23,8 @@ import { IAcqReceipt, IAcqReceiptLine } from '@app/admin/acquisition/classes/rec
 import { RecordPermissions } from '@app/admin/classes/permissions';
 import { RecordPermissionService } from '@app/admin/service/record-permission.service';
 import { CurrentLibraryPermissionValidator } from '@app/admin/utils/permissions';
-import { map, of, switchMap } from 'rxjs';
+import { RecordService } from '@rero/ng-core';
+import { catchError, map, of, switchMap } from 'rxjs';
 
 @Component({
   selector: 'admin-receipt-line',
@@ -36,6 +37,7 @@ export class ReceiptLineComponent {
     CurrentLibraryPermissionValidator
   );
   private acqReceiptApiService: AcqReceiptApiService = inject(AcqReceiptApiService);
+  private recordService: RecordService = inject(RecordService);
 
   line = input<IAcqReceiptLine>();
   receipt = input<IAcqReceipt>();
@@ -43,6 +45,22 @@ export class ReceiptLineComponent {
 
   /** Record permissions */
   permissions = toSignal<RecordPermissions>(toObservable(this.line).pipe(switchMap(() => this.updatePermissions())));
+
+  /** Document state: the record when found, or a notFound flag when the linked document no longer exists */
+  document = toSignal(
+    toObservable(this.line).pipe(
+      switchMap((line) => {
+        if (!line?.document?.pid) {
+          return of({ record: null, notFound: false });
+        }
+        return this.recordService.getRecord('documents', line.document.pid).pipe(
+          map((record) => ({ record, notFound: false })),
+          catchError(() => of({ record: null, notFound: true }))
+        );
+      })
+    ),
+    { initialValue: { record: null as any, notFound: false } }
+  );
 
   // GETTER & SETTER ==========================================================
   /**
@@ -59,7 +77,6 @@ export class ReceiptLineComponent {
   }
 
   updatePermissions() {
-    console.log('line', this.line());
     if (this.line() == null || !this.allowActions()) {
       return of(null);
     }

--- a/projects/admin/src/app/acquisition/formly/type/field-order-line.type.ts
+++ b/projects/admin/src/app/acquisition/formly/type/field-order-line.type.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019-2024 RERO
+ * Copyright (C) 2019-2026 RERO
  * Copyright (C) 2019-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,25 +19,29 @@
 import { ChangeDetectorRef, Component, inject, OnInit } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 import { extractIdOnRef, RecordService } from '@rero/ng-core';
-import { map, switchMap, tap } from 'rxjs';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'admin-formly-order-line-type',
   template: `
-    @if (document) {
-    <div class="ui:flex ui:gap-2">
-      <div class="ui:grow-1">
-        <shared-document-brief-view [record]="document" />
-        <admin-notes class="ui:text-sm" [notes]="orderLine.notes"/>
-      </div>
-      @if(orderLine.priority) {
-        <div class="ui:flex">
-          <p-overlaybadge [value]="orderLine.priority" [severity]="severity(this.orderLine.priority)">
-            <i class="fa fa-tachometer" style="font-size: 1.2rem"></i>
-          </p-overlaybadge>
+    @if (orderLine) {
+      <div class="ui:flex ui:gap-2">
+        <div class="ui:grow-1">
+          @if (document) {
+            <shared-document-brief-view [record]="document" />
+          } @else if (document === null) {
+            <span class="ui:text-muted-color"><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ "Unknown document" | translate }} (pid {{ documentPid }})</span>
+          }
+          <admin-notes class="ui:text-sm" [notes]="orderLine.notes"/>
         </div>
-      }
-    </div>
+        @if(orderLine.priority) {
+          <div class="ui:flex">
+            <p-overlaybadge [value]="orderLine.priority" [severity]="severity(orderLine.priority)">
+              <i class="fa fa-tachometer" style="font-size: 1.2rem"></i>
+            </p-overlaybadge>
+          </div>
+        }
+      </div>
     }
   `,
   standalone: false,
@@ -50,6 +54,10 @@ export class OrderLineTypeComponent extends FieldType implements OnInit {
   orderLine: any;
   document: any;
 
+  get documentPid(): string | null {
+    return this.orderLine ? extractIdOnRef(this.orderLine.document.$ref) : null;
+  }
+
   /** OnInit hook */
   ngOnInit(): void {
     const pid = extractIdOnRef(this.model.acqOrderLineRef);
@@ -58,8 +66,12 @@ export class OrderLineTypeComponent extends FieldType implements OnInit {
       .pipe(
         tap((line) => (this.orderLine = line.metadata)),
         map(() => extractIdOnRef(this.orderLine.document.$ref)),
-        switchMap((pid) => this.recordService.getRecord('documents', pid)),
-        tap((document) => (this.document = document.metadata)),
+        switchMap((pid) =>
+          this.recordService.getRecord('documents', pid).pipe(
+            catchError(() => of(null))
+          )
+        ),
+        tap((document) => (this.document = document?.metadata ?? null)),
         tap(() => this.changeDetectorRef.detectChanges())
       )
       .subscribe();

--- a/projects/admin/src/app/record/editor/formly/primeng/remote-autocomplete/remote/documents-remote.service.ts
+++ b/projects/admin/src/app/record/editor/formly/primeng/remote-autocomplete/remote/documents-remote.service.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2024-2025 RERO
+ * Copyright (C) 2024-2026 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -89,7 +89,10 @@ export class DocumentsRemoteService implements IRemoteAutocomplete {
       .pipe(
         map((data: any) =>
           `<span class="ui:p-2"><strong>${this.mainTitlePipe.transform(data.metadata.title)}</strong></span>`
-        )
+        ),
+        catchError(() => of(
+          `<span class="ui:text-muted-color"><i class="fa fa-exclamation-triangle"></i>&nbsp;${this.translateService.instant('Unknown document')} (pid ${pid})</span>`
+        ))
       );
   }
 


### PR DESCRIPTION
When a document linked to an acq_order_line or acq_receipt_line is
deleted, fetching it now fails gracefully instead of propagating the
HTTP 404 error.

- order-line: fetch document in ngOnInit via forkJoin with catchError;
  display "Unknown document" when the document no longer exists
- receipt-line: replace getRecord pipe with a reactive signal that
  catches errors; display "Unknown document" on 404; remove stale
  console.log
- formly order-line type: wrap document fetch in catchError; store
  extracted document pid in a dedicated property (document data uses
  $ref format, not pid); display "Unknown document" fallback with
  correct pid while keeping order-line notes visible
- documents remote autocomplete: add catchError to getValueAsHTML so
  that the order-line editor no longer throws a console error and shows
  a readable "Unknown document (pid X)" fallback when the linked
  document no longer exists

Relates to rero/rero-ils#3818