### PR TITLE
fix(local-fields): align tab visibility and permissions with backend

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.html
@@ -261,13 +261,13 @@
         <i class="fa fa-bars"></i>
         <span translate>Description</span>
       </p-tab>
-      @if (!record().metadata.harvested && record().metadata.pid) {
+      @if (record()?.metadata?.pid && hasRelatedEntities()) {
         <p-tab value="entity" class="ui:flex ui:items-center ui:!gap-2">
           <i class="fa fa-cubes"></i>
           <span translate>Related Entities</span>
         </p-tab>
       }
-      @if (!record().metadata.harvested && record().metadata.pid && showLocalFieldsTab) {
+      @if (record()?.metadata?.pid && showLocalFieldsTab() && (!record()?.metadata?.harvested || hasLocalFields())) {
         <p-tab value="local" class="ui:flex ui:items-center ui:!gap-2">
            <i class="fa fa-list-ul"></i>
           <span translate>Local fields</span>
@@ -298,14 +298,19 @@
       <p-tabpanel value="description">
         <shared-document-description [record]="record()" />
       </p-tabpanel>
-      @if (!record().metadata.harvested && record().metadata.pid) {
+      @if (record()?.metadata?.pid && hasRelatedEntities()) {
         <p-tabpanel value="entity">
           <admin-entities-related [record]="record()" />
         </p-tabpanel>
       }
-      @if (!record().metadata.harvested && record().metadata.pid && showLocalFieldsTab) {
+      @if (record()?.metadata?.pid && showLocalFieldsTab()) {
         <p-tabpanel value="local">
-          <admin-local-field [resourceType]="'documents'" [resourcePid]="$any(record().metadata.pid)" />
+          <admin-local-field
+            [resourceType]="'documents'"
+            [resourcePid]="$any(record()?.metadata?.pid)"
+            [readOnly]="!!record()?.metadata?.harvested"
+            (hasLocalFields)="hasLocalFields.set($event)"
+          />
         </p-tabpanel>
       }
       @if (!record().metadata.harvested && record().metadata.pid && showFilesTab) {

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, computed, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, input, signal, ChangeDetectionStrategy } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { RecordService, CallbackArrayFilterPipe, RecordData } from '@rero/ng-core';
-import { AppStore, IPermissions, PERMISSIONS, ThumbnailComponent, ContributionComponent, PartOfComponent, OtherEditionComponent, EntityLinkComponent, FilesComponent, DocumentDescriptionComponent, DocumentProvisionActivityPipe, MainTitlePipe } from '@rero/shared';
+import { AppStore, Entity, IPermissions, PERMISSIONS, ThumbnailComponent, ContributionComponent, PartOfComponent, OtherEditionComponent, EntityLinkComponent, FilesComponent, DocumentDescriptionComponent, DocumentProvisionActivityPipe, MainTitlePipe } from '@rero/shared';
 import { of, switchMap } from 'rxjs';
 import { DocumentApiService } from '../../../api/document-api.service';
 import { RelatedResourceComponent } from './related-resource/related-resource.component';
@@ -78,6 +78,19 @@ export class DocumentDetailViewComponent {
 
   readonly relatedResources = computed(() => this._processRelatedResources(this.record()));
   readonly recordMessage = computed(() => this._message(this.record()));
+
+  readonly hasRelatedEntities = computed(() => {
+    const metadata = this.record()?.metadata;
+    if (!metadata) return false;
+    return Entity.FIELDS_WITH_REF.some((field: string) =>
+      field in metadata &&
+      (metadata[field] as any[]).some((e: any) => e.entity?.resource_type)
+    );
+  });
+
+  /** Whether the current (harvested) document has local fields; fed by the local-field component output. */
+  readonly hasLocalFields = signal(false);
+
   readonly activateLink = computed(() =>
     !this.activatedRouter.snapshot.params.type?.startsWith('import_')
   );
@@ -112,9 +125,9 @@ export class DocumentDetailViewComponent {
    * Show local fields tab
    * @return boolean - if False, hide the local fields tab
    */
-  get showLocalFieldsTab(): boolean {
-    return this.appStore.canAccess([PERMISSIONS.LOFI_SEARCH, PERMISSIONS.LOFI_CREATE]);
-  }
+  readonly showLocalFieldsTab = computed(() =>
+    this.appStore.canAccess([PERMISSIONS.LOFI_SEARCH, PERMISSIONS.LOFI_CREATE])
+  );
 
   /**
    * Show or hide files tab

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/holdings-serial-store.spec.ts
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/holdings-serial-store.spec.ts
@@ -102,14 +102,14 @@ describe('Holdings Serial Store', () => {
     store.setHoldings(holdings);
     await vi.advanceTimersByTimeAsync(500);
     expect(store.isAllowIssueCreation()).toBe(true);
-    expect(store.isDisplayLocalFieldsTab()).toBe(true);
+    expect(store.showLocalFieldsTab()).toBe(true);
 
     const newHoldings = {...holdings};
     newHoldings.metadata = {...holdings.metadata, library: { pid: '2', type: 'lib' }};
     store.setHoldings(newHoldings);
     await vi.advanceTimersByTimeAsync(500);
     expect(store.isAllowIssueCreation()).toBe(false);
-    expect(store.isDisplayLocalFieldsTab()).toBe(false);
+    expect(store.showLocalFieldsTab()).toBe(true);
   });
 
   it('should return false, because the paginator is not active', async () => {

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/holdings-serial-store.ts
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/holdings-serial-store.ts
@@ -84,9 +84,8 @@ export const HoldingsSerialStore = signalStore(
     isFilterEnabled: computed(() => store.receivedItemsCount() >= 11 || '' !== store.filter()),
     isPaginatorEnabled: computed(() => store.pager.rows() < store.filterTotal()),
     isAllowIssueCreation: computed(() => store.appStore.currentLibraryPid() === store.holdings().metadata.library.pid),
-    isDisplayLocalFieldsTab: computed(() =>
+    showLocalFieldsTab: computed(() =>
       store.appStore.canAccess(localFieldsPermissions)
-      && store.appStore.currentLibraryPid() === store.holdings().metadata.library.pid
     ),
   })),
   withMethods((store) => ({

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -47,7 +47,7 @@
       <i class="fa fa-list-ul"></i>
       <span translate>Details</span>
     </p-tab>
-    @if (store.isDisplayLocalFieldsTab()) {
+    @if (store.showLocalFieldsTab()) {
       <p-tab value="local" class="ui:flex ui:items-center ui:!gap-2">
         <i class="fa fa-list-ul"></i>
         <span translate>Local fields</span>
@@ -157,9 +157,13 @@
     <p-tabpanel value="detail">
       <admin-holding-detail context="holdings" [holding]="holding()"></admin-holding-detail>
     </p-tabpanel>
-    @if (store.isDisplayLocalFieldsTab()) {
+    @if (store.showLocalFieldsTab()) {
       <p-tabpanel value="local">
-        <admin-local-field [resourceType]="'holdings'" [resourcePid]="$any(holding().metadata.pid)"></admin-local-field>
+        <admin-local-field
+          [resourceType]="'holdings'"
+          [resourcePid]="(holding().metadata.pid)"
+          [resourceLibraryPid]="holding().metadata.library.pid"
+        ></admin-local-field>
       </p-tabpanel>
     }
   </p-tabpanels>

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -210,7 +210,7 @@
           <i class="fa fa-exchange"></i>
           <span translate>Circulation</span>
         </p-tab>
-        @if (isDisplayLocalFieldsTab) {
+        @if (showLocalFieldsTab()) {
           <p-tab value="field" class="ui:flex ui:items-center ui:!gap-2">
             <i class="fa fa-list-ul ui:mr-1"></i>&nbsp;
             <span translate>Local fields</span>
@@ -250,9 +250,13 @@
             }
           </div>
         </p-tabpanel>
-        @if (isDisplayLocalFieldsTab) {
+        @if (showLocalFieldsTab()) {
           <p-tabpanel value="field">
-            <admin-local-field [resourceType]="'items'" [resourcePid]="$any(record()?.metadata.pid)" />
+            <admin-local-field
+              [resourceType]="'items'"
+              [resourcePid]="$any(record()?.metadata.pid)"
+              [resourceLibraryPid]="record()?.metadata.library.pid"
+            />
           </p-tabpanel>
         }
         @if (record()?.metadata?.issue?.claims) {

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ChangeDetectionStrategy, Component, effect, inject, input, model, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, model, signal } from '@angular/core';
 import { ItemApiService } from '@app/admin/api/item-api.service';
 import { IssueService } from '@app/admin/service/issue.service';
 import { DateTranslatePipe, GetRecordPipe, Nl2brPipe, RecordService } from '@rero/ng-core';
@@ -68,8 +68,6 @@ export class ItemDetailViewComponent {
 
   /** Location record */
   readonly location = signal<any>(null);
-  /** Load operation logs on show */
-  showOperationLogs = false;
   /** reference to ItemIssueStatus */
   issueItemStatus = IssueItemStatus;
 
@@ -82,9 +80,9 @@ export class ItemDetailViewComponent {
     });
   }
 
-  get isDisplayLocalFieldsTab(): boolean {
-    return this.appStore.currentLibraryPid() === this.record()?.metadata.library.pid;
-  }
+  readonly showLocalFieldsTab = computed(() =>
+    this.appStore.canAccess([PERMISSIONS.LOFI_SEARCH, PERMISSIONS.LOFI_CREATE])
+  );
 
   /**
    * Get organisation currency

--- a/projects/admin/src/app/record/detail-view/local-field/local-field.component.html
+++ b/projects/admin/src/app/record/detail-view/local-field/local-field.component.html
@@ -25,39 +25,43 @@
         </dl>
       }
     </div>
-    <div class="ui:flex ui:gap-1">
-      @if ($any(recordPermissions())?.update?.can) {
+  }
+  @if (!readOnly()) {
+    @if (localFields().length > 0) {
+      <div class="ui:flex ui:gap-1">
+        @if ($any(recordPermissions())?.update?.can) {
+          <p-button
+            icon="fa fa-pencil"
+            [label]="'Edit'|translate"
+            outlined
+            [routerLink]="['/records', 'local_fields', 'edit', pid()]"
+            [queryParams]="{ type: resourceType(), ref: resourcePid() }"
+            size="small"
+          />
+        }
+        @if ($any(recordPermissions())?.delete?.can) {
+          <p-button
+            icon="fa fa-trash"
+            [label]="'Delete'|translate"
+            severity="danger"
+            outlined
+            size="small"
+            (onClick)="delete()"
+          />
+        }
+      </div>
+    } @else if (canAdd()) {
+      <div class="ui:flex ui:justify-end">
         <p-button
-          icon="fa fa-pencil"
-          [label]="'Edit'|translate"
+          icon="fa fa-plus-square-o"
+          [label]="'Add local fields'|translate"
           outlined
-          [routerLink]="['/records', 'local_fields', 'edit', localFieldRecordPid()]"
+          [routerLink]="['/records', 'local_fields', 'new']"
           [queryParams]="{ type: resourceType(), ref: resourcePid() }"
-          size="small"
         />
-      }
-      @if ($any(recordPermissions())?.delete?.can) {
-        <p-button
-          icon="fa fa-trash"
-          [label]="'Delete'|translate"
-          severity="danger"
-          outlined
-          size="small"
-          (onClick)="delete()"
-        />
-      }
-    </div>
-  } @else {
-  <div class="ui:flex ui:justify-end">
-    <p-button
-      icon="fa fa-plus-square-o"
-      [label]="'Add local fields'|translate"
-      outlined
-      [routerLink]="['/records', 'local_fields', 'new']"
-      [queryParams]="{ type: resourceType(), ref: resourcePid() }"
-    />
-  </div>
-}
+      </div>
+    }
+  }
 
 } @placeholder {
   <i class="fa fa-spin fa-spinner"></i>&nbsp;{{ 'Loading in progress…' | translate }}

--- a/projects/admin/src/app/record/detail-view/local-field/local-field.component.ts
+++ b/projects/admin/src/app/record/detail-view/local-field/local-field.component.ts
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, computed, inject, input, signal, Signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, input, output, signal, Signal, ChangeDetectionStrategy } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { LocalFieldApiService } from '@app/admin/api/local-field-api.service';
 import { RecordPermissionService } from '@app/admin/service/record-permission.service';
-import { AppStore, IPermissions, JoinPipe, PERMISSIONS } from '@rero/shared';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { AppStore, JoinPipe } from '@rero/shared';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { Bind } from 'primeng/bind';
 import { Button } from 'primeng/button';
@@ -36,16 +36,24 @@ import { RouterLink } from '@angular/router';
 export class LocalFieldComponent {
 
   private localFieldApiService: LocalFieldApiService = inject(LocalFieldApiService);
-  private appStore = inject(AppStore);
+  private readonly appStore = inject(AppStore);
   private recordPermissionService: RecordPermissionService = inject(RecordPermissionService);
 
   // INPUTS ===================================================================
   readonly resourceType = input<string>();
   readonly resourcePid = input<string>();
+  readonly resourceLibraryPid = input<string | undefined>();
+  readonly readOnly = input<boolean>(false);
+
+  // OUTPUTS ==================================================================
+  /**
+   * Emits once, when the local_fields record is fetched, whether this resource
+   * has local fields. Lets a host decide tab visibility from the single request
+   * this component already performs, instead of issuing a duplicate one.
+   */
+  readonly hasLocalFields = output<boolean>();
 
   // PUBLIC ===================================================================
-  readonly permissions: IPermissions = PERMISSIONS;
-
   /** Loading state: set to true on each backend call, false when done or on error */
   readonly isLoading = signal(true);
 
@@ -58,8 +66,10 @@ export class LocalFieldComponent {
 
   // SIGNALS ==================================================================
 
-  /** Source of truth: the local_fields record fetched from the API */
-  private readonly record = toSignal(
+  readonly pid = signal<string | null>(null);
+
+  /** Fetches the local_fields record whenever resourcePid changes; sets pid from the result */
+  private readonly _fetchedRecord = toSignal(
     toObservable(this.resourcePid).pipe(
       tap(() => this.isLoading.set(true)),
       switchMap(pid =>
@@ -68,8 +78,15 @@ export class LocalFieldComponent {
           pid,
           this.appStore.currentOrganisationPid()
         ).pipe(
+          tap(result => {
+            const pid = result?.metadata?.pid ?? null;
+            this.pid.set(pid);
+            this.hasLocalFields.emit(pid != null);
+          }),
           catchError(() => {
             this.isLoading.set(false);
+            this.pid.set(null);
+            this.hasLocalFields.emit(false);
             return of({});
           })
         )
@@ -77,6 +94,12 @@ export class LocalFieldComponent {
     ),
     { initialValue: null }
   );
+
+  /** Source of truth: null when pid is null (deleted or not found), else the fetched data */
+  private readonly record = computed(() => {
+    const pid = this.pid();
+    return pid ? this._fetchedRecord() : null;
+  });
 
   /** Permissions for the current record */
   readonly recordPermissions = toSignal(
@@ -100,10 +123,25 @@ export class LocalFieldComponent {
     { initialValue: null }
   );
 
-  /** Pid of the LocalField record */
-  readonly localFieldRecordPid: Signal<string | null> = computed(
-    () => this.record()?.metadata?.pid ?? null
+  /** Backend create permission for local_fields (role-level, not resource-specific) */
+  private readonly canCreatePermission = toSignal(
+    this.recordPermissionService.getPermission('local_fields').pipe(
+      map(perms => perms?.create?.can ?? false),
+      catchError(() => of(false))
+    ),
+    { initialValue: false }
   );
+
+  /** Whether the current user can add a local field to this resource */
+  readonly canAdd: Signal<boolean> = computed(() => {
+    if (!this.canCreatePermission()) return false;
+    const libraryPid = this.resourceLibraryPid();
+    if (libraryPid !== undefined) {
+      const userLibraries = this.appStore.user()?.patronLibrarian?.libraries ?? [];
+      return userLibraries.some(lib => lib.pid === libraryPid);
+    }
+    return true;
+  });
 
   /** Sorted local fields ready for display */
   readonly localFields: Signal<{ name: string; value: string[] }[]> = computed(() => {
@@ -118,11 +156,10 @@ export class LocalFieldComponent {
   /** Delete the complete LocalField resource. */
   delete(): void {
     this.localFieldApiService
-      .delete(this.localFieldRecordPid())
+      .delete(this.pid()!)
       .subscribe((success: any) => {
         if (success) {
-          // The parent detail view is expected to re-render after deletion.
-          // Nothing to do here as record() will be stale until next navigation.
+          this.pid.set(null);
         }
       });
   }


### PR DESCRIPTION
* Closes https://github.com/rero/rero-ils/issues/4091.
* Closes https://github.com/rero/rero-ils/issues/4097.

Items and holdings: show the local fields tab regardless of whether the
resource belongs to the current library. The tab is now gated on LOFI
permissions only, matching the new backend policy introduced in
https://github.com/rero/rero-ils/pull/4092 where library-level restrictions for create/update/delete
are enforced server-side.

The "Add local fields" button checks the backend for the LOFI create
permission and, for items and holdings, additionally verifies that the
resource belongs to one of the user's manageable libraries (checked via
user.patronLibrarian.libraries, passed as resourceLibraryPid input).

Harvested documents: show the local fields tab when local fields exist
(checked via API) and the related entities tab when linked entities are
present in the document metadata. Both tabs are read-only on harvested
documents — add/edit/delete actions are hidden via a new readOnly input
on the local-field component.

The entities tab is now also conditional on hasRelatedEntities() for all
documents, avoiding an empty tab on documents without linked entities.

Fix a bug where deleting a local field record did not refresh the
component — the view now reloads via a _reload signal after successful
deletion.