### PR TITLE
feat: display location public note in holdings views

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.html
@@ -22,6 +22,9 @@
         <admin-record-masked [record]="record"></admin-record-masked>
       }
       <span>{{ record.metadata.library.name }}: {{ record.metadata.location.name }}</span>
+      @if (record.metadata.location.public_note) {
+        <div class="ui:text-sm ui:text-gray-500">{{ record.metadata.location.public_note | getTranslatedLabel : language }}</div>
+      }
     </div>
 
     <div class="ui:col-span-4">

--- a/projects/admin/src/app/record/detail-view/location-detail-view/location-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/location-detail-view/location-detail-view.component.html
@@ -36,6 +36,24 @@
               <dt class="ui:col-span-3" translate>Code</dt>
               <dd class="ui:col-span-7 ui:mb-0">{{ data.code }}</dd>
           </dl>
+          <!-- PUBLIC NOTE -->
+          @if (data.public_note) {
+            <dl class="ui:grid ui:grid-cols-12 ui:gap-4 ui:mb-1">
+              <dt class="ui:col-span-3" translate>Public note</dt>
+              <dd class="ui:col-span-7 ui:mb-0">
+                <ul class="ui:list-none">
+                  @for (note of data.public_note; track $index) {
+                    <li>
+                      <div class="ui:font-bold ui:w-20 ui:inline-block">
+                        <i class="fa fa-language" aria-hidden="true"></i>&nbsp;({{ note.language }})
+                      </div>
+                      {{ note.label }}
+                    </li>
+                  }
+                </ul>
+              </dd>
+            </dl>
+          }
           <!-- IS ONLINE -->
           <dl class="ui:grid ui:grid-cols-12 ui:gap-4 ui:mb-1">
             <dt class="ui:col-span-3" translate>Is online</dt>

--- a/projects/public-holdings-items/.browserslistrc
+++ b/projects/public-holdings-items/.browserslistrc
@@ -15,3 +15,4 @@ last 2 iOS major versions
 Firefox ESR
 not dead
 > 0.2%
+not ios_saf < 15

--- a/projects/public-patron-profile/.browserslistrc
+++ b/projects/public-patron-profile/.browserslistrc
@@ -15,3 +15,4 @@ last 2 iOS major versions
 Firefox ESR
 not dead
 > 0.2%
+not ios_saf < 15

--- a/projects/public-search/.browserslistrc
+++ b/projects/public-search/.browserslistrc
@@ -15,3 +15,4 @@ last 2 iOS major versions
 Firefox ESR
 not dead
 > 0.2%
+not ios_saf < 15

--- a/projects/public-search/src/app/document-detail/holdings/holdings.component.html
+++ b/projects/public-search/src/app/document-detail/holdings/holdings.component.html
@@ -48,6 +48,9 @@
             <div class="ui:grid ui:grid-cols-12 ui:md:gap-4 ui:gap-1 ui:mb-4">
               <div class="ui:col-span-12 ui:md:col-span-5">
                 {{ holding.metadata.library.name }}:&nbsp;{{ holding.metadata.location.name }}
+                @if (holding.metadata.location.public_note) {
+                  <div class="ui:text-sm ui:text-gray-500">{{ holding.metadata.location.public_note | getTranslatedLabel : translateService.currentLang }}</div>
+                }
               </div>
               <div class="ui:col-span-12 ui:md:col-span-2">
                 {{ holding.metadata.circulation_category.circulation_information | getTranslatedLabel : translateService.currentLang }}

--- a/projects/search-bar/.browserslistrc
+++ b/projects/search-bar/.browserslistrc
@@ -15,3 +15,4 @@ last 2 iOS major versions
 Firefox ESR
 not dead
 > 0.2%
+not ios_saf < 15


### PR DESCRIPTION
Show the location's public_note field below the location name in:
- the admin location detail view
- the public and admin document detail view

Also exclude iOS Safari < 15 from the browserslist config across all public projects to avoid build problems because of import.meta.

Related to https://github.com/rero/rero-ils/pull/4040.