### PR TITLE
feat(admin): add CentsCurrencyPipe and migrate all amount displays

### DIFF
--- a/projects/admin/src/app/acquisition/components/account/account-detail-view/account-detail-view.component.html
+++ b/projects/admin/src/app/acquisition/components/account/account-detail-view/account-detail-view.component.html
@@ -58,41 +58,41 @@
           <tr class="ui:p-2">
             <td colspan="2" class="ui:font-bold" translate>Allocated amount</td>
             <td colspan="2" class="text-success ui:text-right">
-              {{ account.allocated_amount | currency: organisation.default_currency }}
+              {{ account.allocated_amount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td colspan="2" class="ui:font-bold" translate>Distribution</td>
             <td colspan="2" class="ui:text-right" [ngClass]="{'text-error': account.distribution > 0}">
-              {{ account.distribution | negativeAmount | currency: organisation.default_currency }}
+              {{ account.distribution | negativeAmount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td class="ui:font-bold" translate>Current encumbrance</td>
             <td class="ui:font-bold" translate>Self</td>
             <td colspan="2" class="ui:text-right" [ngClass]="{'text-error': account.encumbrance_amount.self > 0}">
-              {{ account.encumbrance_amount.self | negativeAmount | currency: organisation.default_currency }}
+              {{ account.encumbrance_amount.self | negativeAmount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td></td>
             <td class="ui:font-bold" translate>Children</td>
             <td colspan="2" class="ui:text-right" [ngClass]="{'text-error': account.encumbrance_amount.children > 0}">
-              {{ account.encumbrance_amount.children | negativeAmount | currency: organisation.default_currency }}
+              {{ account.encumbrance_amount.children | negativeAmount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td class="ui:font-bold" translate>Current expenditure</td>
             <td class="ui:font-bold" translate>Self</td>
             <td colspan="2" class="ui:text-right" [ngClass]="{'text-error': account.expenditure_amount.self > 0}">
-              {{ account.expenditure_amount.self | negativeAmount | currency: organisation.default_currency }}
+              {{ account.expenditure_amount.self | negativeAmount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td></td>
             <td class="ui:font-bold" translate>Children</td>
             <td colspan="2" class="ui:text-right" [ngClass]="{'text-error': account.expenditure_amount.children > 0}">
-              {{ account.expenditure_amount.children | negativeAmount | currency: organisation.default_currency }}
+              {{ account.expenditure_amount.children | negativeAmount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr class="ui:bg-surface-100">
@@ -101,21 +101,21 @@
                 'text-success': account.remaining_balance.self > 0,
                 'text-error': account.remaining_balance.self < 0
               }">
-              {{ account.remaining_balance.self | currency: organisation.default_currency }}
+              {{ account.remaining_balance.self | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td colspan="2" class="ui:font-bold" translate>Allowed encumbrance exceedance</td>
             <td class="ui:text-right">{{ account.encumbrance_exceedance.value }}%</td>
             <td class="ui:text-right">
-              {{ account.encumbrance_exceedance.amount | currency: organisation.default_currency }}
+              {{ account.encumbrance_exceedance.amount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           <tr>
             <td colspan="2" class="ui:font-bold" translate>Allowed expenditure exceedance</td>
             <td class="ui:text-right">{{ account.expenditure_exceedance.value }}%</td>
             <td class="ui:text-right">
-              {{ account.expenditure_exceedance.amount | currency: organisation.default_currency }}
+              {{ account.expenditure_exceedance.amount | centsCurrency: organisation.default_currency }}
             </td>
           </tr>
           </tbody>

--- a/projects/admin/src/app/acquisition/components/account/account-detail-view/account-detail-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/account/account-detail-view/account-detail-view.component.ts
@@ -25,6 +25,7 @@ import { RouterLink } from '@angular/router';
 import { NgClass, AsyncPipe, CurrencyPipe } from '@angular/common';
 import { GetRecordPipe } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { NegativeAmountPipe } from '../../../pipes/negative-amount.pipe';
 import { MessageModule } from 'primeng/message';
 import { PanelModule } from 'primeng/panel';
@@ -32,7 +33,7 @@ import { PanelModule } from 'primeng/panel';
 @Component({
     selector: 'admin-acquisition-account-detail-view',
     templateUrl: './account-detail-view.component.html',
-    imports: [TranslateDirective, RouterLink, NgClass, AsyncPipe, CurrencyPipe, GetRecordPipe, TranslatePipe, NegativeAmountPipe, MessageModule, PanelModule],
+    imports: [TranslateDirective, RouterLink, NgClass, AsyncPipe, CurrencyPipe, GetRecordPipe, TranslatePipe, NegativeAmountPipe, CentsCurrencyPipe, MessageModule, PanelModule],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AccountDetailViewComponent {

--- a/projects/admin/src/app/acquisition/components/account/account-list/account-list.component.html
+++ b/projects/admin/src/app/acquisition/components/account/account-list/account-list.component.html
@@ -70,7 +70,7 @@
               <a [title]="rowData.name +' ('+rowData.number+')'" [routerLink]="['/acquisition', 'records', 'acq_accounts', 'detail', rowData.pid]">{{ rowData.name }}</a>
           </td>
           <td class="ui:!text-right">
-            {{ rowData.allocated_amount | currency: organisation().default_currency }}
+            {{ rowData.allocated_amount | centsCurrency: organisation().default_currency }}
           </td>
           <td class="ui:!text-right">
             @let available_amount = rowData | accountAvailableAmount;
@@ -86,19 +86,19 @@
             'text-error': rowData.encumbrance_amount.self > 0,
             ' ui:text-muted-color': rowData.encumbrance_amount.self <= 0
           }">
-            {{ rowData.encumbrance_amount.self | currency: organisation().default_currency }}
+            {{ rowData.encumbrance_amount.self | centsCurrency: organisation().default_currency }}
           </td>
           <td class="ui:!text-right" [class]="{
             'text-error': rowData.expenditure_amount.self > 0,
             ' ui:text-muted-color': rowData.expenditure_amount.self <= 0
           }">
-            {{ rowData.expenditure_amount.self | currency: organisation().default_currency }}
+            {{ rowData.expenditure_amount.self | centsCurrency: organisation().default_currency }}
           </td>
           <td class="ui:!text-right" [class]="{
             ' ui:text-muted-color': rowData.remaining_balance.self === 0,
             'text-warning': rowData.remaining_balance.self < 0
           }">
-            {{ rowData.remaining_balance.self | currency: organisation().default_currency }}
+            {{ rowData.remaining_balance.self | centsCurrency: organisation().default_currency }}
           </td>
           <td>
             <div class="ui:flex ui:gap-1 ui:justify-end ui:flex-wrap">

--- a/projects/admin/src/app/acquisition/components/account/account-list/account-list.component.ts
+++ b/projects/admin/src/app/acquisition/components/account/account-list/account-list.component.ts
@@ -34,12 +34,13 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TreeTableModule } from 'primeng/treetable';
 import { filter, forkJoin } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { AccountAvailableAmountPipe } from '../../../pipes/account-available-amount.pipe';
 
 @Component({
     selector: 'admin-account-list',
     templateUrl: './account-list.component.html',
-    imports: [TranslateDirective, Bind, Button, RouterLink, PermissionsDirective, ExportButtonComponent, TreeTableModule, CurrencyPipe, Nl2brPipe, TranslatePipe, AccountAvailableAmountPipe, TooltipModule],
+    imports: [TranslateDirective, Bind, Button, RouterLink, PermissionsDirective, ExportButtonComponent, TreeTableModule, CurrencyPipe, Nl2brPipe, TranslatePipe, AccountAvailableAmountPipe, CentsCurrencyPipe, TooltipModule],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AccountListComponent {

--- a/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.html
+++ b/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.html
@@ -66,7 +66,7 @@
               </div>
               <div class="ui:col-span-2 ui:text-right">
                 {{
-                  account.allocated_amount | currency : organisation()!.default_currency
+                  account.allocated_amount | centsCurrency : organisation()!.default_currency
                 }}
               </div>
               <div
@@ -79,7 +79,7 @@
               >
                 {{
                   account.remaining_balance?.self
-                    | currency : organisation()!.default_currency
+                    | centsCurrency : organisation()!.default_currency
                 }}
               </div>
               <div class="ui:col-span-1 ui:text-center">

--- a/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.ts
+++ b/projects/admin/src/app/acquisition/components/account/account-transfer/account-transfer.component.ts
@@ -38,7 +38,8 @@ import { IAcqAccount } from '../../../classes/account';
 import { orderAccountsAsTree } from '../../../utils/account';
 import { Bind } from 'primeng/bind';
 import { Button } from 'primeng/button';
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { SelectModule } from 'primeng/select';
 import { CardModule } from 'primeng/card';
 import { RadioButtonModule } from 'primeng/radiobutton';
@@ -51,7 +52,7 @@ import { InputTextModule } from 'primeng/inputtext';
   templateUrl: './account-transfer.component.html',
   imports: [
     TranslateDirective, FormsModule, ReactiveFormsModule, RouterLink,
-    Bind, Button, AsyncPipe, CurrencyPipe, GetRecordPipe, TranslatePipe,
+    Bind, Button, AsyncPipe, CentsCurrencyPipe, GetRecordPipe, TranslatePipe,
     SelectModule, CardModule, RadioButtonModule, InputGroupModule, InputGroupAddonModule, InputTextModule
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/admin/src/app/acquisition/components/budget/budget-detail-view/budget-detail-view.component.html
+++ b/projects/admin/src/app/acquisition/components/budget/budget-detail-view/budget-detail-view.component.html
@@ -28,7 +28,7 @@
   <section>
     <dl class="metadata">
       <dt translate>Total</dt>
-      <dd>{{ totalAmount() | currency:currencyCode:'symbol' }}</dd>
+      <dd>{{ totalAmount() | centsCurrency:currencyCode:'symbol' }}</dd>
     </dl>
   </section>
 }

--- a/projects/admin/src/app/acquisition/components/budget/budget-detail-view/budget-detail-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/budget/budget-detail-view/budget-detail-view.component.ts
@@ -21,13 +21,13 @@ import { filter, switchMap } from 'rxjs';
 import { AppStore } from '@rero/shared';
 import { AcqBudgetApiService } from '../../../api/acq-budget-api.service';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { CurrencyPipe } from '@angular/common';
 import { MessageModule } from 'primeng/message';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 
 @Component({
     selector: 'admin-budget-detail-view',
     templateUrl: './budget-detail-view.component.html',
-    imports: [TranslateDirective, CurrencyPipe, TranslatePipe, MessageModule],
+    imports: [TranslateDirective, CentsCurrencyPipe, TranslatePipe, MessageModule],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BudgetDetailViewComponent {

--- a/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.html
+++ b/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.html
@@ -72,6 +72,6 @@
       'text-warning': account.remaining_balance.self < 0
     }"
   >
-    {{ account.remaining_balance.self | currency : defaultCurrency() }}
+    {{ account.remaining_balance.self | centsCurrency : defaultCurrency() }}
   </span>
 </ng-template>

--- a/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.ts
+++ b/projects/admin/src/app/acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component.ts
@@ -25,14 +25,15 @@ import { MessageService } from 'primeng/api';
 import { AcqAccountApiService } from '../../../../api/acq-account-api.service';
 import { orderAccountsAsTree } from '../../../../utils/account';
 import { FormsModule } from '@angular/forms';
-import { NgTemplateOutlet, CurrencyPipe } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../pipes/cents-currency.pipe';
 import { SelectModule } from 'primeng/select';
 
 @Component({
     selector: 'admin-select-account-editor-widget',
     templateUrl: './select-account-editor-widget.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, NgTemplateOutlet, CurrencyPipe, TranslatePipe, SelectModule]
+    imports: [FormsModule, NgTemplateOutlet, CentsCurrencyPipe, TranslatePipe, SelectModule]
 })
 export class SelectAccountEditorWidgetComponent extends FieldType implements OnInit {
   // services

--- a/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.html
@@ -48,7 +48,7 @@
       @if (displayProvisionalAccountingData) {
         <div class="ui:flex">
           <span class="ui:w-8/12 ui:text-center ui:border-surface ui:border ui:p-2 ui:bg-surface-100 ui:rounded-l ui:font-bold">
-            {{ order.account_statement.provisional.total_amount | currency : order.currency }}
+            {{ order.account_statement.provisional.total_amount | centsCurrency : order.currency }}
           </span>
           <span class="ui:w-4/12 ui:text-center ui:border-surface ui:border ui:p-2 ui:bg-surface-100 ui:rounded-r ui:text-muted-color ui:text-right">
             <i class="fa fa-shopping-cart"></i>&nbsp;{{ order.account_statement.provisional.quantity }}
@@ -58,7 +58,7 @@
       @if (displayExpenditureAccountingData) {
         <div class="ui:flex">
           <span class="ui:w-8/12 ui:text-center ui:border-surface ui:border ui:p-2 ui:bg-surface-100 ui:rounded-l ui:font-bold">
-            {{ order.account_statement.expenditure.total_amount | currency : order.currency }}
+            {{ order.account_statement.expenditure.total_amount | centsCurrency : order.currency }}
           </span>
           <span class="ui:w-4/12 ui:text-center ui:border-surface ui:border ui:p-2 ui:bg-surface-100 ui:rounded-r ui:text-muted-color ui:text-right">
             <i class="fa fa-sign-in"></i>&nbsp;{{ order.account_statement.expenditure.quantity }}

--- a/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
@@ -20,7 +20,8 @@ import { Component, input, OnInit, ChangeDetectionStrategy} from '@angular/core'
 import { AcqNoteType } from '../../../classes/common';
 import { AcqOrderStatus, IAcqOrder, orderDefaultData } from '../../../classes/order';
 import { RouterLink } from '@angular/router';
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { DateTranslatePipe, GetRecordPipe, Nl2brPipe, TruncateTextPipe } from '@rero/ng-core';
 import { NotesFilterPipe } from '@rero/shared';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -28,7 +29,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 @Component({
     selector: 'admin-acquisition-order-brief-view',
     templateUrl: './order-brief-view.component.html',
-    imports: [RouterLink, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, Nl2brPipe, NotesFilterPipe, TruncateTextPipe, TranslatePipe],
+    imports: [RouterLink, AsyncPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, Nl2brPipe, NotesFilterPipe, TruncateTextPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrderBriefViewComponent implements OnInit {

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
@@ -77,11 +77,11 @@
         </div>
       </div>
       <div class="ui:col-span-2 ui:flex ui:items-end ui:gap-2 ui:flex-col ui:border-x ui:border-surface ui:py-2 ui:px-2">
-        <div class="ui:text-xl ui:font-bold">{{ orderLine().total_amount | currency:order().currency:'symbol' }}</div>
+        <div class="ui:text-xl ui:font-bold">{{ orderLine().total_amount | centsCurrency:order().currency:'symbol' }}</div>
         <div class=" ui:text-muted-color ui:text-sm">
-          {{ orderLine().quantity}} x {{ orderLine().amount | currency:order().currency:'symbol' }}
+          {{ orderLine().quantity}} x {{ orderLine().amount | centsCurrency:order().currency:'symbol' }}
           @if (orderLine().discount_amount > 0) {
-            - {{ orderLine().discount_amount | currency:order().currency:'symbol' }}
+            - {{ orderLine().discount_amount | centsCurrency:order().currency:'symbol' }}
           }
         </div>
       </div>

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
@@ -26,6 +26,7 @@ import { AcqOrderApiService } from '../../../../api/acq-order-api.service';
 import { AcqOrderLineStatus, IAcqOrderLine } from '../../../../classes/order';
 import { AppStore, OpenCloseButtonComponent, DocumentBriefViewComponent, ActionButtonComponent } from '@rero/shared';
 import { NgClass, CurrencyPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../pipes/cents-currency.pipe';
 import { Bind } from 'primeng/bind';
 import { OverlayBadge } from 'primeng/overlaybadge';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
@@ -36,7 +37,7 @@ import { NoteBadgeColorPipe } from '../../../../pipes/note-badge-color.pipe';
 @Component({
     selector: 'admin-order-line',
     templateUrl: './order-line.component.html',
-    imports: [OpenCloseButtonComponent, NgClass, DocumentBriefViewComponent, Bind, OverlayBadge, TranslateDirective, NotesComponent, ActionButtonComponent, RouterLink, CurrencyPipe, TranslatePipe, NoteBadgeColorPipe],
+    imports: [OpenCloseButtonComponent, NgClass, DocumentBriefViewComponent, Bind, OverlayBadge, TranslateDirective, NotesComponent, ActionButtonComponent, RouterLink, CurrencyPipe, CentsCurrencyPipe, TranslatePipe, NoteBadgeColorPipe],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrderLineComponent {

--- a/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.html
@@ -78,7 +78,7 @@
     </div>
     <div class="ui:flex ui:flex-wrap ui:text-center">
       <div class="ui:w-full ui:text-2xl ui:font-bold">
-        {{ total | currency : order().currency : "symbol" }}
+        {{ total | centsCurrency : order().currency : "symbol" }}
       </div>
       <div class="ui:w-full ui:text-sm ui:text-muted-color">{{ label }}</div>
     </div>

--- a/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.ts
@@ -23,13 +23,14 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { RouterLink } from '@angular/router';
 import { Bind } from 'primeng/bind';
 import { Tag } from 'primeng/tag';
-import { NgTemplateOutlet, AsyncPipe, CurrencyPipe } from '@angular/common';
+import { NgTemplateOutlet, AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { DateTranslatePipe, GetRecordPipe } from '@rero/ng-core';
 
 @Component({
     selector: 'admin-order-summary',
     templateUrl: './order-summary.component.html',
-    imports: [TranslateDirective, RouterLink, Bind, Tag, NgTemplateOutlet, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe],
+    imports: [TranslateDirective, RouterLink, Bind, Tag, NgTemplateOutlet, AsyncPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrderSummaryComponent {

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.html
@@ -32,7 +32,7 @@
   <div class="ui:col-span-3 ui:flex ui:flex-col ui:gap-2 ui:items-end">
     <div class="ui:font-bold">{{ line() | receiptLineTotalAmount | currency:receipt().currency:'symbol' }}</div>
     <div class="ui:text-sm ui:text-muted-color">
-      {{ line().quantity }} x {{ line().amount | currency:receipt().currency:'symbol' }}
+      {{ line().quantity }} x {{ line().amount | centsCurrency:receipt().currency:'symbol' }}
       @if (line().vat_rate) {
       + {{ line().vat_rate }}%
       }

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-line/receipt-line.component.ts
@@ -28,6 +28,7 @@ import { AppStore, DocumentBriefViewComponent, ActionButtonComponent } from '@re
 import { RouterLink } from '@angular/router';
 import { AsyncPipe, CurrencyPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { ReceiptLineTotalAmountPipe } from '../../../pipes/receipt-line-total-amount.pipe';
 
 @Component({
@@ -39,6 +40,7 @@ import { ReceiptLineTotalAmountPipe } from '../../../pipes/receipt-line-total-am
         RouterLink,
         AsyncPipe,
         CurrencyPipe,
+        CentsCurrencyPipe,
         GetRecordPipe,
         TranslatePipe,
         ReceiptLineTotalAmountPipe,

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
@@ -51,7 +51,7 @@
           }
         </div>
         <div class="ui:col-span-3 ui:flex ui:font-bold ui:justify-end ui:items-center" [class.ui:border-right-1]="recordPermissions() && allowActions()">
-          {{ receipt().total_amount | currency:receipt().currency:'symbol' }}
+          {{ receipt().total_amount | centsCurrency:receipt().currency:'symbol' }}
         </div>
         <!-- ACTION BUTTON COLUMN -->
         @if (recordPermissions() && allowActions()) {
@@ -91,7 +91,7 @@
             </div>
             <div class="ui:col-span-3 ui:flex-col ui:font-bold ui:flex ui:items-end">
               <div>
-                {{ adjustment.amount | currency:receipt().currency:'symbol' }}
+                {{ adjustment.amount | centsCurrency:receipt().currency:'symbol' }}
               </div>
             </div>
           }

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.ts
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.ts
@@ -32,13 +32,14 @@ import { ReceiptLineComponent } from '../receipt-line/receipt-line.component';
 import { NotesComponent } from '../../notes/notes.component';
 import { CurrencyPipe, I18nPluralPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
+import { CentsCurrencyPipe } from '../../../pipes/cents-currency.pipe';
 import { NoteBadgeColorPipe } from '../../../pipes/note-badge-color.pipe';
 import { ReceptionDatesPipe } from '../../../pipes/reception-dates.pipe';
 
 @Component({
     selector: 'admin-receipt-summary',
     templateUrl: './receipt-summary.component.html',
-    imports: [OpenCloseButtonComponent, Bind, Tag, ActionButtonComponent, RouterLink, ReceiptLineComponent, NotesComponent, CurrencyPipe, I18nPluralPipe, TranslatePipe, NoteBadgeColorPipe, ReceptionDatesPipe],
+    imports: [OpenCloseButtonComponent, Bind, Tag, ActionButtonComponent, RouterLink, ReceiptLineComponent, NotesComponent, CurrencyPipe, CentsCurrencyPipe, I18nPluralPipe, TranslatePipe, NoteBadgeColorPipe, ReceptionDatesPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ReceiptSummaryComponent {

--- a/projects/admin/src/app/acquisition/pipes/account-available-amount.pipe.ts
+++ b/projects/admin/src/app/acquisition/pipes/account-available-amount.pipe.ts
@@ -28,7 +28,7 @@ export class AccountAvailableAmountPipe implements PipeTransform {
    * @returns the available amount
    */
   transform(account: IAcqAccount): number {
-    return account.allocated_amount - account.distribution;
+    return (account.allocated_amount - account.distribution) / 100;
   }
 
 }

--- a/projects/admin/src/app/acquisition/pipes/cents-currency.pipe.ts
+++ b/projects/admin/src/app/acquisition/pipes/cents-currency.pipe.ts
@@ -1,0 +1,37 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2021-2026 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CurrencyPipe } from '@angular/common';
+import { inject, Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'centsCurrency' })
+export class CentsCurrencyPipe implements PipeTransform {
+
+  private currencyPipe: CurrencyPipe = inject(CurrencyPipe);
+
+  /**
+   * Format a cents integer as a currency string.
+   * @param amount - the amount in cents (integer).
+   * @param currencyCode - ISO 4217 currency code.
+   * @param display - currency display format (default 'symbol').
+   * @returns the formatted currency string.
+   */
+  transform(amount: number, currencyCode: string, display: string = 'symbol'): string | null {
+    return this.currencyPipe.transform(amount / 100, currencyCode, display);
+  }
+
+}

--- a/projects/admin/src/app/acquisition/pipes/receipt-line-total-amount.pipe.ts
+++ b/projects/admin/src/app/acquisition/pipes/receipt-line-total-amount.pipe.ts
@@ -29,7 +29,7 @@ export class ReceiptLineTotalAmountPipe implements PipeTransform {
    */
   transform(receiptLine: IAcqReceiptLine): number {
     const vatRate = (receiptLine.vat_rate !== undefined) ? 1 + receiptLine.vat_rate / 100 : 1;
-    return receiptLine.quantity * receiptLine.amount * vatRate;
+    return receiptLine.quantity * (receiptLine.amount / 100) * vatRate;
   }
 
 }

--- a/projects/admin/src/app/circulation/item/item.component.html
+++ b/projects/admin/src/app/circulation/item/item.component.html
@@ -123,7 +123,7 @@
             }
             @if (isCollapsed() && totalAmountOfFee() > 0) {
               <p-tag [title]="'Fees'|translate" severity="warn" class="ui:mr-1">
-                {{ totalAmountOfFee() | currency: organisation.default_currency }}
+                {{ totalAmountOfFee() | centsCurrency: organisation.default_currency }}
               </p-tag>
             }
             @if (isCollapsed() && item().pending_loans && item().pending_loans.length) {
@@ -235,7 +235,7 @@
             <dt translate>Fees</dt>
             <dd>
               <p-tag severity="warn" class="ui:mr-1">
-                {{ totalAmountOfFee() | currency: organisation.default_currency }}
+                {{ totalAmountOfFee() | centsCurrency: organisation.default_currency }}
               </p-tag>
             </dd>
           }

--- a/projects/admin/src/app/circulation/item/item.component.ts
+++ b/projects/admin/src/app/circulation/item/item.component.ts
@@ -27,7 +27,8 @@ import { AppStore, ItemStatus, OpenCloseButtonComponent, InheritedCallNumberComp
 import { map } from 'rxjs/operators';
 import { CirculationStore } from '../store/circulation.store';
 import { computeTotalTransactionsAmount } from '../utils/transaction.utils';
-import { NgClass, AsyncPipe, JsonPipe, CurrencyPipe } from '@angular/common';
+import { NgClass, AsyncPipe, JsonPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../acquisition/pipes/cents-currency.pipe';
 import { RouterLink } from '@angular/router';
 import { Bind } from 'primeng/bind';
 import { Tag } from 'primeng/tag';
@@ -39,7 +40,7 @@ import { GetLoanCipoPipe } from '../pipe/get-loan-cipo.pipe';
 @Component({
     selector: 'admin-item',
     templateUrl: './item.component.html',
-    imports: [NgClass, OpenCloseButtonComponent, RouterLink, InheritedCallNumberComponent, Bind, Tag, ContributionComponent, ButtonDirective, TranslateDirective, Button, ScrollPanel, AsyncPipe, JsonPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, IdAttributePipe, MainTitlePipe, TruncateTextPipe, TranslatePipe, GetLoanCipoPipe],
+    imports: [NgClass, OpenCloseButtonComponent, RouterLink, InheritedCallNumberComponent, Bind, Tag, ContributionComponent, ButtonDirective, TranslateDirective, Button, ScrollPanel, AsyncPipe, JsonPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, IdAttributePipe, MainTitlePipe, TruncateTextPipe, TranslatePipe, GetLoanCipoPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ItemComponent {

--- a/projects/admin/src/app/circulation/patron/main/main.component.html
+++ b/projects/admin/src/app/circulation/patron/main/main.component.html
@@ -30,7 +30,7 @@
             @if (item.withCurrency) {
               <p-badge
                 [severity]="item.severity || 'info'"
-                [value]="$any(store.statistics())[item.id] | currency: appStore.organisation().default_currency"
+                [value]="$any(store.statistics())[item.id] | centsCurrency: appStore.organisation().default_currency"
               />
             } @else {
               <p-badge [severity]="item.severity || 'info'" [value]="$any(store.statistics())[item.id]" />

--- a/projects/admin/src/app/circulation/patron/main/main.component.ts
+++ b/projects/admin/src/app/circulation/patron/main/main.component.ts
@@ -27,13 +27,13 @@ import { CardComponent } from '../card/card.component';
 import { Bind } from 'primeng/bind';
 import { Tabs, TabList, Tab } from 'primeng/tabs';
 import { Ripple } from 'primeng/ripple';
-import { CurrencyPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 import { BadgeModule } from 'primeng/badge';
 
 @Component({
     selector: 'admin-main',
     templateUrl: './main.component.html',
-    imports: [CardComponent, Bind, Tabs, TabList, Ripple, Tab, RouterLink, RouterOutlet, CurrencyPipe, TranslatePipe, BadgeModule],
+    imports: [CardComponent, Bind, Tabs, TabList, Ripple, Tab, RouterLink, RouterOutlet, CentsCurrencyPipe, TranslatePipe, BadgeModule],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MainComponent {

--- a/projects/admin/src/app/circulation/patron/patron-transactions/overdue-transaction/overdue-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/overdue-transaction/overdue-transaction.component.html
@@ -30,7 +30,7 @@
           }
         }
       </div>
-      <div class="ui:col-span-2 ui:flex ui:justify-end">{{ transaction().fees.total | currency: organisation.default_currency }}</div>
+      <div class="ui:col-span-2 ui:flex ui:justify-end">{{ transaction().fees.total | centsCurrency: organisation.default_currency }}</div>
     </div>
     @if (!isCollapsed()) {
       <div class="ui:mt-2">

--- a/projects/admin/src/app/circulation/patron/patron-transactions/overdue-transaction/overdue-transaction.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/overdue-transaction/overdue-transaction.component.ts
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../acquisition/pipes/cents-currency.pipe';
 import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
@@ -32,7 +33,7 @@ import { PatronTransactionHistoryComponent } from '../patron-transaction/patron-
 @Component({
   selector: 'admin-overdue-transaction',
   templateUrl: './overdue-transaction.component.html',
-  imports: [OpenCloseButtonComponent, RouterLink, TranslateDirective, InheritedCallNumberComponent, PatronTransactionHistoryComponent, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, MainTitlePipe, TruncateTextPipe],
+  imports: [OpenCloseButtonComponent, RouterLink, TranslateDirective, InheritedCallNumberComponent, PatronTransactionHistoryComponent, AsyncPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, MainTitlePipe, TruncateTextPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OverdueTransactionComponent {

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.html
@@ -34,7 +34,7 @@
           </div>
           <div class="ui:grid ui:grid-cols-12 ui:gap-4">
             <span class="ui:col-span-4" translate>Total amount</span>
-            <span class="ui:col-span-8">{{ transaction.total_amount | currency: organisation.default_currency }}</span>
+            <span class="ui:col-span-8">{{ transaction.total_amount | centsCurrency: organisation.default_currency }}</span>
           </div>
         </div>
       </p-panel>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
@@ -27,14 +27,14 @@ import { Bind } from 'primeng/bind';
 import { Panel } from 'primeng/panel';
 import { ScrollPanel } from 'primeng/scrollpanel';
 import { Button } from 'primeng/button';
-import { CurrencyPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../acquisition/pipes/cents-currency.pipe';
 import { DateTranslatePipe } from '@rero/ng-core';
 
 
 @Component({
     selector: 'admin-patron-transaction-form',
     templateUrl: './patron-transaction-event-form.component.html',
-    imports: [FormsModule, ReactiveFormsModule, FormlyModule, Bind, ScrollPanel, TranslateDirective, Button, CurrencyPipe, DateTranslatePipe, TranslatePipe, Panel],
+    imports: [FormsModule, ReactiveFormsModule, FormlyModule, Bind, ScrollPanel, TranslateDirective, Button, CentsCurrencyPipe, DateTranslatePipe, TranslatePipe, Panel],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTransactionEventFormComponent implements OnInit {

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction-history/patron-transaction-history.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction-history/patron-transaction-history.component.html
@@ -33,7 +33,7 @@
         <div>{{ eventLabel(event) }}</div>
           @if (event.type !== patronTransactionEventType.DISPUTE) {
             <p-tag
-              [value]="event.amount | currency: organisation.default_currency"
+              [value]="event.amount | centsCurrency: organisation.default_currency"
               [severity]="$any(tagSeverity(event))"
             />
           }
@@ -102,7 +102,7 @@
               <div class="ui:col-span-2">
                 @if (event.type !== patronTransactionEventType.DISPUTE) {
                   <p-tag
-                    [value]="step.amount | currency: organisation.default_currency"
+                    [value]="step.amount | centsCurrency: organisation.default_currency"
                     [severity]="$any(tagSeverity(event))"
                   />
                 }

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction-history/patron-transaction-history.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction-history/patron-transaction-history.component.ts
@@ -20,14 +20,15 @@ import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { AppStore } from '@rero/shared';
 import { Bind } from 'primeng/bind';
 import { Timeline } from 'primeng/timeline';
-import { NgClass, AsyncPipe, CurrencyPipe } from '@angular/common';
+import { NgClass, AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../../acquisition/pipes/cents-currency.pipe';
 import { Tag } from 'primeng/tag';
 import { DateTranslatePipe, GetRecordPipe } from '@rero/ng-core';
 
 @Component({
     selector: 'admin-patron-transaction-history',
     templateUrl: './patron-transaction-history.component.html',
-    imports: [Bind, Timeline, NgClass, Tag, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe],
+    imports: [Bind, Timeline, NgClass, Tag, AsyncPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTransactionHistoryComponent {

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span>{{ t.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}</span>
         }
       </div>
-      <div class="ui:col-span-2 ui:flex ui:justify-end">{{ transactionAmount() | currency: organisation.default_currency }}</div>
+      <div class="ui:col-span-2 ui:flex ui:justify-end">{{ transactionAmount() | centsCurrency: organisation.default_currency }}</div>
       <div class="ui:col-span-2 ui:flex ui:justify-end">
         @if (t.status === patronTransactionStatus.OPEN) {
           <p-select

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.ts
@@ -28,6 +28,7 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { MenuItem } from 'primeng/api';
 import { CurrencyPipe, NgClass, AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../acquisition/pipes/cents-currency.pipe';
 import { SelectChangeEvent } from 'primeng/select';
 import { AppStore, OpenCloseButtonComponent } from '@rero/shared';
 import { FormsModule } from '@angular/forms';
@@ -40,7 +41,7 @@ import { Select } from 'primeng/select';
 @Component({
   selector: 'admin-patron-transaction',
   templateUrl: './patron-transaction.component.html',
-  imports: [NgClass, OpenCloseButtonComponent, FormsModule, TranslateDirective, OverdueTransactionDetailComponent, DefaultTransactionDetailComponent, PatronTransactionHistoryComponent, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe, Select],
+  imports: [NgClass, OpenCloseButtonComponent, FormsModule, TranslateDirective, OverdueTransactionDetailComponent, DefaultTransactionDetailComponent, PatronTransactionHistoryComponent, AsyncPipe, CurrencyPipe, CentsCurrencyPipe, DateTranslatePipe, GetRecordPipe, TranslatePipe, Select],
   providers: [CurrencyPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -70,7 +71,7 @@ export class PatronTransactionComponent {
       {
         label: [
           this.translateService.instant('Pay'),
-          this.currencyPipe.transform(t.total_amount, this.appStore.organisation()?.default_currency)
+          this.currencyPipe.transform(t.total_amount / 100, this.appStore.organisation()?.default_currency)
         ].join(' '),
         command: () => this.patronTransactionAction('pay', 'full')
       },

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
@@ -22,7 +22,7 @@
           <h6 class="ui:flex ui:grow" translate>Engaged fees</h6>
           @if (statistics()['feesEngaged'] > 0) {
             <p-tag severity="warn" class="ui:mr-2">
-              {{ statistics()['feesEngaged'] | currency: organisation.default_currency }}
+              {{ statistics()['feesEngaged'] | centsCurrency: organisation.default_currency }}
             </p-tag>
           }
         </div>
@@ -37,7 +37,7 @@
             <div class="ui:col-span-3" translate>Category</div>
             <div class="ui:col-span-3" translate>Library</div>
             <div class="ui:col-span-2 ui:text-right">
-              {{ 'Total amount' | translate }}: {{ statistics()['feesEngaged'] | currency: organisation.default_currency }}
+              {{ 'Total amount' | translate }}: {{ statistics()['feesEngaged'] | centsCurrency: organisation.default_currency }}
             </div>
             <div class="ui:col-span-2 ui:flex ui:justify-end">
               <p-splitButton
@@ -70,7 +70,7 @@
           <h6 class="ui:flex ui:grow" translate>Overdue preview fees</h6>
           @if (statistics().overdueFees > 0) {
             <p-tag severity="secondary" class="ui:mr-2">
-              {{ statistics().overdueFees| currency: organisation.default_currency }}
+              {{ statistics().overdueFees| centsCurrency: organisation.default_currency }}
             </p-tag>
           }
         </div>
@@ -81,7 +81,7 @@
             <div class="ui:col-span-2" translate>Due date</div>
             <div class="ui:col-span-8" translate>Document</div>
             <div class="ui:col-span-2 ui:text-right">
-              {{ 'Total amount' | translate }}: {{ statistics().overdueFees | currency: organisation.default_currency }}
+              {{ 'Total amount' | translate }}: {{ statistics().overdueFees | centsCurrency: organisation.default_currency }}
             </div>
             <div class="ui:col-span-1"></div>
           </div>

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.ts
@@ -34,12 +34,12 @@ import { Button } from 'primeng/button';
 import { SplitButton } from 'primeng/splitbutton';
 import { PatronTransactionComponent } from './patron-transaction/patron-transaction.component';
 import { OverdueTransactionComponent } from './overdue-transaction/overdue-transaction.component';
-import { CurrencyPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 
 @Component({
     selector: 'admin-patron-transactions',
     templateUrl: './patron-transactions.component.html',
-    imports: [Bind, Accordion, AccordionPanel, Ripple, AccordionHeader, TranslateDirective, Tag, AccordionContent, Button, SplitButton, PatronTransactionComponent, OverdueTransactionComponent, CurrencyPipe, TranslatePipe],
+    imports: [Bind, Accordion, AccordionPanel, Ripple, AccordionHeader, TranslateDirective, Tag, AccordionContent, Button, SplitButton, PatronTransactionComponent, OverdueTransactionComponent, CentsCurrencyPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTransactionsComponent {

--- a/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-events-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-events-brief-view.component.html
@@ -31,7 +31,7 @@
     <div>
       <p-tag [severity]="$any(severity())">
         @if (event().type !== eventTypes.DISPUTE) {
-          {{ event().amount | currency : organisation()?.default_currency }}
+          {{ event().amount | centsCurrency : organisation()?.default_currency }}
         } @else {
           {{ 'dispute' | translate }}
         }

--- a/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-events-brief-view.component.ts
+++ b/projects/admin/src/app/record/brief-view/patron-transaction-events-brief-view/patron-transaction-events-brief-view.component.ts
@@ -25,13 +25,14 @@ import { PatronTransactionEventOverdueComponent } from './patron-transaction-eve
 import { PatronTransactionEventDefaultComponent } from './patron-transaction-event-default.component';
 import { Bind } from 'primeng/bind';
 import { Tag } from 'primeng/tag';
-import { CurrencyPipe, DatePipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
     selector: 'admin-patron-transaction-events-brief-view',
     templateUrl: './patron-transaction-events-brief-view.component.html',
-    imports: [PatronTransactionEventOverdueComponent, PatronTransactionEventDefaultComponent, Bind, Tag, CurrencyPipe, DatePipe, TranslatePipe],
+    imports: [PatronTransactionEventOverdueComponent, PatronTransactionEventDefaultComponent, Bind, Tag, CentsCurrencyPipe, DatePipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTransactionEventsBriefViewComponent implements OnInit {

--- a/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.html
@@ -132,7 +132,7 @@
                 <td>{{ reminder.communication_channel | translate }}</td>
                 <td>
                   @if (reminder.fee_amount) {
-                    {{ reminder.fee_amount | currency: org_currency() }}
+                    {{ reminder.fee_amount | centsCurrency: org_currency() }}
                   } @else {
                     &mdash;
                   }
@@ -167,7 +167,7 @@
                   }
                 </td>
                 <td>
-                  {{ overdue.fee_amount | currency: org_currency() }} / {{ 'day' | translate }}
+                  {{ overdue.fee_amount | centsCurrency: org_currency() }} / {{ 'day' | translate }}
                 </td>
               </tr>
             </ng-template>

--- a/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/circ-policy-detail-view/circ-policy-detail-view.component.ts
@@ -21,13 +21,14 @@ import { AppStore } from '@rero/shared';
 import { Bind } from 'primeng/bind';
 import { Panel } from 'primeng/panel';
 import { TableModule } from 'primeng/table';
-import { NgClass, AsyncPipe, CurrencyPipe, I18nPluralPipe, KeyValuePipe } from '@angular/common';
+import { NgClass, AsyncPipe, I18nPluralPipe, KeyValuePipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 import { GetRecordPipe } from '@rero/ng-core';
 
 @Component({
     selector: 'admin-circ-policy-detail-view',
     templateUrl: './circ-policy-detail-view.component.html',
-    imports: [TranslateDirective, Bind, Panel, TableModule, NgClass, AsyncPipe, CurrencyPipe, I18nPluralPipe, KeyValuePipe, TranslatePipe, GetRecordPipe],
+    imports: [TranslateDirective, Bind, Panel, TableModule, NgClass, AsyncPipe, CentsCurrencyPipe, I18nPluralPipe, KeyValuePipe, TranslatePipe, GetRecordPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CircPolicyDetailViewComponent {

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -125,7 +125,7 @@
       <!-- PRICE -->
       @if (record()?.metadata | keyExists:'price') {
         <dt translate>Price</dt>
-        <dd>{{ record()?.metadata.price | currency:organisationCurrency:'symbol' }}</dd>
+        <dd>{{ record()?.metadata.price | centsCurrency:organisationCurrency:'symbol' }}</dd>
       }
       <!-- PAC CODE -->
       @if (record()?.metadata | keyExists:'pac_code') {

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.ts
@@ -20,7 +20,8 @@ import { ItemApiService } from '@app/admin/api/item-api.service';
 import { IssueService } from '@app/admin/service/issue.service';
 import { DateTranslatePipe, GetRecordPipe, Nl2brPipe, RecordService } from '@rero/ng-core';
 
-import { AsyncPipe, CurrencyPipe, JsonPipe, NgClass, NgPlural, NgPluralCase } from '@angular/common';
+import { AsyncPipe, JsonPipe, NgClass, NgPlural, NgPluralCase } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 import { RouterLink } from '@angular/router';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { AppStore, AvailabilityComponent, InheritedCallNumberComponent, IPermissions, IssueItemStatus, ItemHoldingsCallNumberPipe, KeyExistsPipe, MainTitlePipe, OperationLogsService, PERMISSION_OPERATOR, PERMISSIONS, PermissionsDirective, SafeUrlPipe } from '@rero/shared';
@@ -45,7 +46,7 @@ import { ItemTransactionsComponent } from './item-transactions/item-transactions
     templateUrl: './item-detail-view.component.html',
     providers: [IssueService],
     styles: ['dl * { margin-bottom: 0; }'],
-    imports: [Bind, Button, RouterLink, RecordMaskedComponent, TranslateDirective, InheritedCallNumberComponent, AvailabilityComponent, NgClass, Tooltip, Tabs, TabList, Ripple, Tab, NgPlural, NgPluralCase, TabPanels, TabPanel, CirculationLogsDialogComponent, ItemTransactionsComponent, ItemFeesComponent, PermissionsDirective, LocalFieldComponent, AsyncPipe, JsonPipe, CurrencyPipe, TranslatePipe, DateTranslatePipe, GetRecordPipe, ItemHoldingsCallNumberPipe, KeyExistsPipe, MainTitlePipe, Nl2brPipe, SafeUrlPipe, ItemInCollectionPipe, Badge],
+    imports: [Bind, Button, RouterLink, RecordMaskedComponent, TranslateDirective, InheritedCallNumberComponent, AvailabilityComponent, NgClass, Tooltip, Tabs, TabList, Ripple, Tab, NgPlural, NgPluralCase, TabPanels, TabPanel, CirculationLogsDialogComponent, ItemTransactionsComponent, ItemFeesComponent, PermissionsDirective, LocalFieldComponent, AsyncPipe, JsonPipe, CentsCurrencyPipe, TranslatePipe, DateTranslatePipe, GetRecordPipe, ItemHoldingsCallNumberPipe, KeyExistsPipe, MainTitlePipe, Nl2brPipe, SafeUrlPipe, ItemInCollectionPipe, Badge],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ItemDetailViewComponent {

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-fees/item-fees.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-fees/item-fees.component.html
@@ -23,7 +23,7 @@
       </div>
       <div class="ui:order-2">
         <span class="ui:font-bold" translate>Total</span>&nbsp;
-        <p-tag severity="danger">{{ total() | currency: organisation.default_currency }}</p-tag>
+        <p-tag severity="danger">{{ total() | centsCurrency: organisation.default_currency }}</p-tag>
       </div>
     </div>
   </ng-template>
@@ -41,7 +41,7 @@
                 {{ $any(patron).metadata.last_name }} {{ $any(patron).metadata.first_name }} ({{ $any(patron).metadata.patron.barcode[0] }})
               </a>
             </div>
-            <div>{{ fee.metadata.total_amount | currency: organisation.default_currency }}</div>
+            <div>{{ fee.metadata.total_amount | centsCurrency: organisation.default_currency }}</div>
           </div>
         }
       }

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-fees/item-fees.component.ts
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-fees/item-fees.component.ts
@@ -23,14 +23,15 @@ import { Panel } from 'primeng/panel';
 import { TranslateDirective } from '@ngx-translate/core';
 import { Tag } from 'primeng/tag';
 import { RouterLink } from '@angular/router';
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../acquisition/pipes/cents-currency.pipe';
 import { GetRecordPipe } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
 
 @Component({
     selector: 'admin-item-fees',
     templateUrl: './item-fees.component.html',
-    imports: [Bind, Panel, TranslateDirective, Tag, RouterLink, AsyncPipe, CurrencyPipe, GetRecordPipe],
+    imports: [Bind, Panel, TranslateDirective, Tag, RouterLink, AsyncPipe, CentsCurrencyPipe, GetRecordPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ItemFeesComponent {

--- a/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.html
@@ -38,7 +38,7 @@
     <!-- SUBSCRIPTION AMOUNT -->
     @if (record.metadata.subscription_amount) {
       <dt translate>Subscription amount</dt>
-      <dd>{{ record.metadata.subscription_amount | currency: organisation.default_currency }}</dd>
+      <dd>{{ record.metadata.subscription_amount | centsCurrency: organisation.default_currency }}</dd>
     }
   </dl>
     <!-- Limits -->
@@ -136,7 +136,7 @@
           @if (record.metadata.limits.fee_amount_limits) {
             <dl class="metadata ui:ml-7 ui:mb-4">
               <dt translate>Limit</dt>
-              <dd>{{ record.metadata.limits.fee_amount_limits.default_value | currency: organisation.default_currency }}</dd>
+              <dd>{{ record.metadata.limits.fee_amount_limits.default_value | centsCurrency: organisation.default_currency }}</dd>
             </dl>
           }
         </p-panel>

--- a/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/patron-types-detail-view/patron-types-detail-view.component.ts
@@ -17,7 +17,8 @@
 import { Component, inject, input, ChangeDetectionStrategy} from '@angular/core';
 import { TranslateDirective } from '@ngx-translate/core';
 import { AppStore } from '@rero/shared';
-import { NgClass, AsyncPipe, CurrencyPipe } from '@angular/common';
+import { NgClass, AsyncPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../acquisition/pipes/cents-currency.pipe';
 import { Bind } from 'primeng/bind';
 import { Panel } from 'primeng/panel';
 import { GetRecordPipe } from '@rero/ng-core';
@@ -25,7 +26,7 @@ import { GetRecordPipe } from '@rero/ng-core';
 @Component({
     selector: 'admin-patron-types-detail-view',
     templateUrl: './patron-types-detail-view.component.html',
-    imports: [TranslateDirective, NgClass, Bind, Panel, AsyncPipe, CurrencyPipe, GetRecordPipe],
+    imports: [TranslateDirective, NgClass, Bind, Panel, AsyncPipe, CentsCurrencyPipe, GetRecordPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTypesDetailViewComponent {

--- a/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/table/payments-data-table.component.html
+++ b/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/table/payments-data-table.component.html
@@ -21,14 +21,14 @@
     <li>
       <div class="ui:flex">
         <span class="ui:grow">{{ subtype.name | translate }}</span>
-        <span>{{ subtype.total | currency: org_currency: 'symbol' }}</span>
+        <span>{{ subtype.total | centsCurrency: org_currency: 'symbol' }}</span>
       </div>
     </li>
   }
     <p-divider></p-divider>
   <li class="ui:flex ui:font-bold">
     <span class="ui:grow" translate>Total</span>
-    <span>{{ data()?.total | currency: org_currency: 'symbol' }}</span>
+    <span>{{ data()?.total | centsCurrency: org_currency: 'symbol' }}</span>
   </li>
 </ul>
 

--- a/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/table/payments-data-table.component.ts
+++ b/projects/admin/src/app/record/search-view/patron-transaction-event-search-view/payments-data/table/payments-data-table.component.ts
@@ -21,12 +21,12 @@ import { AppStore } from '@rero/shared';
 import { Bind } from 'primeng/bind';
 import { Divider } from 'primeng/divider';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { CurrencyPipe } from '@angular/common';
+import { CentsCurrencyPipe } from '../../../../../acquisition/pipes/cents-currency.pipe';
 
 @Component({
     selector: 'admin-payments-data-table',
     templateUrl: './payments-data-table.component.html',
-    imports: [Bind, Divider, TranslateDirective, CurrencyPipe, TranslatePipe],
+    imports: [Bind, Divider, TranslateDirective, CentsCurrencyPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PaymentsDataTableComponent {


### PR DESCRIPTION
* Adds `CentsCurrencyPipe` that divides a cents integer by 100 and delegates formatting to Angular's `CurrencyPipe`.
* Migrates acquisition components (account, budget, order, receipt) to use the new pipe instead of inline division.
* Migrates circulation components (item, patron transactions) to use the new pipe.
* Migrates record views (circ-policy, item fees, patron types, patron transaction events, payments) to use the new pipe.