### PR TITLE
fix: fix column alignment in document description

### DIFF
--- a/projects/shared/src/lib/component/documents/document-description/description-zone/description-zone.component.html
+++ b/projects/shared/src/lib/component/documents/document-description/description-zone/description-zone.component.html
@@ -1,6 +1,6 @@
 <!--
   RERO ILS UI
-  Copyright (C) 2021-2025 RERO
+  Copyright (C) 2021-2026 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -18,7 +18,7 @@
   <div class="ui:font-bold ui:md:w-[30%] ui:w-[100%]" translate>
     <ng-content select="[label]" />
   </div>
-  <div>
+  <div class="ui:flex-1">
     <ng-content select="[content]" />
   </div>
 </div>

--- a/projects/shared/src/lib/component/documents/document-description/other-edition/other-edition.component.html
+++ b/projects/shared/src/lib/component/documents/document-description/other-edition/other-edition.component.html
@@ -41,11 +41,9 @@
     </dd>
   </dl>
 } @else {
-  <div class="ui:flex ui:flex-col ui:md:flex-row">
-    <div class="ui:font-bold ui:md:w-[30%] ui:w-[100%]">
-      {{ fieldLabel }}
-    </div>
-    <div>
+  <shared-description-zone>
+    <ng-container label>{{ fieldLabel }}</ng-container>
+    <ng-container content>
       <ul class="ui:list-none">
         @for (edition of field; track $index; let last=$last) {
           <li class="ui:inline">
@@ -64,6 +62,6 @@
           </li>
         }
       </ul>
-    </div>
-  </div>
+    </ng-container>
+  </shared-description-zone>
 }


### PR DESCRIPTION
Add `flex-1` to the content column of `description-zone` to ensure consistent alignment when text is long. Refactor `other-edition` block view to use `shared-description-zone` instead of duplicating the two-column layout.

<img width="1443" height="903" alt="image" src="https://github.com/user-attachments/assets/aa7d1cde-5e05-443b-ba25-ec7594f14dfb" />