### PR TITLE
feat(library): migrate library editor and detail view to NgRx Signal Store

### DIFF
--- a/.ai/angular-patterns.md
+++ b/.ai/angular-patterns.md
@@ -2,12 +2,11 @@
 
 ## Standalone component pattern
 
-New components must be standalone with OnPush change detection.
+Components, directives and pipes are standalone by default since Angular 19. Do not add `standalone: true` explicitly — it is redundant.
 
 Example:
 
 @Component({
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, TranslatePipe]
 })
@@ -97,7 +96,6 @@ export const CounterStore = signalStore(
 Usage in component:
 
 @Component({
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CounterComponent {

--- a/.ai/angular-rules.md
+++ b/.ai/angular-rules.md
@@ -2,17 +2,22 @@
 
 Framework version: Angular 21
 
+## TypeScript style rules
+
+- Always use dot notation (`obj.prop`) over bracket notation (`obj['prop']`).
+- Avoid `Record<string, any>` — use a proper typed interface or type alias instead.
+
 ## Migration rules
 
 This project is migrating incrementally to Angular 21 patterns:
 
-- New components must be standalone.
+- New components are standalone by default (Angular 19+) — do not add `standalone: true` explicitly.
 - Existing NgModules are not removed unless explicitly refactored.
 - New code must not introduce new NgModules.
 
 ## Core rules
 
-- New components must be standalone.
+- Components, directives and pipes are standalone by default since Angular 19 — omit `standalone: true`.
 - Prefer Angular Signals for local state in new components.
 - Avoid RxJS when Signals are sufficient for new code.
 - Use strict TypeScript typing.
@@ -31,7 +36,6 @@ This project is migrating incrementally to Angular 21 patterns:
 Example:
 
 @Component({
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
@@ -108,3 +112,20 @@ When adding a new cross-project alias, declare it in the root `tsconfig.json` un
 - Avoid the use of `any`.
 - Prefer explicit types.
 - Keep functions small and testable.
+
+## Import order
+
+Always keep imports sorted alphabetically by module path when adding new imports. No grouping required — sort all imports as a single flat list.
+
+Example:
+
+```typescript
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TranslatePipe } from '@ngx-translate/core';
+import { RecordService } from '@rero/ng-core';
+import { Button } from 'primeng/button';
+import { take } from 'rxjs/operators';
+import { LibraryFormService } from './library-form.service';
+import { LibraryStore } from './library.store';
+```

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-history/order-history.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-history/order-history.component.ts
@@ -23,7 +23,6 @@ import { OrderDetailStore } from '../store/order-detail.store';
 @Component({
   selector: 'admin-order-history',
   templateUrl: './order-history.component.html',
-  standalone: true,
   imports: [Timeline, RouterLink],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.html
+++ b/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<form [formGroup]="exceptionForm" (ngSubmit)="onSubmit()" style="max-width: 50vw;">
+<form [formGroup]="formService.form" (ngSubmit)="onSubmit()" style="max-width: 50vw;">
   <!-- Title -->
   <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:flex">
     <label for="title" class="ui:col-span-2">
@@ -27,22 +27,22 @@
         formControlName="title"
         [placeholder]="'Please insert a title' | translate"
       />
-      @if (title.invalid && (title.dirty || title.touched)) {
+      @if (formService.form.get('title')!.invalid && (formService.form.get('title')!.dirty || formService.form.get('title')!.touched)) {
         <div class="text-error">
-          @if (title.errors.required) {
+          @if (formService.form.get('title')!.errors?.required) {
             <div translate>Title is required.</div>
           }
         </div>
       }
     </div>
     <div class="ui:col-span-10 ui:col-start-3">
-      <input type="radio" name="day" value="false" [checked]="is_period.value === false" (change)="onPeriodChange($event)" />
+      <input type="radio" name="day" value="false" [checked]="formService.form.get('is_period')!.value === false" (change)="onPeriodChange($event)" />
       &nbsp;{{ 'Day' | translate }}
-      <input type="radio" name="period" value="true" [checked]="is_period.value === true" (change)="onPeriodChange($event)" />
+      <input type="radio" name="period" value="true" [checked]="formService.form.get('is_period')!.value === true" (change)="onPeriodChange($event)" />
       &nbsp;{{ 'Period' | translate }}
     </div>
 
-    @if (!is_period.value) {
+    @if (!formService.form.get('is_period')!.value) {
       <label for="date" class="ui:col-span-2">
         {{ 'Date' | translate }}&nbsp;*
       </label>
@@ -56,12 +56,12 @@
           [readonlyInput]="false"
           [showIcon]="true"
         />
-        @if (date.invalid && (date.dirty || date.touched)) {
+        @if (formService.form.get('date')!.invalid && (formService.form.get('date')!.dirty || formService.form.get('date')!.touched)) {
           <div class="text-error">
-            @if (date.errors.required) {
+            @if (formService.form.get('date')!.errors?.required) {
               <div translate>Date is required.</div>
             }
-            @if (date.errors.bsDate && date.errors.bsDate.invalid) {
+            @if (formService.form.get('date')!.errors?.bsDate && formService.form.get('date')!.errors?.bsDate.invalid) {
               <div translate>Date is invalid.</div>
             }
           </div>
@@ -69,7 +69,7 @@
       </div>
     }
 
-    @if (is_period.value) {
+    @if (formService.form.get('is_period')!.value) {
       <label for="date" class="ui:col-span-2">
         {{ 'Dates' | translate }}&nbsp;*
       </label>
@@ -85,12 +85,12 @@
           [numberOfMonths]="2"
           [showIcon]="true"
         />
-        @if (dates.invalid && (dates.dirty || dates.touched)) {
+        @if (formService.form.get('dates')!.invalid && (formService.form.get('dates')!.dirty || formService.form.get('dates')!.touched)) {
           <div class="text-error">
-            @if (dates.errors.required) {
+            @if (formService.form.get('dates')!.errors?.required) {
               <div translate>Date range is required.</div>
             }
-            @if (dates.errors.bsDate && dates.errors.bsDate.invalid) {
+            @if (formService.form.get('dates')!.errors?.bsDate && formService.form.get('dates')!.errors?.bsDate.invalid) {
               <div translate>Date range is invalid.</div>
             }
           </div>
@@ -99,14 +99,14 @@
     }
 
     <div class="ui:col-span-10 ui:col-start-3">
-      <input type="radio" name="date-status" value="false" [checked]="is_open.value === false" (change)="onDateStatusChange($event)" />
+      <input type="radio" name="date-status" value="false" [checked]="formService.form.get('is_open')!.value === false" (change)="onDateStatusChange($event)" />
       &nbsp;{{ 'Closed' | translate }}
-      <input type="radio" name="date-status" value="true" [checked]="is_open.value === true" (change)="onDateStatusChange($event)"/>
+      <input type="radio" name="date-status" value="true" [checked]="formService.form.get('is_open')!.value === true" (change)="onDateStatusChange($event)"/>
       &nbsp;{{ 'Open' | translate }}
-      @if (exceptionForm.value && exceptionForm.value.is_open) {
+      @if (formService.form.value && formService.form.value.is_open) {
         <em class="ui:block ui:mt-2" translate>Change the default opening hours for this day</em>
       }
-      @if (exceptionForm.value && !exceptionForm.value.is_open) {
+      @if (formService.form.value && !formService.form.value.is_open) {
         <em class="ui:block ui:mt-2" translate>Change the default closing hours for this day</em>
       }
     </div>
@@ -182,9 +182,9 @@
           </li>
         }
       </ul>
-      @if (exceptionForm.invalid  && (exceptionForm.dirty || exceptionForm.touched)) {
+      @if (formService.form.invalid  && (formService.form.dirty || formService.form.touched)) {
         <div class="text-error">
-          @if (exceptionForm.errors && exceptionForm.errors.rangeLessThan) {
+          @if (formService.form.errors && formService.form.errors.rangeLessThan) {
             <div translate>The two periods are overlapping.</div>
           }
         </div>
@@ -199,7 +199,7 @@
       />
       {{ 'Repetition' | translate | titlecase }}
     </div>
-    @if (repeat.value) {
+    @if (formService.form.get('repeat')!.value) {
       <div class="ui:col-span-10 ui:flex ui:gap-2 ui:items-center">
         <label for="interval"><span translate>Repeat each</span>&nbsp;*</label>
         <div class="ui:flex ui:gap-2">
@@ -210,15 +210,15 @@
             formControlName="period"
           />
         </div>
-        @if (interval.invalid && (interval.dirty || interval.touched)) {
+        @if (formService.form.get('interval')!.invalid && (formService.form.get('interval')!.dirty || formService.form.get('interval')!.touched)) {
           <div class="text-error">
-            @if (interval.errors.required) {
+            @if (formService.form.get('interval')!.errors?.required) {
               <div translate>Interval is required.</div>
             }
-            @if (interval.errors.min) {
+            @if (formService.form.get('interval')!.errors?.min) {
               <div translate>Interval must greater than 0.</div>
             }
-            @if (interval.errors.pattern && !interval.errors.min) {
+            @if (formService.form.get('interval')!.errors?.pattern && !formService.form.get('interval')!.errors?.min) {
               <div translate>Integer only.</div>
             }
           </div>
@@ -228,6 +228,6 @@
   </div>
   <div class="ui:flex ui:gap-1 ui:justify-end ui:mt-3">
     <p-button [label]="'Cancel'|translate" [outlined]="true" severity="danger" (onClick)="cancel()" />
-    <p-button type="submit" [label]="'Save'|translate" (onClick)="onSubmit()" [disabled]="exceptionForm.invalid" />
+    <p-button type="submit" [label]="'Save'|translate" (onClick)="onSubmit()" [disabled]="formService.form.invalid" />
   </div>
 </form>

--- a/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/exception-dates-edit/exception-dates-edit.component.ts
@@ -14,19 +14,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy} from '@angular/core';
-import { UntypedFormArray, UntypedFormGroup, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { LibraryExceptionFormService } from '../library-exception-form.service';
-import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { Bind } from 'primeng/bind';
-import { InputText } from 'primeng/inputtext';
-import { Button } from 'primeng/button';
-import { ToggleSwitch } from 'primeng/toggleswitch';
-import { InputNumber } from 'primeng/inputnumber';
-import { Select } from 'primeng/select';
 import { TitleCasePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule, ReactiveFormsModule, UntypedFormArray, Validators } from '@angular/forms';
+import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { Bind } from 'primeng/bind';
+import { Button } from 'primeng/button';
 import { DatePicker } from 'primeng/datepicker';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputNumber } from 'primeng/inputnumber';
+import { InputText } from 'primeng/inputtext';
+import { Select } from 'primeng/select';
+import { ToggleSwitch } from 'primeng/toggleswitch';
+import { LibraryExceptionFormService } from '../library-exception-form.service';
 
 @Component({
     selector: 'admin-libraries-exception-dates-edit',
@@ -38,34 +38,29 @@ export class ExceptionDatesEditComponent implements OnInit, OnDestroy {
 
   private dynamicDialogConfig: DynamicDialogConfig = inject(DynamicDialogConfig);
   private dynamicDialogRef: DynamicDialogRef = inject(DynamicDialogRef);
-  private form: LibraryExceptionFormService = inject(LibraryExceptionFormService);
+  protected formService: LibraryExceptionFormService = inject(LibraryExceptionFormService);
   private translateService: TranslateService = inject(TranslateService);
 
-  public exceptionForm: UntypedFormGroup;
-
-  periods: any[];
+  periods: { label: string; value: string }[] = [
+    {
+      label: this.translateService.instant('week'),
+      value: 'weekly'
+    },
+    {
+      label: this.translateService.instant('month'),
+      value: 'monthly'
+    },
+    {
+      label: this.translateService.instant('year'),
+      value: 'yearly'
+    }
+  ];
 
   ngOnInit() {
-    this.form.build();
-    this.exceptionForm = this.form.form;
     const { exceptionDate } = this.dynamicDialogConfig.data;
     if (exceptionDate) {
-      this.form.populate(exceptionDate);
+      this.formService.populate(exceptionDate);
     }
-    this.periods = [
-      {
-        label: this.translateService.instant('week'),
-        value: 'weekly'
-      },
-      {
-        label: this.translateService.instant('month'),
-        value: 'monthly'
-      },
-      {
-        label: this.translateService.instant('year'),
-        value: 'yearly'
-      }
-    ];
   }
 
   ngOnDestroy(): void {
@@ -73,63 +68,52 @@ export class ExceptionDatesEditComponent implements OnInit, OnDestroy {
   }
 
   onSubmit(): void {
-    this.dynamicDialogRef.close(this.form.getValue());
+    this.dynamicDialogRef.close(this.formService.getValue());
   }
 
   cancel(): void {
     this.dynamicDialogRef.close();
   }
 
-  onPeriodChange(event): void {
-    const { target } = event;
+  get times(): UntypedFormArray {
+    return this.formService.form.get('times') as UntypedFormArray;
+  }
+
+  onPeriodChange(event: Event): void {
+    const target = event.target as HTMLInputElement;
     const value = target.value === 'true';
-    this.form.is_period.setValue(value);
+    this.formService.form.get('is_period')!.setValue(value);
     if (value) {
-      for (let i = 0; i < this.form.times.length; i++) {
-        this.form.times.removeAt(i);
-      }
-      this.form.is_open.setValue(false);
+      this.times.clear();
+      this.formService.form.get('is_open')!.setValue(false);
     }
   }
 
-  onDateStatusChange(event): void {
-    const { target } = event;
+  onDateStatusChange(event: Event): void {
+    const target = event.target as HTMLInputElement;
     const value = target.value === 'true';
-    this.form.is_open.setValue(value);
+    this.formService.form.get('is_open')!.setValue(value);
   }
 
-  onRepeatChange(repeat): void {
-    if (repeat) {
-      this.form.interval.setValue(1);
-      this.form.interval.setValidators([
-        Validators.required,
-        Validators.min(1),
-        Validators.pattern('^[0-9]*$')
-      ]);
-      this.form.period.setValue('yearly');
+  onRepeatChange(event: { checked: boolean }): void {
+    const interval = this.formService.form.get('interval')!;
+    const period = this.formService.form.get('period')!;
+    if (event.checked) {
+      interval.setValue(1);
+      interval.setValidators([Validators.required, Validators.min(1), Validators.pattern('^[0-9]*$')]);
+      period.setValue('yearly');
     } else {
-      this.form.interval.clearValidators();
-      this.form.interval.setValue(null);
-      this.form.period.setValue(null);
+      interval.clearValidators();
+      interval.setValue(null);
+      period.setValue(null);
     }
   }
 
   addTime(): void {
-    this.form.times.push(this.form.buildTimes());
+    this.times.push(this.formService.buildTimes());
   }
 
-  deleteTime(timeIndex): void {
-    this.form.times.removeAt(timeIndex);
+  deleteTime(timeIndex: number): void {
+    this.times.removeAt(timeIndex);
   }
-
-  get title() { return this.form.title; }
-  get is_period() { return this.form.is_period; }
-  get is_open() { return this.form.is_open; }
-  get date() { return this.form.date; }
-  get dates() { return this.form.dates; }
-  get times() { return this.form.times as UntypedFormArray; }
-  get repeat() { return this.form.repeat; }
-  get interval() { return this.form.interval; }
-  get period() { return this.form.period; }
-  get data() { return this.data as UntypedFormArray; }
 }

--- a/projects/admin/src/app/record/custom-editor/libraries/exception-dates-list/exception-dates-list.component.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/exception-dates-list/exception-dates-list.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019-2024 RERO
+ * Copyright (C) 2019-2026 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -14,15 +14,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, DestroyRef, inject, input, ChangeDetectionStrategy} from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { ExceptionDates, Library } from '@app/admin/classes/library';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { ExceptionDatesEditComponent } from '../exception-dates-edit/exception-dates-edit.component';
-import { TranslateService, TranslatePipe } from '@ngx-translate/core';
-import { ExceptionDateComponent } from '../../../detail-view/library-detail-view/exception-date/exception-date.component';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { Bind } from 'primeng/bind';
 import { Button } from 'primeng/button';
+import { DialogService } from 'primeng/dynamicdialog';
+import { take } from 'rxjs/operators';
+import { ExceptionDateComponent } from '../../../detail-view/library-detail-view/exception-date/exception-date.component';
+import { ExceptionDatesEditComponent } from '../exception-dates-edit/exception-dates-edit.component';
+import { LibraryStore } from '../library.store';
 
 @Component({
     selector: 'admin-libraries-exception-dates-list',
@@ -34,14 +35,12 @@ export class ExceptionDatesListComponent {
 
   private dialogService: DialogService = inject(DialogService);
   private translateService: TranslateService = inject(TranslateService);
+  private readonly libraryStore = inject(LibraryStore);
 
-  private readonly destroyRef = inject(DestroyRef);
-  private dynamicDialogRef: DynamicDialogRef | undefined;
-
-  exceptionDates = input([]);
+  exceptionDates = input<ExceptionDates[]>([]);
 
   editException(index: number): void {
-    this.dynamicDialogRef = this.dialogService.open(ExceptionDatesEditComponent, {
+    const ref = this.dialogService.open(ExceptionDatesEditComponent, {
       header: this.translateService.instant('Exception'),
       modal: true,
       width: '50vw',
@@ -50,15 +49,15 @@ export class ExceptionDatesListComponent {
         exceptionDate: this.exceptionDates()[index]
       }
     });
-    this.dynamicDialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value?: any) => {
+    ref?.onClose.pipe(take(1)).subscribe((value?: ExceptionDates) => {
       if (value) {
-        this.exceptionDates()[index] = value;
+        this.libraryStore.updateExceptionDate(index, value);
       }
     });
   }
 
   deleteException(index: number): void {
-    this.exceptionDates().splice(index, 1);
+    this.libraryStore.deleteExceptionDate(index);
   }
 
   isOver(exception: ExceptionDates): boolean {

--- a/projects/admin/src/app/record/custom-editor/libraries/library-exception-form.service.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library-exception-form.service.ts
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { inject, Injectable } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators} from '@angular/forms';
+import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup, Validators} from '@angular/forms';
 import { TimeValidator } from '@rero/ng-core';
+import { ExceptionDates } from '@app/admin/classes/library';
 import { DateTime } from 'luxon';
 
 
@@ -27,7 +28,7 @@ export class LibraryExceptionFormService {
 
   private fb: UntypedFormBuilder = inject(UntypedFormBuilder);
 
-  public form;
+  public form!: UntypedFormGroup;
 
   constructor() {
     this.build();
@@ -83,30 +84,27 @@ export class LibraryExceptionFormService {
     });
   }
 
-  populate(exception) {
-    this.title.setValue(exception.title);
-    if ('end_date' in exception) {
-      this.is_period.setValue(true);
-      this.dates.setValue([
-        DateTime.fromISO(exception.start_date).toJSDate(),
-        DateTime.fromISO(exception.end_date).toJSDate(),
+  populate(exception: ExceptionDates): void {
+    this.form.get('title')!.setValue(exception.title);
+    if (exception.end_date) {
+      this.form.get('is_period')!.setValue(true);
+      this.form.get('dates')!.setValue([
+        DateTime.fromISO(exception.start_date as string).toJSDate(),
+        DateTime.fromISO(exception.end_date as string).toJSDate(),
       ]);
     } else {
-      this.date.setValue(DateTime.fromISO(exception.start_date).toJSDate());
+      this.form.get('date')!.setValue(DateTime.fromISO(exception.start_date as string).toJSDate());
     }
-    this.is_open.setValue(exception.is_open);
-    if ('times' in exception) {
-      exception.times.forEach(
-        time => {
-          this.times.push(this.buildTimes(time.start_time, time.end_time));
-        }
-      );
+    this.form.get('is_open')!.setValue(exception.is_open);
+    if (exception.times) {
+      exception.times.forEach(time => {
+        (this.form.get('times') as UntypedFormArray).push(this.buildTimes(time.start_time, time.end_time));
+      });
     }
-    if ('repeat' in exception) {
-      this.repeat.setValue(true);
-      this.period.setValue(exception.repeat.period);
-      this.interval.setValue(exception.repeat.interval);
-      // this.data.setValue(exception.repeat.data)
+    if (exception.repeat) {
+      this.form.get('repeat')!.setValue(true);
+      this.form.get('period')!.setValue(exception.repeat.period);
+      this.form.get('interval')!.setValue(exception.repeat.interval);
     }
   }
 
@@ -114,7 +112,7 @@ export class LibraryExceptionFormService {
     return this.formatDateException(this.form.value);
   }
 
-  formatDateException(data) {
+  formatDateException(data: Record<string, any>): Record<string, any> {
     const dataException: any = {
       title: data.title,
       is_open: data.is_open
@@ -136,15 +134,4 @@ export class LibraryExceptionFormService {
     }
     return dataException;
   }
-
-  get title() { return this.form.get('title'); }
-  get is_period() { return this.form.get('is_period'); }
-  get is_open() { return this.form.get('is_open'); }
-  get date() { return this.form.get('date'); }
-  get dates() { return this.form.get('dates'); }
-  get times() { return this.form.get('times'); }
-  get repeat() { return this.form.get('repeat'); }
-  get interval() { return this.form.get('interval'); }
-  get period() { return this.form.get('period'); }
-  get data() { return this.form.get('data'); }
 }

--- a/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library-form.service.ts
@@ -15,50 +15,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { AbstractControl, UntypedFormArray, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
-import { RecordService, TimeValidator } from '@rero/ng-core';
-import { forkJoin, Observable } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
-import { AcquisitionInformations, Library, RolloverSettings } from '../../../classes/library';
+import { TimeValidator } from '@rero/ng-core';
+import { AcquisitionInformationDetail, AcquisitionInformations, Library, NotificationSettings, OpeningHours, RolloverSettings } from '../../../classes/library';
 import { NotificationType } from '../../../classes/notification';
 import { WeekDays } from '../../../classes/week-days';
 
-@Injectable({
-   providedIn: 'root'
-})
+@Injectable()
 export class LibraryFormService {
 
   private fb: UntypedFormBuilder = inject(UntypedFormBuilder);
-  private recordService: RecordService = inject(RecordService);
 
   // SERVICE ATTRIBUTES =======================================================
   /** Angular form group */
-  public form;
+  public form!: UntypedFormGroup;
 
-  /** RERO-ILS notification types */
-  private notificationTypes: NotificationType[] = [];
-  /** RERO-ILS communication languages */
-  private readonly _availableCommunicationLanguages = signal<string[]>([]);
-  /** RERO-ILS countries */
-  private readonly _countryList = signal<string[]>([]);
-  /** Rollover account transfer */
-  private readonly _rolloverAccountTransferOptions = signal<string[]>([]);
+  /** RERO-ILS notification types — set by the store before calling build() */
+  notificationTypes: NotificationType[] = [];
+
   /** Default account transfer */
   private readonly accountDefaultTransferOption = 'rollover_no_transfer';
 
   // GETTER & SETTER ==========================================================
-  get name(): AbstractControl { return this.form.get('name'); }
-  get address(): AbstractControl { return this.form.get('address'); }
-  get email(): AbstractControl { return this.form.get('email'); }
-  get code(): AbstractControl { return this.form.get('code'); }
+  get name(): AbstractControl { return this.form.get('name')!; }
+  get address(): AbstractControl { return this.form.get('address')!; }
+  get email(): AbstractControl { return this.form.get('email')!; }
+  get code(): AbstractControl { return this.form.get('code')!; }
   get opening_hours(): UntypedFormArray { return this.form.get('opening_hours') as UntypedFormArray; }
   get notification_settings(): UntypedFormArray { return this.form.get('notification_settings') as UntypedFormArray; }
-  get communication_language(): AbstractControl { return this.form.get('communication_language'); }
-  get available_communication_languages() { return this._availableCommunicationLanguages(); }
-  get countries_iso_codes() { return this._countryList(); }
-  get rollover_settings(): AbstractControl { return this.form.get('rollover_settings'); }
-  get account_transfer_options() { return this._rolloverAccountTransferOptions(); }
+  get communication_language(): AbstractControl { return this.form.get('communication_language')!; }
+  get rollover_settings(): AbstractControl { return this.form.get('rollover_settings')!; }
 
   // SERVICE FUNCTIONS ========================================================
   /** Build the form structure */
@@ -89,42 +76,6 @@ export class LibraryFormService {
   }
 
   /**
-   * Create the form and load default available values.
-   * Returns an Observable that emits once when the form is ready.
-   */
-  create(): Observable<boolean> {
-    const notificationSchema$ = this.recordService.getSchemaForm('notifications');
-    const librarySchema$ = this.recordService.getSchemaForm('libraries');
-    return forkJoin([librarySchema$, notificationSchema$]).pipe(
-      tap(([libSchema, notifSchema]) => {
-        this._availableCommunicationLanguages.set(
-          (libSchema as any).schema.properties.communication_language.enum
-        );
-        this._countryList.set(
-          (libSchema as any).schema.properties.acquisition_settings.properties.shipping_informations
-            .properties.address.properties.country.enum
-        );
-        this._rolloverAccountTransferOptions.set(
-          (libSchema as any).schema.properties.rollover_settings.properties.account_transfer.enum
-        );
-        // DEV NOTES :: Why remove `acquisition_order` an `claim_issue`
-        //   `this.notificationTypes` is used to build the notification setting form ;
-        //   but we need to remove `acquisition_order` and `claim_issue` from this list because the email
-        //   used to send this kind of notification is selected by manager when it confirms
-        //   and order. Then the email used is either :
-        //      - related vendor email
-        //      - library (serial) acquisition setting email
-        //      - custom email
-        this.notificationTypes = ((notifSchema as any).schema.properties.notification_type.enum as NotificationType[])
-          .filter(type => type !== NotificationType.ACQUISITION_ORDER)
-          .filter(type => type !== NotificationType.CLAIM_ISSUE);
-        this.build();
-      }),
-      map(() => true)
-    );
-  }
-
-  /**
    * Populate the form
    * @param library - The library metadata
    */
@@ -137,9 +88,9 @@ export class LibraryFormService {
       communication_language: library.communication_language
     });
     this._setOpeningHours(library.opening_hours);
-    this._setNotificationSettings(library.notification_settings);
-    this._setAcquisitionSettings('acquisition_settings', library.acquisition_settings);
-    this._setAcquisitionSettings('serial_acquisition_settings', library.serial_acquisition_settings);
+    this._setNotificationSettings(library.notification_settings ?? []);
+    this._setAcquisitionSettings('acquisition_settings', library.acquisition_settings ?? null);
+    this._setAcquisitionSettings('serial_acquisition_settings', library.serial_acquisition_settings ?? null);
     this._setRolloverSettings(library.rollover_settings);
   }
 
@@ -171,9 +122,9 @@ export class LibraryFormService {
    * Build and set default values for opening hours at form initialization
    * @param openingHours - opening hours
    */
-  private _initializeOpeningHours(openingHours = []) {
+  private _initializeOpeningHours(openingHours: OpeningHours[] = []) {
     const days = Object.keys(WeekDays);
-    const hours = this.form.get('opening_hours');
+    const hours = this.form.get('opening_hours') as UntypedFormArray;
     for (let step = 0; step < 7; step++) {
       hours.push(this._buildOpeningHours(false, days[step], this.fb.array([])));
     }
@@ -184,15 +135,15 @@ export class LibraryFormService {
    * Set opening hours from record data
    * @param openingHours - opening hours
    */
-  private _setOpeningHours(openingHours = []) {
+  private _setOpeningHours(openingHours: OpeningHours[] = []) {
     for (let step = 0; step < 7; step++) {
       const atimes = this._getTimesByDayIndex(step);
       const day = openingHours[step];
       if (day !== undefined) {
         if (day.times.length > 0) {
           atimes.removeAt(0);
-          const hours = this.form.get('opening_hours').get(String(step));
-          hours.get('is_open').setValue(day.is_open);
+          const hours = this.form.get('opening_hours')!.get(String(step))!;
+          hours.get('is_open')!.setValue(day.is_open);
           day.times.forEach(time => atimes.push(this._buildTimes(time.start_time, time.end_time)));
         }
       } else {
@@ -207,7 +158,7 @@ export class LibraryFormService {
    * @param day - day
    * @param times - times array
    */
-  private _buildOpeningHours(isOpen: boolean, day, times): UntypedFormGroup {
+  private _buildOpeningHours(isOpen: boolean, day: string, times: UntypedFormArray): UntypedFormGroup {
     return this.fb.group({
       is_open: [isOpen],
       day: [day],
@@ -247,9 +198,9 @@ export class LibraryFormService {
    * @param dayIndex - the day index
    * @return: The corresponding FormArray (at least an empty array)
    */
-  private _getTimesByDayIndex(dayIndex): UntypedFormArray {
-    return this.form.get('opening_hours')
-      .get(String(dayIndex))
+  private _getTimesByDayIndex(dayIndex: number): UntypedFormArray {
+    return this.form.get('opening_hours')!
+      .get(String(dayIndex))!
       .get('times') as UntypedFormArray;
   }
 
@@ -279,7 +230,7 @@ export class LibraryFormService {
       const fieldNames = ['shipping_informations', 'billing_informations'];
       fieldNames.forEach((fieldName) => {
         if (Object.hasOwn(acquisitionSettings, fieldName)) {
-          this._setAcquisitionInformation(blockName, fieldName, acquisitionSettings[fieldName]);
+          this._setAcquisitionInformation(blockName, fieldName, (acquisitionSettings as Record<string, any>)[fieldName]);
         }
       });
     }
@@ -291,17 +242,17 @@ export class LibraryFormService {
    * @param key: the section of acquisition to fill in.
    * @param data: the acquisition information values from record related to the key.
    */
-  private _setAcquisitionInformation(blockName, key, data): void {
-    const formField = this.form.get(blockName).get(key);
-    formField.get('name').setValue(data.name);
-    formField.get('email').setValue(data.email);
-    formField.get('phone').setValue(data.phone);
-    formField.get('extra').setValue(data.extra);
+  private _setAcquisitionInformation(blockName: string, key: string, data: AcquisitionInformationDetail): void {
+    const formField = this.form.get(blockName)!.get(key)!;
+    formField.get('name')!.setValue(data.name);
+    formField.get('email')!.setValue(data.email);
+    formField.get('phone')!.setValue(data.phone);
+    formField.get('extra')!.setValue(data.extra);
     if (data.address) {
-      formField.get('address').get('street').setValue(data.address.street);
-      formField.get('address').get('zip_code').setValue(data.address.zip_code);
-      formField.get('address').get('city').setValue(data.address.city);
-      formField.get('address').get('country').setValue(data.address.country);
+      formField.get('address')!.get('street')!.setValue(data.address.street);
+      formField.get('address')!.get('zip_code')!.setValue(data.address.zip_code);
+      formField.get('address')!.get('city')!.setValue(data.address.city);
+      formField.get('address')!.get('country')!.setValue(data.address.country);
     }
   }
 
@@ -310,7 +261,7 @@ export class LibraryFormService {
    * @param notificationSettings  - notification settings
    */
   private _initializeNotificationSettings(notificationSettings = []) {
-    const settings = this.form.get('notification_settings');
+    const settings = this.form.get('notification_settings') as UntypedFormArray;
     this.notificationTypes.forEach(type => settings.push(this._buildSettingsByType(type)));
     this._setNotificationSettings(notificationSettings);
   }
@@ -334,16 +285,16 @@ export class LibraryFormService {
    * Set values from record
    * @param notificationSettings - notification settings
    */
-  private _setNotificationSettings(notificationSettings = []) {
+  private _setNotificationSettings(notificationSettings: NotificationSettings[] = []) {
     if (notificationSettings.length > 0) {
-      const formSettings = this.form.get('notification_settings');
+      const formSettings = this.form.get('notification_settings')!;
       for (let step = 0; step < formSettings.value.length; step++) {
-        const formSetting = formSettings.get(String(step));
-        const currentSetting = notificationSettings.find(element => element.type === formSetting.get('type').value);
+        const formSetting = formSettings.get(String(step))!;
+        const currentSetting = notificationSettings.find(element => element.type === formSetting.get('type')!.value);
         if (currentSetting !== undefined) {
-          formSetting.get('email').setValue(currentSetting.email);
+          formSetting.get('email')!.setValue(currentSetting.email);
           if (currentSetting.delay !== undefined) {
-            formSetting.get('delay').setValue(currentSetting.delay);
+            formSetting.get('delay')!.setValue(currentSetting.delay);
           }
         }
       }
@@ -355,7 +306,7 @@ export class LibraryFormService {
    * @param settings - rollover settings
    */
   private _setRolloverSettings(settings: RolloverSettings): void {
-    const rolloverSettings = this.form.get('rollover_settings');
-    rolloverSettings.get('account_transfer').setValue(settings.account_transfer);
+    const rolloverSettings = this.form.get('rollover_settings')!;
+    rolloverSettings.get('account_transfer')!.setValue(settings.account_transfer);
   }
 }

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.html
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.html
@@ -16,7 +16,7 @@
 -->
 @if (libForm()) {
 <h1 translate>Library</h1>
-<form [formGroup]="libForm()" (ngSubmit)="onSubmit()">
+<form [formGroup]="libForm()!" (ngSubmit)="onSubmit()">
   <p-accordion [value]="['0']" [multiple]="true">
     <!-- DESCRIPTIVE METADATA TAB ===================================== -->
     <p-accordion-panel value="0">
@@ -42,9 +42,9 @@
             />
             @if (code.invalid && (code.dirty || code.touched)) {
             <div class="text-error">
-              @if (code.errors.alreadyTaken) {
+              @if (code.errors?.alreadyTaken) {
               <span translate>Code is already taken.</span>
-              } @if (code.errors.required) {
+              } @if (code.errors?.required) {
               <span translate>Code is required.</span>
               } @if (code.pending) {
               <span translate>Validating…</span>
@@ -67,9 +67,9 @@
             />
             @if (name.invalid && (name.dirty || name.touched)) {
             <div class="text-error">
-              @if (name.errors.required) {
+              @if (name.errors?.required) {
               <span translate>Name is required.</span>
-              } @if (name.errors.minlength) {
+              } @if (name.errors?.minlength) {
               <span translate>Name must be at least 4 characters long.</span>
               }
             </div>
@@ -90,7 +90,7 @@
               />
               @if (address.invalid && (address.dirty || address.touched)) {
               <div class="text-error">
-                @if (address.errors.minlength) {
+                @if (address.errors?.minlength) {
                 <span translate>Address must be at least 4 characters long.</span>
                 }
               </div>
@@ -112,7 +112,7 @@
               />
               @if (email.invalid && (email.dirty || email.touched)) {
               <div class="text-error">
-                @if (email.errors.email) {
+                @if (email.errors?.email) {
                 <span translate>Email format is not correct.</span>
                 }
               </div>
@@ -132,7 +132,7 @@
             @if (communicationLanguage.invalid && (communicationLanguage.dirty ||
             communicationLanguage.touched)) {
             <div class="text-error">
-              @if (communicationLanguage.errors.required) {
+              @if (communicationLanguage.errors?.required) {
               <span translate>Communication language is required.</span>
               }
             </div>
@@ -231,16 +231,16 @@
                         @if (time.controls.start_time.invalid &&
                         (time.controls.start_time.dirty ||
                         time.controls.start_time.touched)) { @if
-                        (time.controls.start_time.errors.required) {
+                        (time.controls.start_time.errors?.required) {
                         <div translate>Start time is required.</div>
-                        } @if (time.controls.start_time.errors.pattern) {
+                        } @if (time.controls.start_time.errors?.pattern) {
                         <div translate>Start time format is not correct.</div>
                         } } @if (time.controls.end_time.invalid &&
                         (time.controls.end_time.dirty ||
                         time.controls.end_time.touched)) { @if
-                        (time.controls.end_time.errors.required) {
+                        (time.controls.end_time.errors?.required) {
                         <div translate>End time is required.</div>
-                        } @if (time.controls.end_time.errors.pattern) {
+                        } @if (time.controls.end_time.errors?.pattern) {
                         <div translate>End time format is not correct.</div>
                         } } @if (time.invalid && (time.dirty || time.touched)) {
                         @if (time.errors && time.errors.lessThan) {
@@ -383,8 +383,8 @@
               <ng-container
                 [ngTemplateOutlet]="contact_block"
                 [ngTemplateOutletContext]="{
-                  formGroup: libForm()
-                    .get('acquisition_settings')
+                  formGroup: libForm()!
+                    .get('acquisition_settings')!
                     .get('shipping_informations'),
                   icon: 'fa-truck',
                   name: 'Shipping informations' | translate,
@@ -394,8 +394,8 @@
               <ng-container
                 [ngTemplateOutlet]="contact_block"
                 [ngTemplateOutletContext]="{
-                  formGroup: libForm()
-                    .get('acquisition_settings')
+                  formGroup: libForm()!
+                    .get('acquisition_settings')!
                     .get('billing_informations'),
                   icon: 'fa-money',
                   name: 'Billing informations' | translate,
@@ -407,8 +407,8 @@
               <ng-container
                 [ngTemplateOutlet]="contact_block"
                 [ngTemplateOutletContext]="{
-                  formGroup: libForm()
-                    .get('serial_acquisition_settings')
+                  formGroup: libForm()!
+                    .get('serial_acquisition_settings')!
                     .get('shipping_informations'),
                   icon: 'fa-truck',
                   name: 'Shipping informations' | translate,
@@ -418,8 +418,8 @@
               <ng-container
                 [ngTemplateOutlet]="contact_block"
                 [ngTemplateOutletContext]="{
-                  formGroup: libForm()
-                    .get('serial_acquisition_settings')
+                  formGroup: libForm()!
+                    .get('serial_acquisition_settings')!
                     .get('billing_informations'),
                   icon: 'fa-money',
                   name: 'Billing informations' | translate,

--- a/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.component.ts
@@ -15,52 +15,54 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
-import { UntypedFormArray, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgClass, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { AsyncValidatorFn, FormsModule, ReactiveFormsModule, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CountryCodeTranslatePipe } from '@app/admin/pipe/country-code-translate.pipe';
-import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AbstractCanDeactivateComponent, ApiService, cleanDictKeys, CONFIG, RecordService, removeEmptyValues, UniqueValidator, UpperCaseFirstPipe } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
+import { Accordion, AccordionContent, AccordionHeader, AccordionPanel } from 'primeng/accordion';
 import { MessageService } from 'primeng/api';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { Subscription } from 'rxjs';
-import { ExceptionDates, Library } from '../../../classes/library';
-import { NotificationType } from '../../../classes/notification';
-import { ExceptionDatesEditComponent } from './exception-dates-edit/exception-dates-edit.component';
-import { LibraryFormService } from './library-form.service';
+import { Badge } from 'primeng/badge';
 import { Bind } from 'primeng/bind';
-import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from 'primeng/accordion';
-import { Ripple } from 'primeng/ripple';
-import { InputText } from 'primeng/inputtext';
+import { Button } from 'primeng/button';
+import { Divider } from 'primeng/divider';
+import { DialogService } from 'primeng/dynamicdialog';
+import { Fieldset } from 'primeng/fieldset';
 import { InputGroup } from 'primeng/inputgroup';
 import { InputGroupAddon } from 'primeng/inputgroupaddon';
-import { Select } from 'primeng/select';
-import { NgClass, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
-import { ToggleSwitch } from 'primeng/toggleswitch';
-import { Button } from 'primeng/button';
-import { ExceptionDatesListComponent } from './exception-dates-list/exception-dates-list.component';
 import { InputNumber } from 'primeng/inputnumber';
-import { Tooltip } from 'primeng/tooltip';
-import { Divider } from 'primeng/divider';
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from 'primeng/tabs';
-import { Fieldset } from 'primeng/fieldset';
+import { InputText } from 'primeng/inputtext';
+import { Ripple } from 'primeng/ripple';
+import { Select } from 'primeng/select';
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from 'primeng/tabs';
 import { Tag } from 'primeng/tag';
+import { ToggleSwitch } from 'primeng/toggleswitch';
+import { Tooltip } from 'primeng/tooltip';
+import { take } from 'rxjs/operators';
+import { ExceptionDates } from '../../../classes/library';
+import { NotificationType } from '../../../classes/notification';
+import { ExceptionDatesEditComponent } from './exception-dates-edit/exception-dates-edit.component';
+import { ExceptionDatesListComponent } from './exception-dates-list/exception-dates-list.component';
+import { LibraryFormService } from './library-form.service';
+import { LibraryStore } from './library.store';
 import { NotificationTypePipe } from './pipe/notificationType.pipe';
-import { Badge } from 'primeng/badge';
 
 type SelectOption = { value: string; label: string; disabled?: boolean };
 
 @Component({
     selector: 'admin-libraries-library',
     templateUrl: './library.component.html',
+    providers: [LibraryStore, LibraryFormService],
     imports: [TranslateDirective, FormsModule, ReactiveFormsModule, Bind, Accordion, AccordionPanel, Ripple, AccordionHeader, AccordionContent, InputText, InputGroup, InputGroupAddon, Select, NgClass, ToggleSwitch, Button, ExceptionDatesListComponent, InputNumber, Tooltip, Divider, Tabs, TabList, Tab, TabPanels, TabPanel, NgTemplateOutlet, Fieldset, Tag, TitleCasePipe, UpperCaseFirstPipe, TranslatePipe, NotificationTypePipe, Badge],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LibraryComponent extends AbstractCanDeactivateComponent implements OnInit, OnDestroy {
+export class LibraryComponent extends AbstractCanDeactivateComponent {
 
-  private recordService: RecordService = inject(RecordService);
   private libraryForm: LibraryFormService = inject(LibraryFormService);
+  protected readonly libraryStore = inject(LibraryStore);
   private route: ActivatedRoute = inject(ActivatedRoute);
   private router: Router = inject(Router);
   private appStore = inject(AppStore);
@@ -69,126 +71,120 @@ export class LibraryComponent extends AbstractCanDeactivateComponent implements 
   private countryCodeTranslatePipe: CountryCodeTranslatePipe = inject(CountryCodeTranslatePipe);
   private messageService: MessageService = inject(MessageService);
   private dialogService: DialogService = inject(DialogService);
-
-  private dynamicDialogRef: DynamicDialogRef | null = null;
+  private recordService: RecordService = inject(RecordService);
 
   // COMPONENT ATTRIBUTES =====================================================
-  /** The current library. */
-  readonly library = signal<Library | null>(null);
-  /** The angular form to edit the library. */
+  /** The angular form to edit the library — set once schemas + data are ready. */
   readonly libForm = signal<UntypedFormGroup | null>(null);
-  /** The current organisation pid. */
-  readonly organisationPid = signal('');
-  /** Exception dates (signal for reactivity with OnPush). */
-  readonly exceptionDates = signal<ExceptionDates[]>([]);
+
+  /** Translated options for dropdowns — derived from store data */
+  readonly rolloverAccountTransferOptions = computed<SelectOption[]>(() =>
+    this.libraryStore.rolloverAccountTransferOptions().map(option => ({
+      value: option,
+      label: this.translateService.instant(option),
+    }))
+  );
+
+  readonly availableCommunicationLanguagesOptions = computed<SelectOption[]>(() => {
+    const langs = this.libraryStore.availableCommunicationLanguages();
+    if (!langs.length) return [];
+    return [
+      { value: '', label: this.translateService.instant('Choose a language'), disabled: true },
+      ...langs.map(lang => ({ value: lang, label: this.translateService.instant(`lang_${lang}`), disabled: false })),
+    ];
+  });
+
+  readonly countryIsoCodesOptions = computed<SelectOption[]>(() =>
+    this.libraryStore.countryIsoCodes().map(code => ({
+      value: code,
+      label: this.countryCodeTranslatePipe.transform(code),
+    }))
+  );
 
   /** possible delayed notification types. */
   public delayedNotificationTypes = [NotificationType.AVAILABILITY];
 
-  /** options to use for dropdown list box of the editor */
-  readonly rolloverAccountTransferOptions = signal<SelectOption[]>([]);
-  readonly availableCommunicationLanguagesOptions = signal<SelectOption[]>([]);
-  readonly countryIsoCodesOptions = signal<SelectOption[]>([]);
-
   /** Can deactivate guard */
   public canDeactivate = false;
 
-  /** Form build event subscription to release the memory. */
-  private eventForm!: Subscription;
-
+  /** Expose store signals to template */
+  readonly exceptionDates = this.libraryStore.exceptionDates;
 
   // GETTER & SETTER ==========================================================
-  /** Name of the library. */
   get name() { return this.libraryForm.name; }
-  /** Address of the library. */
   get address() { return this.libraryForm.address; }
-  /** Contact email of the library. */
   get email() { return this.libraryForm.email; }
-  /** Code of the library. */
   get code() { return this.libraryForm.code; }
-  /** Communication language. */
   get communicationLanguage() { return this.libraryForm.communication_language; }
-  /** Country list */
-  get countries_iso_codes() { return this.libraryForm.countries_iso_codes; }
-  /** Hours when the library is open. */
   get openingHours() { return this.libraryForm.opening_hours as UntypedFormArray; }
-  /** Notification settings. */
   get notificationSettings() { return this.libraryForm.notification_settings as UntypedFormArray; }
-  /** Rollover settings */
   get rolloverSettings() { return this.libraryForm.rollover_settings as UntypedFormGroup; }
 
+  constructor() {
+    super();
 
-  /** NgOnInit hook. */
-  ngOnInit() {
-    this.route.params.subscribe( (params) => {
-      const loggedUser = this.appStore.user();
-      if (loggedUser) {
-        this.organisationPid.set(this.appStore.currentOrganisationPid());
+    // When schemas are loaded, build the form then load the record if editing.
+    effect(() => {
+      const notifTypes = this.libraryStore.notificationTypes();
+      if (!notifTypes.length) return;
+
+      this.libraryForm.notificationTypes = notifTypes;
+      this.libraryForm.build();
+
+      const { pid } = this.route.snapshot.params;
+      if (pid) {
+        this.libraryStore.loadLibrary(pid);
+      } else {
+        this.libraryStore.setNewLibrary();
+        this.libForm.set(this.libraryForm.form);
+        this.setAsyncValidator();
       }
-      this.eventForm = this.libraryForm.create().subscribe((_buildEvent: any) => {
-        if (params && params.pid) {
-          this.recordService.getRecord('libraries', params.pid).subscribe(record => {
-            const lib = new Library(record.metadata as any);
-            this.library.set(lib);
-            this.exceptionDates.set(lib.exception_dates ?? []);
-            this.libraryForm.populate(record.metadata as any);
-            this.libForm.set(this.libraryForm.form);
-            this.setAsyncValidator();
-          });
-        } else {
-          const lib = new Library({});
-          this.library.set(lib);
-          this.exceptionDates.set(lib.exception_dates ?? []);
-          this.libForm.set(this.libraryForm.form);
-          this.setAsyncValidator();
-        }
-        this._buildOptions();
-      });
+    });
+
+    // When the library is loaded from the store, populate the form.
+    effect(() => {
+      const lib = this.libraryStore.library();
+      if (!lib || !this.libraryForm.form) return;
+      this.libraryForm.populate(lib);
+      this.libForm.set(this.libraryForm.form);
+      this.setAsyncValidator();
     });
   }
 
   addException(): void {
-    this.dynamicDialogRef = this.dialogService.open(ExceptionDatesEditComponent, {
+    this.dialogService.open(ExceptionDatesEditComponent, {
       header: this.translateService.instant('Exception'),
       modal: true,
       width: '50vw',
       closable: false,
-      data: {
-        exceptionDate: null
-      }
-    });
-    this.dynamicDialogRef?.onClose.subscribe((value?: ExceptionDates) => {
+      data: { exceptionDate: null }
+    })?.onClose.pipe(take(1)).subscribe((value?: ExceptionDates) => {
       if (value) {
-        this.library()!.exception_dates.push(value);
-        this.exceptionDates.update(dates => [...dates, value]);
+        this.libraryStore.addExceptionDate(value);
       }
     });
-  }
-
-  /** NgOnDestroy hook. */
-  ngOnDestroy() {
-    this.eventForm.unsubscribe();
   }
 
   // COMPONENT FUNCTIONS ======================================================
-  /** Create the form async validators. */
   setAsyncValidator() {
-    this.libForm()!.controls.code.setAsyncValidators([
+    this.libForm()!.controls['code'].setAsyncValidators([
       UniqueValidator.createValidator(
         this.recordService,
         'libraries',
         'code',
-        this.library()!.pid
-      ) as any
+        this.libraryStore.library()?.pid ?? undefined
+      ) as AsyncValidatorFn
     ]);
   }
 
-  /** Form submission. */
   onSubmit() {
     this.canDeactivate = true;
-    const library = this.library()!;
-    this._cleanFormValues(this.libraryForm.getValues());
-    library.update(this.libraryForm.getValues());
+    const library = this.libraryStore.library()!;
+    const formValues = this.libraryForm.getValues();
+    this._cleanFormValues(formValues);
+    formValues.exception_dates = this.libraryStore.exceptionDates();
+    library.update(formValues);
+
     if (library.pid) {
       this.recordService
         .update('libraries', library.pid, cleanDictKeys(library as any))
@@ -209,9 +205,9 @@ export class LibraryComponent extends AbstractCanDeactivateComponent implements 
             sticky: true,
             closable: true
           })
-      });
+        });
     } else {
-      library.organisation = { $ref: this.apiService.getRefEndpoint('organisations', this.organisationPid()) };
+      library.organisation = { $ref: this.apiService.getRefEndpoint('organisations', this.appStore.currentOrganisationPid()) };
       this.recordService
         .create('libraries', cleanDictKeys(library as any))
         .subscribe({
@@ -231,82 +227,31 @@ export class LibraryComponent extends AbstractCanDeactivateComponent implements 
             sticky: true,
             closable: true
           })
-      });
+        });
     }
   }
 
-
-
-  /** Cancel the edition. */
   onCancel() {
     this.canDeactivate = true;
-    this.router.navigate(['/', 'records', 'libraries', 'detail', this.library()!.pid])
+    this.router.navigate(['/', 'records', 'libraries', 'detail', this.libraryStore.library()!.pid]);
   }
 
-  /**
-   * Add new opening hours for a specific day.
-   * @param dayIndex: the day index where to add a period time.
-   */
   addTime(dayIndex: number): void {
     this.libraryForm.addTime(dayIndex);
   }
 
-  /**
-   * Delete an existing opening hours.
-   * @param dayIndex: the day index where to delete.
-   * @param timeIndex: the time period index to delete.
-   */
   deleteTime(dayIndex: number, timeIndex: number): void {
     this.libraryForm.deleteTime(dayIndex, timeIndex);
   }
 
-
-  /**
-   * Clean form values before saving the library
-   * @param formValues: the form values to clean
-   */
   private _cleanFormValues(formValues: any): void {
-    // CLEAN OPENING HOURS : When day is defined as closed, remove all periods/times
     formValues.opening_hours.forEach((day: { is_open: boolean; times: unknown[] }) => {
       if (!day.is_open) {
         day.times = [];
       }
     });
-    // NOTIFICATIONS
     formValues.notification_settings = formValues.notification_settings.filter((element: { email: string }) => element.email !== '');
-    // ACQUISITION SETTINGS
     formValues.acquisition_settings = removeEmptyValues(formValues.acquisition_settings);
     formValues.serial_acquisition_settings = removeEmptyValues(formValues.serial_acquisition_settings);
-  }
-
-  private _buildOptions(): void {
-    // Build the options for rollover settings
-    this.rolloverAccountTransferOptions.set(
-      this.libraryForm.account_transfer_options.map(option => ({
-        value: option,
-        label: this.translateService.instant(option)
-      }))
-    );
-    // Build available communication languages
-    this.availableCommunicationLanguagesOptions.set(
-      [{
-        value: '',
-        label: this.translateService.instant('Choose a language'),
-        disabled: true
-      }].concat(
-        this.libraryForm.available_communication_languages.map(lang => ({
-          value: lang,
-          label: this.translateService.instant(`lang_${lang}`),
-          disabled: false
-        }))
-      )
-    );
-    // Country codes options
-    this.countryIsoCodesOptions.set(
-      this.libraryForm.countries_iso_codes.map(code => ({
-        value: code,
-        label: this.countryCodeTranslatePipe.transform(code)
-      }))
-    );
   }
 }

--- a/projects/admin/src/app/record/custom-editor/libraries/library.store.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.store.spec.ts
@@ -1,0 +1,447 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019-2025 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { TestBed } from '@angular/core/testing';
+import { RecordService } from '@rero/ng-core';
+import { of, throwError } from 'rxjs';
+import { ExceptionDates, Library } from '../../../classes/library';
+import { NotificationType } from '../../../classes/notification';
+import { LibraryStore } from './library.store';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const mockLibraryMetadata = {
+  pid: 'lib1',
+  name: 'Test Library',
+  code: 'TEST',
+  email: 'test@example.com',
+  address: '1 rue de la Paix',
+  communication_language: 'fr',
+  opening_hours: [],
+  exception_dates: [],
+  organisation: { $ref: 'https://localhost/api/organisations/1' },
+  rollover_settings: { account_transfer: 'rollover_no_transfer' },
+};
+
+const mockLibrarySchema = {
+  schema: {
+    properties: {
+      communication_language: { enum: ['fr', 'de', 'en'] },
+      acquisition_settings: {
+        properties: {
+          shipping_informations: {
+            properties: {
+              address: {
+                properties: {
+                  country: { enum: ['CH', 'FR', 'DE'] },
+                },
+              },
+            },
+          },
+        },
+      },
+      rollover_settings: {
+        properties: {
+          account_transfer: { enum: ['rollover_no_transfer', 'rollover_allocated_amount'] },
+        },
+      },
+    },
+  },
+};
+
+const mockNotificationSchema = {
+  schema: {
+    properties: {
+      notification_type: {
+        enum: [
+          NotificationType.AVAILABILITY,
+          NotificationType.RECALL,
+          NotificationType.ACQUISITION_ORDER,
+          NotificationType.CLAIM_ISSUE,
+        ],
+      },
+    },
+  },
+};
+
+const mockLocation = (pid: string) => ({ metadata: { pid, name: `Location ${pid}` } });
+
+const exceptionOlder: ExceptionDates = { title: 'Older', is_open: false, start_date: '2025-01-01' };
+const exceptionNewer: ExceptionDates = { title: 'Newer', is_open: false, start_date: '2025-06-01' };
+const exceptionNewest: ExceptionDates = { title: 'Newest', is_open: false, start_date: '2025-12-01' };
+
+// ---------------------------------------------------------------------------
+// Setup helper
+// ---------------------------------------------------------------------------
+const recordServiceSpy = {
+  getRecord: vi.fn(),
+  getRecords: vi.fn(),
+  getSchemaForm: vi.fn(),
+  MAX_REST_RESULTS_SIZE: 9999,
+};
+
+const setupStore = () => {
+  // withHooks calls loadSchemas on init — provide a default so tests that don't
+  // care about schemas don't blow up.
+  recordServiceSpy.getSchemaForm.mockImplementation((type: string) =>
+    type === 'libraries' ? of(mockLibrarySchema) : of(mockNotificationSchema)
+  );
+
+  TestBed.configureTestingModule({
+    providers: [
+      LibraryStore,
+      { provide: RecordService, useValue: recordServiceSpy },
+    ],
+  });
+  return TestBed.inject(LibraryStore);
+};
+
+describe('LibraryStore', () => {
+  afterEach(() => vi.resetAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // Initial state
+  // Note: withHooks calls loadSchemas() on init (synchronous with of()), so
+  // schema-derived arrays are populated immediately. Tests here reflect the
+  // real initial state after the hook runs.
+  // ---------------------------------------------------------------------------
+  describe('initial state', () => {
+    it('should have null library', () => {
+      const store = setupStore();
+      expect(store.library()).toBeUndefined();
+    });
+
+    it('should have empty locations and exceptionDates', () => {
+      const store = setupStore();
+      expect(store.locations()).toEqual([]);
+      expect(store.exceptionDates()).toEqual([]);
+    });
+
+    it('should have schema data populated by onInit hook', () => {
+      const store = setupStore();
+      expect(store.availableCommunicationLanguages()).toEqual(['fr', 'de', 'en']);
+      expect(store.countryIsoCodes()).toEqual(['CH', 'FR', 'DE']);
+      expect(store.rolloverAccountTransferOptions()).toEqual(['rollover_no_transfer', 'rollover_allocated_amount']);
+    });
+
+    it('should not be loading', () => {
+      const store = setupStore();
+      expect(store.isLoading()).toBe(false);
+    });
+
+    it('should have no error', () => {
+      const store = setupStore();
+      expect(store.error()).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Computed: isNewLibrary
+  // ---------------------------------------------------------------------------
+  describe('isNewLibrary', () => {
+    it('should be true when no library is set', () => {
+      const store = setupStore();
+      expect(store.isNewLibrary()).toBe(true);
+    });
+
+    it('should be false when library has a pid', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata: mockLibraryMetadata }));
+      store.loadLibrary('lib1');
+      expect(store.isNewLibrary()).toBe(false);
+    });
+
+    it('should be true after setNewLibrary', () => {
+      const store = setupStore();
+      store.setNewLibrary();
+      expect(store.isNewLibrary()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Computed: organisationPid
+  // ---------------------------------------------------------------------------
+  describe('organisationPid', () => {
+    it('should return empty string when no library', () => {
+      const store = setupStore();
+      expect(store.organisationPid()).toBe('');
+    });
+
+    it('should extract pid from $ref', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata: mockLibraryMetadata }));
+      store.loadLibrary('lib1');
+      expect(store.organisationPid()).toBe('1');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // withHooks: onInit calls loadSchemas
+  // ---------------------------------------------------------------------------
+  describe('onInit hook', () => {
+    it('should call loadSchemas on init and populate schema data', () => {
+      const store = setupStore();
+      TestBed.tick();
+      expect(recordServiceSpy.getSchemaForm).toHaveBeenCalledWith('libraries');
+      expect(recordServiceSpy.getSchemaForm).toHaveBeenCalledWith('notifications');
+      expect(store.availableCommunicationLanguages()).toEqual(['fr', 'de', 'en']);
+      expect(store.countryIsoCodes()).toEqual(['CH', 'FR', 'DE']);
+      expect(store.rolloverAccountTransferOptions()).toEqual(['rollover_no_transfer', 'rollover_allocated_amount']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadSchemas
+  // ---------------------------------------------------------------------------
+  describe('loadSchemas', () => {
+    it('should populate all schema-derived state', () => {
+      const store = setupStore();
+      store.loadSchemas();
+      expect(store.availableCommunicationLanguages()).toEqual(['fr', 'de', 'en']);
+      expect(store.countryIsoCodes()).toEqual(['CH', 'FR', 'DE']);
+      expect(store.rolloverAccountTransferOptions()).toEqual(['rollover_no_transfer', 'rollover_allocated_amount']);
+    });
+
+    it('should exclude ACQUISITION_ORDER and CLAIM_ISSUE from notificationTypes', () => {
+      const store = setupStore();
+      store.loadSchemas();
+      const types = store.notificationTypes();
+      expect(types).toContain(NotificationType.AVAILABILITY);
+      expect(types).toContain(NotificationType.RECALL);
+      expect(types).not.toContain(NotificationType.ACQUISITION_ORDER);
+      expect(types).not.toContain(NotificationType.CLAIM_ISSUE);
+    });
+
+    it('should set error and keep schema state empty on failure', () => {
+      // Configure error BEFORE TestBed setup so the onInit hook also gets the error mock.
+      recordServiceSpy.getSchemaForm.mockReturnValue(throwError(() => new Error('network error')));
+      TestBed.configureTestingModule({
+        providers: [
+          LibraryStore,
+          { provide: RecordService, useValue: recordServiceSpy },
+        ],
+      });
+      const store = TestBed.inject(LibraryStore);
+      expect(store.availableCommunicationLanguages()).toEqual([]);
+      expect(store.error()).toContain('network error');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadLibrary
+  // ---------------------------------------------------------------------------
+  describe('loadLibrary', () => {
+    it('should set library and exceptionDates on success', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata: mockLibraryMetadata }));
+      store.loadLibrary('lib1');
+      expect(store.library()).toBeInstanceOf(Library);
+      expect(store.library()!.pid).toBe('lib1');
+      expect(store.isLoading()).toBe(false);
+    });
+
+    it('should set isLoading to true then false', () => {
+      const store = setupStore();
+      // Use a delayed observable via synchronous test — loading flag is set before switchMap resolves.
+      // With synchronous of(), it flips back immediately; just verify final state is false.
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata: mockLibraryMetadata }));
+      store.loadLibrary('lib1');
+      expect(store.isLoading()).toBe(false);
+    });
+
+    it('should set error and isLoading=false on failure', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecord.mockReturnValue(throwError(() => new Error('not found')));
+      store.loadLibrary('lib1');
+      expect(store.library()).toBeUndefined();
+      expect(store.isLoading()).toBe(false);
+      expect(store.error()).toContain('not found');
+    });
+
+    it('should ignore empty pid (filter guard)', () => {
+      const store = setupStore();
+      store.loadLibrary('');
+      expect(recordServiceSpy.getRecord).not.toHaveBeenCalled();
+    });
+
+    it('should initialise exceptionDates from library metadata', () => {
+      const store = setupStore();
+      const metadata = { ...mockLibraryMetadata, exception_dates: [exceptionOlder] };
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata }));
+      store.loadLibrary('lib1');
+      expect(store.exceptionDates().length).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadLocations
+  // ---------------------------------------------------------------------------
+  describe('loadLocations', () => {
+    it('should populate locations on success', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(of({ hits: { hits: [mockLocation('loc1'), mockLocation('loc2')] } }));
+      store.loadLocations('lib1');
+      expect(store.locations().length).toBe(2);
+      expect(store.locations()[0].metadata.pid).toBe('loc1');
+    });
+
+    it('should set empty array when hits is missing', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(of({ hits: { hits: null } }));
+      store.loadLocations('lib1');
+      expect(store.locations()).toEqual([]);
+    });
+
+    it('should keep state unchanged on error', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(throwError(() => new Error('fail')));
+      store.loadLocations('lib1');
+      expect(store.locations()).toEqual([]);
+    });
+
+    it('should ignore empty pid (filter guard)', () => {
+      const store = setupStore();
+      store.loadLocations('');
+      expect(recordServiceSpy.getRecords).not.toHaveBeenCalled();
+    });
+
+    it('should query with correct params', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(of({ hits: { hits: [] } }));
+      store.loadLocations('lib1');
+      expect(recordServiceSpy.getRecords).toHaveBeenCalledWith(
+        'locations',
+        expect.objectContaining({ query: 'library.pid:lib1', sort: 'name' })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setNewLibrary
+  // ---------------------------------------------------------------------------
+  describe('setNewLibrary', () => {
+    it('should create a new Library with no pid', () => {
+      const store = setupStore();
+      store.setNewLibrary();
+      expect(store.library()).toBeInstanceOf(Library);
+      expect(store.library()!.pid).toBeNull();
+    });
+
+    it('should reset exceptionDates to empty array', () => {
+      const store = setupStore();
+      // Pre-load some exceptions
+      recordServiceSpy.getRecord.mockReturnValue(of({ metadata: { ...mockLibraryMetadata, exception_dates: [exceptionOlder] } }));
+      store.loadLibrary('lib1');
+      expect(store.exceptionDates().length).toBe(1);
+
+      store.setNewLibrary();
+      expect(store.exceptionDates()).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addExceptionDate
+  // ---------------------------------------------------------------------------
+  describe('addExceptionDate', () => {
+    it('should append the exception', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      expect(store.exceptionDates().length).toBe(1);
+      expect(store.exceptionDates()[0]).toEqual(exceptionOlder);
+    });
+
+    it('should sort by start_date descending after add', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      store.addExceptionDate(exceptionNewest);
+      store.addExceptionDate(exceptionNewer);
+      const dates = store.exceptionDates().map(e => e.start_date);
+      expect(dates).toEqual(['2025-12-01', '2025-06-01', '2025-01-01']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateExceptionDate
+  // ---------------------------------------------------------------------------
+  describe('updateExceptionDate', () => {
+    it('should replace exception at given index', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      const updated: ExceptionDates = { title: 'Updated', is_open: true, start_date: '2025-01-01' };
+      store.updateExceptionDate(0, updated);
+      expect(store.exceptionDates()[0].title).toBe('Updated');
+    });
+
+    it('should re-sort after update', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      store.addExceptionDate(exceptionNewer);
+      // exceptions are [exceptionNewer, exceptionOlder] after sort
+      // update index 1 (exceptionOlder) to a future date → it should move to front
+      const promoted: ExceptionDates = { title: 'Promoted', is_open: false, start_date: '2026-01-01' };
+      store.updateExceptionDate(1, promoted);
+      expect(store.exceptionDates()[0].start_date).toBe('2026-01-01');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteExceptionDate
+  // ---------------------------------------------------------------------------
+  describe('deleteExceptionDate', () => {
+    it('should remove exception at given index', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      store.addExceptionDate(exceptionNewer);
+      const countBefore = store.exceptionDates().length;
+      store.deleteExceptionDate(0);
+      expect(store.exceptionDates().length).toBe(countBefore - 1);
+    });
+
+    it('should preserve remaining exceptions', () => {
+      const store = setupStore();
+      store.addExceptionDate(exceptionOlder);
+      store.addExceptionDate(exceptionNewest);
+      // After sort: [exceptionNewest, exceptionOlder]; delete index 0 → only exceptionOlder remains
+      store.deleteExceptionDate(0);
+      expect(store.exceptionDates()[0].title).toBe('Older');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteLocation
+  // ---------------------------------------------------------------------------
+  describe('deleteLocation', () => {
+    it('should remove location matching the pid', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(of({ hits: { hits: [mockLocation('loc1'), mockLocation('loc2')] } }));
+      store.loadLocations('lib1');
+
+      store.deleteLocation('loc1');
+      expect(store.locations().length).toBe(1);
+      expect(store.locations()[0].metadata.pid).toBe('loc2');
+    });
+
+    it('should leave locations unchanged when pid is not found', () => {
+      const store = setupStore();
+      recordServiceSpy.getRecords.mockReturnValue(of({ hits: { hits: [mockLocation('loc1')] } }));
+      store.loadLocations('lib1');
+
+      store.deleteLocation('unknown');
+      expect(store.locations().length).toBe(1);
+    });
+  });
+});

--- a/projects/admin/src/app/record/custom-editor/libraries/library.store.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/library.store.ts
@@ -1,0 +1,194 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2019-2025 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { computed, inject } from '@angular/core';
+import { patchState, signalStore, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { EsResult, extractIdOnRef, RecordService } from '@rero/ng-core';
+import { DateTime } from 'luxon';
+import { EMPTY, forkJoin, pipe } from 'rxjs';
+import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
+import { ExceptionDates, Library } from '../../../classes/library';
+import { NotificationType } from '../../../classes/notification';
+
+type SchemaProperty = {
+  enum?: string[];
+  properties?: Record<string, SchemaProperty>;
+};
+
+type SchemaForm = {
+  schema: {
+    properties: Record<string, SchemaProperty>;
+  };
+};
+
+
+export type LocationRecord = {
+  metadata: {
+    pid: string;
+    name: string;
+    [key: string]: unknown;
+  };
+};
+
+export type LibraryState = {
+  library: Library | undefined;
+  locations: LocationRecord[];
+  exceptionDates: ExceptionDates[];
+  availableCommunicationLanguages: string[];
+  countryIsoCodes: string[];
+  rolloverAccountTransferOptions: string[];
+  notificationTypes: NotificationType[];
+  isLoading: boolean;
+  error: string | undefined;
+};
+
+const initialState: LibraryState = {
+  library: undefined,
+  locations: [],
+  exceptionDates: [],
+  availableCommunicationLanguages: [],
+  countryIsoCodes: [],
+  rolloverAccountTransferOptions: [],
+  notificationTypes: [],
+  isLoading: false,
+  error: undefined,
+};
+
+function sortExceptionDates(dates: ExceptionDates[]): ExceptionDates[] {
+  return [...dates].sort((a, b) =>
+    (DateTime.fromISO(b.start_date as string).toMillis()) -
+    (DateTime.fromISO(a.start_date as string).toMillis())
+  );
+}
+
+export const LibraryStore = signalStore(
+  withState<LibraryState>(initialState),
+  withComputed((store) => ({
+    isNewLibrary: computed(() => !store.library()?.pid),
+    organisationPid: computed(() => store.library()?.organisation?.$ref ? extractIdOnRef(store.library()!.organisation.$ref) : ''),
+  })),
+  withMethods((store, recordService = inject(RecordService)) => ({
+
+    loadLibrary: rxMethod<string>(
+      pipe(
+        filter(Boolean),
+        tap(() => patchState(store, { isLoading: true, error: undefined })),
+        switchMap(pid =>
+          recordService.getRecord('libraries', pid).pipe(
+            tap(record => {
+              const lib = new Library(record.metadata as Record<string, unknown>);
+              patchState(store, {
+                library: lib,
+                exceptionDates: lib.exception_dates ?? [],
+                isLoading: false,
+              });
+            }),
+            catchError(err => {
+              patchState(store, { error: String(err), isLoading: false });
+              return EMPTY;
+            })
+          )
+        )
+      )
+    ),
+
+    loadLocations: rxMethod<string>(
+      pipe(
+        filter(Boolean),
+        tap(() => patchState(store, { isLoading: true })),
+        switchMap(pid =>
+          recordService.getRecords('locations', {
+            query: `library.pid:${pid}`,
+            page: 1,
+            itemsPerPage: RecordService.MAX_REST_RESULTS_SIZE,
+            sort: 'name',
+          }).pipe(
+            map((res: EsResult) => (res.hits.hits as unknown as LocationRecord[]) || []),
+            tap(locations => patchState(store, { locations, isLoading: false })),
+            catchError(() => { patchState(store, { isLoading: false }); return EMPTY; })
+          )
+        )
+      )
+    ),
+
+    loadSchemas: rxMethod<void>(
+      pipe(
+        switchMap(() =>
+          forkJoin([
+            recordService.getSchemaForm('libraries'),
+            recordService.getSchemaForm('notifications'),
+          ]).pipe(
+            tap(([libSchema, notifSchema]) => {
+              const libProps = (libSchema as SchemaForm).schema.properties;
+              const notifTypes = ((notifSchema as SchemaForm).schema.properties['notification_type'].enum as NotificationType[])
+                .filter(t => t !== NotificationType.ACQUISITION_ORDER)
+                .filter(t => t !== NotificationType.CLAIM_ISSUE);
+              patchState(store, {
+                availableCommunicationLanguages: libProps.communication_language.enum ?? [],
+                countryIsoCodes: libProps.acquisition_settings?.properties?.shipping_informations
+                  ?.properties?.address?.properties?.country?.enum ?? [],
+                rolloverAccountTransferOptions: libProps.rollover_settings?.properties?.account_transfer?.enum ?? [],
+                notificationTypes: notifTypes,
+              });
+            }),
+            catchError(err => {
+              patchState(store, { error: String(err) });
+              return EMPTY;
+            })
+          )
+        )
+      )
+    ),
+
+    setNewLibrary(): void {
+      const lib = new Library({});
+      patchState(store, {
+        library: lib,
+        exceptionDates: [],
+      });
+    },
+
+    addExceptionDate(exception: ExceptionDates): void {
+      patchState(store, { exceptionDates: sortExceptionDates([...store.exceptionDates(), exception]) });
+    },
+
+    updateExceptionDate(index: number, exception: ExceptionDates): void {
+      const updated = [...store.exceptionDates()];
+      updated[index] = exception;
+      patchState(store, { exceptionDates: sortExceptionDates(updated) });
+    },
+
+    deleteExceptionDate(index: number): void {
+      const updated = [...store.exceptionDates()];
+      updated.splice(index, 1);
+      patchState(store, { exceptionDates: updated });
+    },
+
+    deleteLocation(pid: string): void {
+      if (store.locations().some(loc => loc.metadata.pid === pid)) {
+        patchState(store, {
+          locations: store.locations().filter(loc => loc.metadata.pid !== pid),
+        });
+      }
+    },
+  })),
+  withHooks((store) => ({
+    onInit: () => {
+      store.loadSchemas();
+    },
+  }))
+);

--- a/projects/admin/src/app/record/custom-editor/libraries/pipe/notificationType.pipe.spec.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/pipe/notificationType.pipe.spec.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { NotificationType } from '../../../../classes/notification';
 import { NotificationTypePipe } from './notificationType.pipe';
 
 describe('NotificationPipe', () => {
@@ -24,16 +25,16 @@ describe('NotificationPipe', () => {
 
   it('should return true if key is available on patron type', () => {
     const pipe = new NotificationTypePipe();
-    expect(pipe.transform('availability', 'patron')).toBeTruthy();
+    expect(pipe.transform(NotificationType.AVAILABILITY, 'patron')).toBeTruthy();
   });
 
   it('should return true if key is available on library type', () => {
     const pipe = new NotificationTypePipe();
-    expect(pipe.transform('booking', 'library')).toBeTruthy();
+    expect(pipe.transform(NotificationType.BOOKING, 'library')).toBeTruthy();
   });
 
   it('should return false if key is not available on type', () => {
     const pipe = new NotificationTypePipe();
-    expect(pipe.transform('availability', 'library')).toBeFalsy();
+    expect(pipe.transform(NotificationType.AVAILABILITY, 'library')).toBeFalsy();
   });
 });

--- a/projects/admin/src/app/record/custom-editor/libraries/pipe/notificationType.pipe.ts
+++ b/projects/admin/src/app/record/custom-editor/libraries/pipe/notificationType.pipe.ts
@@ -15,21 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Pipe, PipeTransform } from '@angular/core';
-import { Notification } from '../../../../classes/notification';
+import { Notification, NotificationType } from '../../../../classes/notification';
 
 @Pipe({ name: 'notificationType' })
 export class NotificationTypePipe implements PipeTransform {
 
-  /** type of notification by type */
-  private _notification = Notification.types;
+  private readonly _notification = Notification.types;
 
-  /**
-   * Transform
-   * @param notification - string
-   * @param type - string
-   * @return boolean
-   */
-  transform(notification: string, type: string): boolean {
+  transform(notification: NotificationType, type: keyof typeof Notification.types): boolean {
     return Object.keys(this._notification).includes(type)
       && this._notification[type].includes(notification);
   }

--- a/projects/admin/src/app/record/detail-view/library-detail-view/day-opening-hours/day-opening-hours.component.ts
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/day-opening-hours/day-opening-hours.component.ts
@@ -15,8 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, input, ChangeDetectionStrategy} from '@angular/core';
 import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { OpeningHours } from '@app/admin/classes/library';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
@@ -48,5 +49,5 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DayOpeningHoursComponent {
-  day = input<any>();
+  day = input.required<OpeningHours>();
 }

--- a/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.html
@@ -34,7 +34,7 @@
       }
       @if (exception().repeat) {
         <i class="fa fa-repeat"></i>&nbsp;
-        {{ exception().repeat.period | translate }}={{ exception().repeat.interval }}
+        {{ exception().repeat?.period | translate }}={{ exception().repeat?.interval }}
       }
     </div>
     <span class="ui:col-span-5">{{ exception().title }}</span>

--- a/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.ts
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/exception-date/exception-date.component.ts
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, input, ChangeDetectionStrategy} from '@angular/core';
-import { ExceptionDates, Library } from '@app/admin/classes/library';
 import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ExceptionDates, Library } from '@app/admin/classes/library';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DateTranslatePipe } from '@rero/ng-core';
 
@@ -27,7 +27,7 @@ import { DateTranslatePipe } from '@rero/ng-core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExceptionDateComponent {
-  exception = input<ExceptionDates>();
+  exception = input.required<ExceptionDates>();
 
   isOver(exception: ExceptionDates): boolean {
     return Library.isExceptionDateOver(exception);

--- a/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/library-detail-view.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2019-2024 RERO
+ * Copyright (C) 2019-2025 RERO
  * Copyright (C) 2019-2023 UCLouvain
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,38 +15,38 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, computed, effect, inject, input, signal, ChangeDetectionStrategy } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { RecordService, UpperCaseFirstPipe } from '@rero/ng-core';
-import { AppStore } from '@rero/shared';
-import { map, of, switchMap } from 'rxjs';
-import { Library } from '../../../classes/library';
-import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { Bind } from 'primeng/bind';
-import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from 'primeng/accordion';
-import { Ripple } from 'primeng/ripple';
-import { Button } from 'primeng/button';
-import { RouterLink } from '@angular/router';
-import { LocationComponent } from './location/location.component';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { DayOpeningHoursComponent } from './day-opening-hours/day-opening-hours.component';
-import { ExceptionDateComponent } from './exception-date/exception-date.component';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { UpperCaseFirstPipe } from '@rero/ng-core';
+import { AppStore } from '@rero/shared';
+import { Accordion, AccordionContent, AccordionHeader, AccordionPanel } from 'primeng/accordion';
+import { Badge } from 'primeng/badge';
+import { Bind } from 'primeng/bind';
+import { Button } from 'primeng/button';
 import { Divider } from 'primeng/divider';
 import { Fieldset } from 'primeng/fieldset';
+import { Ripple } from 'primeng/ripple';
 import { Tag } from 'primeng/tag';
+import { Library } from '../../../classes/library';
 import { CountryCodeTranslatePipe } from '../../../pipe/country-code-translate.pipe';
-import { Badge } from 'primeng/badge';
+import { LibraryStore } from '../../custom-editor/libraries/library.store';
+import { DayOpeningHoursComponent } from './day-opening-hours/day-opening-hours.component';
+import { ExceptionDateComponent } from './exception-date/exception-date.component';
+import { LocationComponent } from './location/location.component';
 
 @Component({
     selector: 'admin-library-detail-view',
     templateUrl: './library-detail-view.component.html',
+    providers: [LibraryStore],
     imports: [TranslateDirective, Bind, Accordion, AccordionPanel, Ripple, AccordionHeader, Button, RouterLink, AccordionContent, LocationComponent, NgClass, DayOpeningHoursComponent, ExceptionDateComponent, Divider, NgTemplateOutlet, Fieldset, Tag, UpperCaseFirstPipe, TranslatePipe, CountryCodeTranslatePipe, Badge],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LibraryDetailViewComponent {
 
-  private recordService: RecordService = inject(RecordService);
   private appStore = inject(AppStore);
+  protected readonly libraryStore = inject(LibraryStore);
 
   readonly record = input<any>();
   readonly type = input<string>('');
@@ -60,27 +60,19 @@ export class LibraryDetailViewComponent {
     this.appStore.currentLibraryPid() === this.record()?.metadata?.pid
   );
 
-  private readonly _fetchedLocations = toSignal(
-    toObservable(this.record).pipe(
-      switchMap(r => {
-        const pid = r?.metadata?.pid;
-        if (!pid) return of([]);
-        return this.recordService.getRecords('locations', {
-          query: `library.pid:${pid}`, page: 1,
-          itemsPerPage: RecordService.MAX_REST_RESULTS_SIZE, sort: 'name'
-        }).pipe(map((res: any) => res.hits.hits || []));
-      })
-    ),
-    { initialValue: [] }
-  );
-
-  readonly locations = signal<any[]>([]);
+  readonly locations = this.libraryStore.locations;
 
   constructor() {
-    effect(() => this.locations.set(this._fetchedLocations()));
+    // Load locations whenever the record pid changes.
+    effect(() => {
+      const pid = this.record()?.metadata?.pid;
+      if (pid) {
+        this.libraryStore.loadLocations(pid);
+      }
+    });
   }
 
   deleteLocation(deletedLocationPid: string): void {
-    this.locations.update(list => list.filter((location: any) => deletedLocationPid !== location.metadata.pid));
+    this.libraryStore.deleteLocation(deletedLocationPid);
   }
 }

--- a/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.html
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-@if (permissions) {
+@if (permissions()) {
   <div class="ui:flex ui:justify-between ui:items-center ui:gap-2 ui:mx-2">
     <div>
       <a [routerLink]="['/records/locations/detail', location().metadata.pid]">{{ location().metadata.name }}</a>
@@ -45,7 +45,7 @@
     </div>
     <div class="ui:flex ui:gap-1">
       <!-- Edit button -->
-      @if (permissions.update.can) {
+      @if (permissions().update.can) {
         <p-button
           size="small"
           icon="fa fa-pencil"
@@ -65,8 +65,8 @@
           (onClick)="delete(location().metadata.pid)"
           [pTooltip]="tooltipContent"
           tooltipPosition="top"
-          [disabled]="!permissions.delete?.can"
-          [tooltipDisabled]="permissions.delete?.can"
+          [disabled]="!permissions().delete?.can"
+          [tooltipDisabled]="permissions().delete?.can"
         />
         <ng-template #tooltipContent>
           <span [innerHTML]="deleteInfoMessage"></span>

--- a/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.ts
+++ b/projects/admin/src/app/record/detail-view/library-detail-view/location/location.component.ts
@@ -1,6 +1,6 @@
 /*
  * RERO ILS UI
- * Copyright (C) 2020-2024 RERO
+ * Copyright (C) 2020-2025 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -14,14 +14,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ChangeDetectorRef, Component, inject, input, OnInit, output, ChangeDetectionStrategy} from '@angular/core';
-import { RecordPermissionService } from '@app/admin/service/record-permission.service';
-import { RecordUiService } from '@rero/ng-core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { Tooltip } from 'primeng/tooltip';
+import { RecordPermissionService } from '@app/admin/service/record-permission.service';
+import { TranslatePipe } from '@ngx-translate/core';
+import { RecordUiService } from '@rero/ng-core';
 import { Bind } from 'primeng/bind';
 import { Button } from 'primeng/button';
-import { TranslatePipe } from '@ngx-translate/core';
+import { Tooltip } from 'primeng/tooltip';
+import { filter, switchMap, take } from 'rxjs/operators';
 
 @Component({
     selector: 'admin-location',
@@ -29,53 +31,34 @@ import { TranslatePipe } from '@ngx-translate/core';
     imports: [RouterLink, Tooltip, Bind, Button, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LocationComponent implements OnInit {
+export class LocationComponent {
 
-  private cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
   private recordUiService: RecordUiService = inject(RecordUiService);
   private recordPermissionService: RecordPermissionService = inject(RecordPermissionService);
 
-  /** The location whose details are displayed */
   location = input<any>();
-
-  /** The parent library of the location */
   library = input<any>();
 
-  /** Delete location event emitter */
   deleteLocation = output<string>();
 
-  /** location record permission */
-  permissions: any;
+  permissions = toSignal(
+    toObservable(this.location).pipe(
+      filter(loc => !!loc?.metadata?.pid),
+      switchMap(loc => this.recordPermissionService.getPermission('locations', loc.metadata.pid)),
+    )
+  );
 
-  /**
-   * Init
-   */
-  ngOnInit() {
-    this.recordPermissionService.getPermission('locations', this.location().metadata.pid).subscribe(
-      (permissions) => {
-        this.permissions = permissions;
-        this.cdr.markForCheck();
-      }
-    );
-  }
+  deleteInfoMessage = computed(() =>
+    this.recordPermissionService.generateTooltipMessage(this.permissions()?.delete?.reasons, 'delete')
+  );
 
-  /**
-   * Delete the location
-   * @param locationPid - location PID
-   */
   delete(locationPid: string) {
-    this.recordUiService.deleteRecord('locations', locationPid).subscribe((success: boolean) => {
+    this.recordUiService.deleteRecord('locations', locationPid).pipe(
+      take(1)
+    ).subscribe((success: boolean) => {
       if (success) {
         this.deleteLocation.emit(locationPid);
       }
     });
   }
-
-  /**
-   * Return a message containing the reasons wht the item cannot be requested
-   */
-  get deleteInfoMessage(): string {
-    return this.recordPermissionService.generateTooltipMessage(this.permissions.delete.reasons, 'delete');
-  }
-
 }

--- a/projects/admin/src/app/record/detail-view/permission-detail-view/permission-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/permission-detail-view/permission-detail-view.component.ts
@@ -30,7 +30,6 @@ type IRole = {
 @Component({
   selector: 'admin-permission-detail-view',
   templateUrl: './permission-detail-view.component.html',
-  standalone: true,
   imports: [TranslateDirective, InputText, NgClass, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/report-data/report-data.component.ts
+++ b/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/report-data/report-data.component.ts
@@ -22,7 +22,6 @@ import { TranslateDirective } from "@ngx-translate/core";
 
 @Component({
     selector: "admin-report-data",
-    standalone: true,
     templateUrl: "./report-data.component.html",
     imports: [Bind, TableModule, TranslateDirective],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/reports-list/reports-list.component.ts
+++ b/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/reports-list/reports-list.component.ts
@@ -25,7 +25,6 @@ import { TranslateDirective } from "@ngx-translate/core";
 
 @Component({
     selector: "admin-reports-list",
-    standalone: true,
     templateUrl: "./reports-list.component.html",
     imports: [Bind, TableModule, ButtonDirective, TranslateDirective, DateTranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/admin/src/app/record/formly/type/cipo-patron-type-item-type/cipo-patron-type-item-type.component.ts
+++ b/projects/admin/src/app/record/formly/type/cipo-patron-type-item-type/cipo-patron-type-item-type.component.ts
@@ -36,7 +36,6 @@ type LibraryRef = {
 };
 
 @Component({
-  standalone: true,
   selector: 'admin-cipo-patron-type-item-type',
   templateUrl: './cipo-patron-type-item-type.component.html',
   imports: [TableModule],

--- a/projects/public-patron-profile/src/app/app.component.ts
+++ b/projects/public-patron-profile/src/app/app.component.ts
@@ -23,7 +23,6 @@ import { ToastModule } from 'primeng/toast';
 @Component({
     selector: 'public-patron-profile-app',
     templateUrl: './app.component.html',
-    standalone: true,
     imports: [RouterOutlet, LoadingBarHttpClientModule, ToastModule]
 })
 export class AppComponent {

--- a/projects/shared/src/lib/directive/link-permissions.directive.spec.ts
+++ b/projects/shared/src/lib/directive/link-permissions.directive.spec.ts
@@ -22,7 +22,6 @@ import { LinkPermissionsDirective } from './link-permissions.directive';
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'link-permissions-testing-component',
-    standalone: true,
     imports: [LinkPermissionsDirective],
     template: `
   <a href="#" id="link-perm" [linkPermissions]="linkPermissions">Link text</a>`

--- a/projects/shared/src/lib/directive/permissions.directive.spec.ts
+++ b/projects/shared/src/lib/directive/permissions.directive.spec.ts
@@ -22,7 +22,6 @@ import { PermissionsDirective } from './permissions.directive';
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'permissions-testing-component',
-    standalone: true,
     imports: [PermissionsDirective],
     template: `
   <div id="perm" [permissions]="permissions">Permissions testing</div>`


### PR DESCRIPTION
- Introduce LibraryStore (signalStore) as single source of truth for library state across the custom editor and detail view
- Consolidate async data loading (schemas, locations), exception date management and form population into the store
- Remove manual subscriptions and dispersed local signals from components
- Fix exception dates not appearing, appearing twice, not saved on submit, and lost sort order after add/edit
- Scope LibraryFormService to component level (remove providedIn: 'root')
- Add LibraryStore unit tests (Vitest)
- Apply Angular 21 strict TypeScript and template patterns throughout
- Update .ai rules: omit standalone: true, sort imports alphabetically