### PR TITLE
refactor: remove dynamic thumbnail resolution

### DIFF
--- a/projects/shared/src/lib/view/thumbnail/thumbnail.component.ts
+++ b/projects/shared/src/lib/view/thumbnail/thumbnail.component.ts
@@ -15,10 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { HttpClient } from '@angular/common/http';
-import { Component, inject, Input, OnInit } from '@angular/core';
-import { of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Component, Input, OnInit } from '@angular/core';
 
 
 @Component({
@@ -28,13 +25,8 @@ import { catchError } from 'rxjs/operators';
 })
 export class ThumbnailComponent implements OnInit {
 
-  protected httpClient: HttpClient = inject(HttpClient);
-
   /** Cover url */
   coverUrl: string;
-
-  /** ISBN of the record */
-  isbn: string;
 
   /** is a svg image */
   svgImage = true;
@@ -46,44 +38,18 @@ export class ThumbnailComponent implements OnInit {
   @Input() styleClass = 'ui:w-24';
 
   /**
-   * Get cover url
-   * @returns string - url of the cover if cover exists.
-   */
-  getCoverUrl() {
-    this.httpClient.get<any>(`/api/document/cover/${this.isbn}`).pipe(
-      catchError(e => {
-        if (e.status === 404) {
-          return of(null);
-        }
-      })
-    ).subscribe(result => {
-      if (result !== null && result.success) {
-        this.coverUrl = result.image;
-        this.svgImage = false;
-      }
-    });
-  }
-
-  /**
    * On init hook
    * Set default cover image, or get cover image if exists.
    */
   ngOnInit() {
     if (this.record && this.record.metadata) {
       this.coverUrl = `/static/images/icon_${this.record.metadata.type[0].main_type}.svg`;
-      const cover = this.record.metadata.electronicLocator?.filter((e: any) => e.content === 'coverImage' && e.type=== 'relatedResource');
-      if (this.record.metadata.electronicLocator && cover.length > 0) {
-        this.coverUrl = cover[0].url;
+      const cover = this.record.metadata.electronicLocator?.find(
+        (e: { content?: string; type: string; url: string }) => e.content === 'coverImage' && e.type === 'relatedResource'
+      );
+      if (cover) {
+        this.coverUrl = cover.url;
         this.svgImage = false;
-      } else if (this.record.metadata.identifiedBy) {
-        for (const identifier of this.record.metadata.identifiedBy) {
-          if (identifier.type === 'bf:Isbn') {
-            this.isbn = identifier.value;
-          }
-        }
-        if (this.isbn) {
-          this.getCoverUrl();
-        }
       }
     }
   }


### PR DESCRIPTION
Following the backend thumbnail refactor
(https://github.com/rero/rero-ils/pull/4018), the responsibility for thumbnail resolution and display is now fully on the backend. The frontend now only displays the existing thumbnail in the database, or the default SVG.