### PR TITLE
fix(files): set download filename via HTML attribute

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.html
@@ -105,7 +105,7 @@
             tooltipPosition="top"
             title="download"
             [href]="toRelative(file.links.content)"
-            download
+            [download]="file.key"
             >{{ file.key }} <i class="fa fa-download"></i
           ></a>
         </div>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
@@ -45,7 +45,7 @@ export class UploadFilesComponent implements OnInit {
   // input text filter
   filterText = '';
   // filtered array of files
-  filteredFiles = [];
+  filteredFiles: any[] = [];
   // A file record as used by rero-invenio-files.
   parentRecord: Record = null;
 

--- a/projects/shared/src/lib/component/documents/files/files.component.html
+++ b/projects/shared/src/lib/component/documents/files/files.component.html
@@ -72,7 +72,7 @@
                   </a>
                 }
                 @if (file.download) {
-                  <a [href]="file.download" download>
+                  <a [href]="file.download" [download]="file.key">
                     <i class="fa fa-download ui:text-muted-color ui:mx-1"></i>
                   </a>
                 }

--- a/projects/shared/src/lib/component/documents/files/files.component.ts
+++ b/projects/shared/src/lib/component/documents/files/files.component.ts
@@ -30,6 +30,8 @@ export type File = {
   thumbnail?: string;
   // download URL
   download: string;
+  // actual filename (used as download attribute value for browser save dialog)
+  key: string;
   // thumbnail legend
   label: string;
   // preview URL
@@ -177,6 +179,7 @@ export class FilesComponent implements OnInit, OnDestroy {
             // main file (such as pdf)
             if (!['thumbnail', 'fulltext'].includes(entry?.metadata?.type)) {
               const dataFile: any = {
+                key: entry.key,
                 label: entry?.metadata?.label ? entry.metadata.label : entry.key,
                 mimetype: entry.mimetype,
                 download: new URL(entry.links.content).pathname,


### PR DESCRIPTION
Use the `download` attribute on file download links so browsers suggest the correct filename (the file key) instead of deriving it from the URL path. Also use relative URLs for `href` to avoid cross-origin restrictions on the attribute.