### PR TITLE
fix(alert-type): change to warn

### DIFF
--- a/projects/admin/src/app/circulation/checkin/checkin.component.ts
+++ b/projects/admin/src/app/circulation/checkin/checkin.component.ts
@@ -407,11 +407,10 @@ export class CheckinComponent {
   hasFees(event: boolean) {
     if (event) {
       this.messageService.add({
-        severity: 'error',
+        severity: 'warn',
         summary: this.translate.instant('Checkin'),
         detail: this.translate.instant('The item has fees'),
-        sticky: true,
-        closable: true
+        life: CONFIG.MESSAGE_LIFE
       });
     }
   }

--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -435,11 +435,10 @@ export class LoanComponent {
   hasFees(event: boolean): void {
     if (event) {
       this.messageService.add({
-        severity: 'error',
+        severity: 'warn',
         summary: this.translateService.instant('Checkin'),
         detail: this.translateService.instant('The item has fees'),
-        sticky: true,
-        closable: true,
+        life: CONFIG.MESSAGE_LIFE,
       });
     }
   }


### PR DESCRIPTION
* Changes alert type from error to warn.
* Removes sticky parameter, it needs to be false to remove the toast.
* Closes rero/rero-ils#4087.