### PR TITLE
feat(patron-profile): renew all loans

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "contributors": [
     "Alicia Zangger <alicia.zangger@rero.ch>",
     "Aly Badr <aly.badr@rero.ch>",
+    "Ana Gomes Gonçalves <anagoncalves7@icloud.com>",
     "Benoit Erken <benoit.erken@uclouvain.be>",
     "Bertrand Zuchuat <bertrand.zuchuat@rero.ch>",
     "Gianni Pante <gianni.pante@rero.ch>",

--- a/projects/public-search/src/app/api/loan-api.service.ts
+++ b/projects/public-search/src/app/api/loan-api.service.ts
@@ -8,6 +8,7 @@ import type { Error, EsResult } from '@rero/ng-core';
 import { BaseApi } from '@rero/shared';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import type { PatronLoan } from '../patron-profile/patron-profile-loans/types';
 
 @Injectable({
   providedIn: 'root'
@@ -30,9 +31,9 @@ export class LoanApiService extends BaseApi {
     patronPid: string, page: number,
     itemsPerPage = 20, headers = BaseApi.reroJsonheaders,
     sort?: string
-  ): Observable<EsResult | Error> {
+  ): Observable<EsResult<PatronLoan['metadata']> | Error> {
     const loanStates = ['ITEM_ON_LOAN'];
-    return this.recordService.getRecords(
+    return this.recordService.getRecords<EsResult<PatronLoan['metadata']>>(
       'loans', { query: this._patronStateQuery(patronPid, loanStates), page, itemsPerPage, headers, sort }
     );
   }

--- a/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fee/patron-profile-fee.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fee/patron-profile-fee.component.ts
@@ -5,7 +5,7 @@ import { Component, inject, input, OnDestroy, OnInit, signal, ChangeDetectionStr
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { DateTranslatePipe, RecordService } from '@rero/ng-core';
 import { MainTitlePipe, OpenCloseButtonComponent, IOrganisation } from '@rero/shared';
-import { fee } from '../types';
+import { Fee } from '../types';
 import { PanelModule } from 'primeng/panel';
 import { TagModule } from 'primeng/tag';
 import { TimelineModule } from 'primeng/timeline';
@@ -37,7 +37,7 @@ export class PatronProfileFeeComponent<T> implements OnInit, OnDestroy {
   private recordService = inject(RecordService);
 
   /** Fee record */
-  record = input<fee>();
+  record = input<Fee>();
 
   /** Detail collapsed */
   isCollapsed = true;

--- a/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.html
@@ -14,9 +14,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         </div>
     </ng-template>
 
-    @defer (when loaded()) {
-      @if (records().length > 0) {
-        @for (record of records(); track $index) {
+    @defer (when store.feesLoaded()) {
+      @if (store.fees().length > 0) {
+        @for (record of store.fees(); track $index) {
           <div class="ui:odd:bg-surface-50 ui:my-1">
             <public-search-patron-profile-fee [record]="record" />
           </div>

--- a/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.spec.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.spec.ts
@@ -5,17 +5,20 @@ import { Component, Input, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
+import { provideHttpClient } from '@angular/common/http';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RecordService } from '@rero/ng-core';
 import { AppStore, testUserPatronWithSettings, User, UserApiService } from '@rero/shared';
 import { cloneDeep } from 'lodash-es';
+import { MessageService } from 'primeng/api';
 import { of } from 'rxjs';
+import { IllRequestApiService } from '../../api/ill-request-api.service';
+import { LoanApiService } from '../../api/loan-api.service';
+import { PatronApiService } from '../../api/patron-api.service';
 import { PatronTransactionApiService } from '../../api/patron-transaction-api.service';
 import { PatronProfileStore } from '../store/patron-profile.store';
-import { PatronApiService } from '../../api/patron-api.service';
-import { PatronProfileFeesComponent } from './patron-profile-fees.component';
 import { PatronProfileFeeComponent } from './patron-profile-fee/patron-profile-fee.component';
-import { provideHttpClient } from '@angular/common/http';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PatronProfileFeesComponent } from './patron-profile-fees.component';
 
 @Component({ selector: 'public-search-patron-profile-fee', template: '' })
 class StubPatronProfileFeeComponent {
@@ -57,27 +60,42 @@ describe('PatronProfileFeeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [
         TranslateModule.forRoot(),
         PatronProfileFeesComponent
-    ],
-    providers: [
+      ],
+      providers: [
+        PatronProfileStore,
         { provide: UserApiService, useValue: userApiServiceSpy },
         { provide: AppStore, useValue: appStoreSpy },
+        {
+          provide: LoanApiService,
+          useValue: {
+            getOnLoan: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+            getRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
         { provide: PatronTransactionApiService, useValue: patronTransactionApiServiceSpy },
         { provide: PatronApiService, useValue: { getOverduePreviewByPatronPid: vi.fn().mockReturnValue(of([])) } },
+        {
+          provide: IllRequestApiService,
+          useValue: {
+            getPublicIllRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
+        { provide: MessageService, useValue: { add: vi.fn() } },
         { provide: RecordService, useValue: { getRecord: vi.fn().mockReturnValue(of(null)), MAX_REST_RESULTS_SIZE: 1000 } },
         provideHttpClient(),
         provideHttpClientTesting(),
         provideNoopAnimations()
-    ]
-})
-    .overrideComponent(PatronProfileFeesComponent, {
-      remove: { imports: [PatronProfileFeeComponent] },
-      add: { imports: [StubPatronProfileFeeComponent] }
+      ]
     })
-    .compileComponents();
+      .overrideComponent(PatronProfileFeesComponent, {
+        remove: { imports: [PatronProfileFeeComponent] },
+        add: { imports: [StubPatronProfileFeeComponent] }
+      })
+      .compileComponents();
   });
 
   beforeEach(() => {

--- a/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-fees/patron-profile-fees.component.ts
@@ -1,99 +1,25 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { CurrencyPipe } from '@angular/common';
-import { Component, inject, input, OnInit, signal, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { RecordService } from '@rero/ng-core';
-import type { EsResult } from '@rero/ng-core';
 import { PanelModule } from 'primeng/panel';
-import { forkJoin } from 'rxjs';
-import { PatronApiService } from '../../api/patron-api.service';
-import { PatronTransactionApiService } from '../../api/patron-transaction-api.service';
 import { PatronProfileStore } from '../store/patron-profile.store';
 import { PatronProfileFeeComponent } from './patron-profile-fee/patron-profile-fee.component';
-import { fee, overdueFee } from './types';
 
 @Component({
-    selector: 'public-search-patron-profile-fees',
-    templateUrl: './patron-profile-fees.component.html',
-    imports: [CurrencyPipe, TranslateDirective, TranslatePipe, PanelModule, PatronProfileFeeComponent],
+  selector: 'public-search-patron-profile-fees',
+  templateUrl: './patron-profile-fees.component.html',
+  imports: [CurrencyPipe, TranslateDirective, TranslatePipe, PanelModule, PatronProfileFeeComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PatronProfileFeesComponent implements OnInit {
+export class PatronProfileFeesComponent {
 
-  private patronTransactionApiService = inject(PatronTransactionApiService);
-  private store = inject(PatronProfileStore);
-  private patronApiService = inject(PatronApiService);
+  protected store = inject(PatronProfileStore);
 
   feesTotal = input<number>();
 
-  readonly loaded = signal(false);
-  readonly records = signal<any[]>([]);
-
   get currency() {
     return this.store.currentPatron()?.organisation.currency;
-  }
-
-  ngOnInit(): void {
-    const patronPid = this.store.currentPatron()!.pid;
-    const queryFees = this.patronTransactionApiService.getFees(patronPid, 'open', 1, RecordService.MAX_REST_RESULTS_SIZE);
-    const queryOverdue = this.patronApiService.getOverduePreviewByPatronPid(patronPid);
-
-    forkJoin([queryFees, queryOverdue]).subscribe({
-      next: ([feesResponse, overdueResponse]: [EsResult, overdueFee[]]) => {
-        const records: any[] = [];
-        feesResponse.hits.hits.map((record: any) => {
-          if (record.metadata?.loan) {
-            const result = records.filter((fee: fee) => record.metadata?.loan?.pid === fee.loan?.pid);
-            if (result.length === 1) {
-              if (record.metadata.note) {
-                result[0].notes.push(record.metadata.note);
-              }
-              result[0].totalAmount += record.metadata.total_amount;
-              result[0].transactions.push(record);
-            } else {
-              records.push(this.buildFee(record));
-            }
-          } else {
-            records.push(this.buildFee(record));
-          }
-        });
-        overdueResponse.map((overdue: overdueFee) => {
-          const result = records.filter((record: fee) => record.loan?.pid === overdue.loan.pid);
-          if (result.length === 1) {
-            result[0].totalAmount += overdue.fees.total;
-            result[0].overdue = overdue.fees.total;
-          } else {
-            records.push({
-              type: 'overdue',
-              createdAt: new Date(),
-              loan: overdue.loan,
-              totalAmount: overdue.fees.total,
-              overdue: overdue.fees.total
-            });
-          }
-        });
-        records.sort((a, b) => a.createdAt - b.createdAt);
-        this.records.set(records);
-        this.loaded.set(true);
-      }
-    });
-  }
-
-  private buildFee(record): fee {
-    const result: fee = {
-      type: record.metadata.type,
-      notes: [],
-      createdAt: new Date(record.metadata.creation_date),
-      totalAmount: record.metadata.total_amount,
-      transactions: [record]
-    };
-    if (record.metadata.note) {
-      result.notes.push(record.metadata.note);
-    }
-    if (record.metadata.loan) {
-      result.loan = record.metadata.loan;
-    }
-    return result;
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile-fees/types.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-fees/types.ts
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export type fee = {
+export type Fee = {
   createdAt: Date;
-  notes?: string[];
+  notes: string[];
   loan?: any;
-  totalAmount?: number;
+  totalAmount: number;
   overdue?: number;
   type: string;
   transactions: any[];
 };
 
-export type overdueFee = {
+export type OverdueFee = {
   fees: {
     steps: [],
     total: number;

--- a/projects/public-search/src/app/patron-profile/patron-profile-ill-requests/patron-profile-ill-requests.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-ill-requests/patron-profile-ill-requests.component.html
@@ -11,9 +11,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         </div>
       </ng-template>
 
-    @defer (when loaded()) {
-      @if (paginator.getRecordsCount() > 0) {
-        @for (record of records(); track $index) {
+    @if (store.illRequestsLoaded()) {
+      @if (store.illRequestsTotal() > 0) {
+        @for (record of store.illRequests(); track record.metadata.pid) {
           <div class="ui:odd:bg-surface-50">
             <public-search-patron-profile-ill-request
               [record]="record"
@@ -21,12 +21,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             />
           </div>
         }
-        <shared-search-show-more-pager id="show-more-ill-requests" [paginator]="paginator" />
+        <shared-paginator
+          [pager]="store.illRequestsPager()"
+          [total]="store.illRequestsTotal()"
+          (pageChange)="onPageChange($event)" />
       } @else {
         <div class="ui:font-bold ui:mx-2 ui:my-6" translate>No ill request</div>
       }
-    }
-    @placeholder {
+    } @else {
       <div class="ui:font-bold ui:mx-2 ui:my-6" translate>Loading in progress</div>
     }
   </p-panel>

--- a/projects/public-search/src/app/patron-profile/patron-profile-ill-requests/patron-profile-ill-requests.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-ill-requests/patron-profile-ill-requests.component.ts
@@ -1,77 +1,24 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, effect, inject, OnInit, signal, untracked } from '@angular/core';
-import { _, TranslateDirective } from "@ngx-translate/core";
-import { BaseApi, Paginator, ShowMorePagerComponent } from '@rero/shared';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { TranslateDirective } from "@ngx-translate/core";
+import { PaginatorComponent } from '@rero/shared';
+import { PaginatorState } from 'primeng/paginator';
 import { PanelModule } from 'primeng/panel';
-import { IllRequestApiService } from '../../api/ill-request-api.service';
 import { PatronProfileStore } from '../store/patron-profile.store';
 import { PatronProfileIllRequestComponent } from './patron-profile-ill-request/patron-profile-ill-request.component';
 
 @Component({
-    selector: 'public-search-patron-profile-ill-requests',
-    templateUrl: './patron-profile-ill-requests.component.html',
-    imports: [TranslateDirective, PanelModule, ShowMorePagerComponent, PatronProfileIllRequestComponent],
+  selector: 'public-search-patron-profile-ill-requests',
+  templateUrl: './patron-profile-ill-requests.component.html',
+  imports: [TranslateDirective, PanelModule, PaginatorComponent, PatronProfileIllRequestComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PatronProfileIllRequestsComponent implements OnInit {
+export class PatronProfileIllRequestsComponent {
 
-  private illRequestApiService = inject(IllRequestApiService);
-  private store = inject(PatronProfileStore);
+  protected store = inject(PatronProfileStore);
 
-  readonly loaded = signal(false);
-  readonly records = signal<any[]>([]);
-
-  paginator: Paginator;
-
-  constructor() {
-    effect(() => {
-      this.store.currentPatron();
-      untracked(() => this._reset());
-    });
-    effect(() => {
-      if (this.store.activeTab() === 'illRequest') {
-        untracked(() => this._initialLoad());
-      }
-    });
-  }
-
-  ngOnInit(): void {
-    this.paginator = new Paginator();
-    this.paginator.setHiddenInfo(
-      _('({{ count }} hidden ill request)'),
-      _('({{ count }} hidden ill requests)')
-    );
-    this.paginator.more$.subscribe((page: number) => {
-      this._illRequestQuery(page).subscribe((response) => {
-        if (!('hits' in response)) return;
-        this.records.update(r => [...r, ...response.hits.hits]);
-      });
-    });
-  }
-
-  private _initialLoad(): void {
-    if (!this.paginator) return;
-    this._illRequestQuery(1).subscribe((response) => {
-      if (!('hits' in response)) return;
-      this.paginator.setRecordsCount(response.hits.total.value);
-      this.records.set(response.hits.hits);
-      this.loaded.set(true);
-    });
-  }
-
-  private _reset(): void {
-    if (!this.paginator) return;
-    this.paginator.setRecordsCount(0);
-    this.records.set([]);
-    this.loaded.set(false);
-  }
-
-  private _illRequestQuery(page: number) {
-    const patronPid = this.store.currentPatron()!.pid;
-    return this.illRequestApiService.getPublicIllRequest(
-      patronPid, page, this.paginator.getRecordsPerPage(),
-      BaseApi.reroJsonheaders, '-created', { remove_archived: '1' }
-    );
+  onPageChange(event: PaginatorState): void {
+    this.store.changeIllRequestsPager(event);
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loan/patron-profile-loan.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loan/patron-profile-loan.component.html
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </public-search-patron-profile-document>
       <dl class="ui:md:hidden">
         <dt translate>Due date</dt>
-        <dd [ngClass]="{ 'ui:font-bold text-success': actionSuccess()}">{{ record()?.metadata.end_date | dateTranslate :'shortDate' }}</dd>
+        <dd [ngClass]="{ 'ui:font-bold text-success': record()?.renewed }">{{ record()?.metadata.end_date | dateTranslate :'shortDate' }}</dd>
       </dl>
       <div class="ui:md:hidden">
         <ng-container [ngTemplateOutlet]="tags" />
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <!-- DUE DATE & BADGES -->
   <div class="ui:md:col-span-2 ui:col-span-12 ui:hidden ui:md:block">
     <div>
-      <span [ngClass]="{ 'ui:font-bold text-success': actionSuccess()}">
+      <span [ngClass]="{ 'ui:font-bold text-success': record()?.renewed }">
         {{ record()?.metadata.end_date | dateTranslate :'shortDate' }}
       </span>
     </div>
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       tooltipPosition="top"
       [tooltipDisabled]="canExtend().can"
       (onClick)="renew()"
-      [disabled]="renewInProgress() || actionDone() || !canExtend().can"
+      [disabled]="store.renewingLoans() || record()?.renewed || !canExtend().can"
       [label]="'Renew' | translate"
       [icon]="renewInProgress() ? 'fa-solid fa-spin fa-spinner': 'fa-solid fa-arrows-rotate'"
     />

--- a/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loan/patron-profile-loan.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loan/patron-profile-loan.component.ts
@@ -1,17 +1,15 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { I18nPluralPipe, NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, inject, input, OnInit, signal, ChangeDetectionStrategy} from '@angular/core';
-import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { CONFIG, DateTranslatePipe } from '@rero/ng-core';
+import { Component, computed, inject, input, ChangeDetectionStrategy} from '@angular/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { DateTranslatePipe } from '@rero/ng-core';
 import { ArrayTranslatePipe, IOrganisation, JoinPipe, OpenCloseButtonComponent } from '@rero/shared';
 import { DateTime } from 'luxon';
-import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
-import { finalize } from 'rxjs/operators';
-import { CanExtend, LoanApiService } from '../../../api/loan-api.service';
+import { CanExtend } from '../../../api/loan-api.service';
 import { PatronProfileStore } from '../../store/patron-profile.store';
 import { PatronProfileDocumentComponent } from '../../patron-profile-document/patron-profile-document.component';
 
@@ -35,12 +33,9 @@ import { PatronProfileDocumentComponent } from '../../patron-profile-document/pa
     ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PatronProfileLoanComponent implements OnInit {
+export class PatronProfileLoanComponent {
 
-  private loanApiService = inject(LoanApiService);
-  private translateService = inject(TranslateService);
-  private store = inject(PatronProfileStore);
-  private messageService = inject(MessageService);
+  protected readonly store = inject(PatronProfileStore);
 
   // COMPONENT ATTRIBUTES =====================================================
   /** Loan record */
@@ -48,14 +43,12 @@ export class PatronProfileLoanComponent implements OnInit {
 
   /** Document section is collapsed */
   isCollapsed = true;
-  /** Renew action done */
-  readonly actionDone = signal(false);
-  /** Renew action success */
-  readonly actionSuccess = signal(false);
   /** Request in progress */
-  readonly renewInProgress = signal(false);
+  readonly renewInProgress = computed(
+    () => this.store.renewingLoanPid() === this.record()?.metadata.pid
+  );
   /** Loan can extend */
-  readonly canExtend = signal<CanExtend>({ can: false, reasons: {} });
+  readonly canExtend = computed<CanExtend>(() => this.record()?.canExtend ?? { can: false, reasons: {} });
   /** Fees */
   fees = 0;
 
@@ -82,51 +75,9 @@ export class PatronProfileLoanComponent implements OnInit {
     return Object.values(this.canExtend()?.reasons || {});
   }
 
-  /** OnInit hook */
-  ngOnInit(): void {
-    this.loanApiService
-      .canExtend(this.record()?.metadata?.pid)
-      .subscribe((response: CanExtend) => this.canExtend.set(response));
-  }
-
   // COMPONENTS FUNCTIONS =====================================================
   /** Renew the current loan */
   renew(): void {
-    const patronPid = this.store.currentPatron()!.pid;
-    this.renewInProgress.set(true);
-    const metadata = this.record()?.metadata;
-    this.loanApiService.renew({
-      pid: metadata?.pid,
-      item_pid: metadata?.item.pid,
-      transaction_location_pid: metadata?.item.location.pid,
-      transaction_user_pid: patronPid
-    })
-      .pipe(finalize(() => this.renewInProgress.set(false)))
-      .subscribe((extendLoan: any) => {
-      this.actionDone.set(true);
-      if (extendLoan !== undefined) {
-        this.actionSuccess.set(true);
-        const metadata = this.record()?.metadata;
-        if (metadata) {
-          ['end_date', 'extension_count', 'is_late', 'due_soon_date'].map(field => metadata[field] = extendLoan[field]);
-          if ('overdue' in metadata) {
-            delete metadata.overdue;
-          }
-        }
-        this.messageService.add({
-          severity: 'success',
-          summary: this.translateService.instant('Success'),
-          detail: this.translateService.instant('The item has been renewed.'),
-          life: CONFIG.MESSAGE_LIFE
-        });
-      } else {
-        this.messageService.add({
-          severity: 'error',
-          summary: this.translateService.instant('Error'),
-          detail: this.translateService.instant('Error during the renewal of the item.'),
-          closable: true
-        });
-      }
-    });
+    this.store.renewLoan(this.record().metadata.pid);
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loans.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loans.component.html
@@ -2,15 +2,19 @@
 SPDX-FileCopyrightText: Fondation RERO+
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
+<ngx-spinner name="renew-all-loans" color="#fff" size="medium" type="ball-zig-zag" [fullScreen]="true">
+  <p class="ui:text-white" translate>Loading…</p>
+</ngx-spinner>
+
 <!-- Due date dropdown menu -->
-@if (paginator.getRecordsCount() > 0) {
-  <section class="ui:flex ui:justify-end">
+@if (store.loans().length > 0) {
+  <section class="ui:flex ui:justify-end ui:gap-2">
     <p-select
       [options]="sortOptions"
-      [(ngModel)]="sortCriteria"
+      [ngModel]="store.loansSortCriteria()"
       optionLabel="label"
       optionValue="value"
-      (onChange)="selectingSortCriteria($event.value)">
+      (onChange)="this.store.changeLoansSortCriteria($event.value)">
       <ng-template #selectedItem let-opt>
         <span><i [class]="opt.icon" class="ui:mr-1"></i>{{ opt.label }}</span>
       </ng-template>
@@ -21,6 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   </section>
 }
 
+<section class="ui:flex ui:justify-end ui:mt-2 ui:md:hidden">
+  <p-button
+    [label]="'Renew all' | translate"
+    icon="fa fa-refresh"
+    [disabled]="store.renewableLoans().length === 0 || store.renewingLoans()"
+    (onClick)="store.renewAllLoans()" />
+</section>
+
 <!-- header -->
 <section id="loans-section" class="ui:mt-4">
   <p-panel>
@@ -28,16 +40,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <div class="ui:hidden ui:w-full ui:md:grid ui:grid-cols-12 ui:gap-4 ui:text-lg ui:font-bold ui:items-center">
         <div class="ui:col-span-8" translate>Document</div>
         <div class="ui:col-span-2" translate>Due date</div>
+        <p-button class="ui:md:col-span-2 ui:col-span-12 ui:flex ui:justify-end"
+          [label]="'Renew all' | translate"
+          icon="fa fa-refresh"
+          [disabled]="store.renewableLoans().length === 0 || store.renewingLoans()"
+          (onClick)="store.renewAllLoans()" />
       </div>
     </ng-template>
-  @if (loaded()) {
-    @if (paginator.getRecordsCount() > 0) {
-      @for (loan of records(); track $index) {
+  @if (store.loansLoaded()) {
+    @if (store.loans().length > 0) {
+      @for (loan of store.loans(); track loan.metadata.pid) {
         <div class="ui:odd:bg-surface-50 ui:my-1">
           <public-search-patron-profile-loan [record]="loan" id="loan-{{ loan.metadata.pid }}" />
         </div>
       }
-      <shared-search-show-more-pager id="show-more-loans" [paginator]="paginator" />
     } @else {
         <div class="ui:font-bold ui:mx-2 ui:my-6" translate>No loan</div>
     }

--- a/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loans.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-loans/patron-profile-loans.component.ts
@@ -1,87 +1,50 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, effect, inject, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { _, TranslateDirective, TranslateService } from "@ngx-translate/core";
-import { Paginator, ShowMorePagerComponent } from '@rero/shared';
+import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { NgxSpinnerComponent, NgxSpinnerService } from 'ngx-spinner';
+import { ButtonModule } from 'primeng/button';
 import { PanelModule } from 'primeng/panel';
 import { Select } from 'primeng/select';
-import { LoanApiService } from '../../api/loan-api.service';
 import { PatronProfileStore } from '../store/patron-profile.store';
 import { PatronProfileLoanComponent } from './patron-profile-loan/patron-profile-loan.component';
 
 @Component({
-    selector: 'public-search-patron-profile-loans',
-    templateUrl: './patron-profile-loans.component.html',
-    imports: [FormsModule, TranslateDirective, Select, PanelModule, ShowMorePagerComponent, PatronProfileLoanComponent],
+  selector: 'public-search-patron-profile-loans',
+  templateUrl: './patron-profile-loans.component.html',
+  imports: [
+    FormsModule,
+    TranslateDirective,
+    TranslatePipe,
+    NgxSpinnerComponent,
+    ButtonModule,
+    Select,
+    PanelModule,
+    PatronProfileLoanComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronProfileLoansComponent {
 
-  private loanApiService = inject(LoanApiService);
-  private store = inject(PatronProfileStore);
+  protected store = inject(PatronProfileStore);
   private translateService = inject(TranslateService);
+  private spinner = inject(NgxSpinnerService);
 
-  readonly loaded = signal(false);
-  readonly records = signal<any[]>([]);
-
-  sortCriteria = 'duedate';
+  constructor() {
+    // Spinner when renewing all loans
+    effect(() => {
+      const renewingAll = this.store.renewingLoans() && this.store.renewingLoanPid() === null;
+      void (renewingAll
+        ? this.spinner.show('renew-all-loans')
+        : this.spinner.hide('renew-all-loans'));
+    });
+  }
 
   get sortOptions() {
     return [
       { value: 'duedate', label: this.translateService.instant('Due date (earliest)'), icon: 'fa-solid fa-arrow-down-1-9' },
       { value: '-duedate', label: this.translateService.instant('Due date (latest)'), icon: 'fa-solid fa-arrow-down-9-1' },
     ];
-  }
-
-  page = 1;
-  nRecords = 20;
-  paginator: Paginator;
-
-  constructor() {
-    this.paginator = new Paginator();
-    this.paginator
-      .setRecordsPerPage(this.nRecords)
-      .setHiddenInfo(
-        _('({{ count }} hidden loan)'),
-        _('({{ count }} hidden loans)')
-      );
-    this.paginator.more$.subscribe((page: number) => {
-      this._loanQuery(page).subscribe((response) => {
-        if (!('hits' in response)) return;
-        this.records.update(r => [...r, ...response.hits.hits]);
-        this.page = page;
-      });
-    });
-    effect(() => {
-      this.store.currentPatron();
-      untracked(() => this._load());
-    });
-  }
-
-  selectingSortCriteria(sortCriteria: string): void {
-    this.sortCriteria = sortCriteria;
-    this.paginator.setRecordsPerPage(this.page * this.nRecords);
-    this._loanQuery(1).subscribe((response) => {
-      if (!('hits' in response)) return;
-      this.records.set(response.hits.hits);
-      this.paginator.setRecordsPerPage(this.nRecords);
-      this.loaded.set(true);
-    });
-  }
-
-  private _loanQuery(page: number) {
-    const patronPid = this.store.currentPatron()!.pid;
-    return this.loanApiService.getOnLoan(patronPid, page, this.paginator.getRecordsPerPage(), undefined, this.sortCriteria);
-  }
-
-  private _load(): void {
-    this.loaded.set(false);
-    this._loanQuery(1).subscribe((response) => {
-      if (!('hits' in response)) return;
-      this.paginator.setPage(1).setRecordsCount(response.hits.total.value);
-      this.records.set(response.hits.hits);
-      this.loaded.set(true);
-    });
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile-loans/types.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-loans/types.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { RecordData } from '@rero/ng-core';
+import type { CanExtend } from '../../api/loan-api.service';
+
+export type PatronLoan = RecordData<{
+  pid: string;
+  end_date: string;
+  extension_count?: number;
+  is_late?: boolean;
+  due_soon_date?: string;
+  overdue?: number;
+
+  document: {
+    pid: string;
+  };
+
+  library: {
+    name: string;
+  };
+
+  item: {
+    pid: string;
+    call_number?: string;
+    second_call_number?: string;
+
+    location: {
+      pid: string;
+    };
+  };
+}> & {
+  // Added by the store after calling canExtend()
+  canExtend?: CanExtend;
+
+  // Added locally after a successful renewal
+  renewed?: boolean;
+};

--- a/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.html
@@ -39,11 +39,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           size="small"
           id="request-cancel-{{ m.pid }}"
           (onClick)="cancel()"
-          [disabled]="cancelInProgress()"
+          [disabled]="store.cancellingRequestPid() !== null"
           [label]="'Cancel' | translate"
           outlined
           severity="danger"
-          [icon]="!(!cancelInProgress() || actionDone()) ? 'fa-solid fa-spinner': 'fa-solid fa-trash-can'"
+          [icon]="cancelInProgress() ? 'fa-solid fa-spinner': 'fa-solid fa-trash-can'"
         />
       }
     </div>

--- a/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.spec.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.spec.ts
@@ -11,6 +11,9 @@ import { cloneDeep } from 'lodash-es';
 import { of } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { LoanApiService } from '../../../api/loan-api.service';
+import { IllRequestApiService } from '../../../api/ill-request-api.service';
+import { PatronApiService } from '../../../api/patron-api.service';
+import { PatronTransactionApiService } from '../../../api/patron-transaction-api.service';
 import { PatronProfileStore } from '../../store/patron-profile.store';
 import { PatronProfileRequestComponent } from './patron-profile-request.component';
 
@@ -46,8 +49,23 @@ describe('PatronProfileRequestComponent', () => {
     ],
     providers: [
       { provide: AppStore, useValue: appStoreSpy },
-        { provide: LoanApiService, useValue: { cancel: vi.fn().mockReturnValue(of(null)) } },
+        {
+          provide: LoanApiService,
+          useValue: {
+            cancel: vi.fn().mockReturnValue(of(null)),
+            getOnLoan: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+            getRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
+        {
+          provide: IllRequestApiService,
+          useValue: {
+            getPublicIllRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
         { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: PatronTransactionApiService, useValue: { getFees: vi.fn().mockReturnValue(of({ hits: { hits: [] } })) } },
+        { provide: PatronApiService, useValue: { getOverduePreviewByPatronPid: vi.fn().mockReturnValue(of([])) } },
         { provide: RecordService, useValue: { getRecord: vi.fn().mockReturnValue(of({ metadata: {} })), MAX_REST_RESULTS_SIZE: 1000 } },
         provideHttpClient(),
         provideHttpClientTesting()

--- a/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-request/patron-profile-request.component.ts
@@ -1,77 +1,46 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, inject, input, signal, ChangeDetectionStrategy} from '@angular/core';
-import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { CONFIG, DateTranslatePipe, RecordData } from '@rero/ng-core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { DateTranslatePipe, RecordData } from '@rero/ng-core';
 import { OpenCloseButtonComponent } from '@rero/shared';
-import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { LoanApiService } from '../../../api/loan-api.service';
-import { PatronProfileStore } from '../../store/patron-profile.store';
 import { PatronProfileDocumentComponent } from '../../patron-profile-document/patron-profile-document.component';
+import { PatronProfileStore } from '../../store/patron-profile.store';
 
 @Component({
-    selector: 'public-search-patron-profile-request',
-    templateUrl: './patron-profile-request.component.html',
-    imports: [NgClass, NgTemplateOutlet, TranslateDirective, TranslatePipe, DateTranslatePipe, OpenCloseButtonComponent, ButtonModule, PatronProfileDocumentComponent],
+  selector: 'public-search-patron-profile-request',
+  templateUrl: './patron-profile-request.component.html',
+  imports: [NgClass, NgTemplateOutlet, TranslateDirective, TranslatePipe, DateTranslatePipe, OpenCloseButtonComponent, ButtonModule, PatronProfileDocumentComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronProfileRequestComponent {
 
-  private loanApiService = inject(LoanApiService);
-  private translateService = inject(TranslateService);
-  private store = inject(PatronProfileStore);
-  private messageService = inject(MessageService);
+  protected readonly store = inject(PatronProfileStore);
 
+  // COMPONENT ATTRIBUTES =====================================================
   /** Request record */
   record = input<RecordData>();
 
   /** Document section is collapsed */
   isCollapsed = true;
 
-  /** Renew action done */
-  readonly actionDone = signal(false);
-
-  /** Cancel action success */
-  readonly actionSuccess = signal(false);
-
   /** Cancel in progress */
-  readonly cancelInProgress = signal(false);
+  readonly cancelInProgress = computed(
+    () => this.store.cancellingRequestPid() === this.record()?.metadata.pid
+  );
 
+  // GETTER & SETTER ==========================================================
   /** Get current viewcode */
   get viewcode(): string {
     return this.store.currentPatron()?.organisation.code ?? '';
   }
 
+  // COMPONENTS FUNCTIONS =====================================================
   /** Cancel a request */
   cancel(): void {
-    const patronPid = this.store.currentPatron()!.pid;
-    this.cancelInProgress.set(true);
-    const metadata = this.record()?.metadata as any;
-    this.loanApiService.cancel({
-      pid: metadata?.pid,
-      transaction_location_pid: metadata?.item.location.pid,
-      transaction_user_pid: patronPid
-    }).subscribe((cancelLoan: any) => {
-      if (cancelLoan !== undefined) {
-        this.store.cancelRequest(metadata?.pid);
-        this.actionDone.set(true);
-        this.messageService.add({
-          severity: 'success',
-          summary: this.translateService.instant('Success'),
-          detail: this.translateService.instant('The request has been cancelled.'),
-          life: CONFIG.MESSAGE_LIFE
-        });
-      } else {
-        this.cancelInProgress.set(false);
-        this.messageService.add({
-          severity: 'error',
-          summary: this.translateService.instant('Error'),
-          detail: this.translateService.instant('Error during the cancellation of the request.'),
-          closable: true
-        });
-      }
-    });
+    const requestPid = this.record()?.metadata.pid;
+    if (typeof requestPid === 'string') this.store.cancelPatronRequest(requestPid);
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-requests.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-requests.component.html
@@ -11,14 +11,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </div>
     </ng-template>
 
-  @defer (when loaded()) {
-    @if (paginator.getRecordsCount() > 0) {
-      @for (request of records(); track $index) {
+  @defer (when store.requestsLoaded()) {
+    @if (store.requestsTotal() > 0) {
+      @for (request of store.requests(); track request.metadata.pid) {
         <div class="ui:odd:bg-surface-50 ui:my-1">
           <public-search-patron-profile-request [record]="request" id="request-{{ request.metadata.pid }}" />
         </div>
       }
-      <shared-search-show-more-pager id="show-more-requests" [paginator]="paginator" />
+      <shared-paginator
+        [pager]="store.requestPager()"
+        [total]="store.requestsTotal()"
+        (pageChange)="onPageChange($event)" />
     } @else {
         <div class="ui:font-bold ui:mx-2 ui:my-6" translate>No request</div>
     }

--- a/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-requests.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-requests/patron-profile-requests.component.ts
@@ -1,83 +1,26 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, effect, inject, OnInit, signal, untracked } from '@angular/core';
-import { _, TranslateDirective } from "@ngx-translate/core";
-import { Paginator, ShowMorePagerComponent } from '@rero/shared';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { TranslateDirective } from "@ngx-translate/core";
+import { PaginatorComponent } from '@rero/shared';
 import { PanelModule } from 'primeng/panel';
-import { LoanApiService } from '../../api/loan-api.service';
+import { PaginatorState } from 'primeng/paginator';
 import { PatronProfileStore } from '../store/patron-profile.store';
 import { PatronProfileRequestComponent } from './patron-profile-request/patron-profile-request.component';
 
 @Component({
     selector: 'public-search-patron-profile-requests',
     templateUrl: './patron-profile-requests.component.html',
-    imports: [TranslateDirective, PanelModule, ShowMorePagerComponent, PatronProfileRequestComponent],
+    imports: [TranslateDirective, PanelModule, PaginatorComponent, PatronProfileRequestComponent],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PatronProfileRequestsComponent implements OnInit {
+export class PatronProfileRequestsComponent {
 
-  private loanApiService = inject(LoanApiService);
-  private store = inject(PatronProfileStore);
+  protected store = inject(PatronProfileStore);
 
-  readonly loaded = signal(false);
-  readonly records = signal<any[]>([]);
-
-  paginator: Paginator;
-
-  constructor() {
-    effect(() => {
-      this.store.currentPatron();
-      untracked(() => this._reset());
-    });
-    effect(() => {
-      if (this.store.activeTab() === 'request') {
-        untracked(() => this._initialLoad());
-      }
-    });
-    effect(() => {
-      const pid = this.store.cancelledRequestPid();
-      if (pid) {
-        untracked(() => {
-          this.records.update(r => r.filter(record => record.metadata.pid !== pid));
-          if (this.paginator) this.paginator.setRecordsCount(this.records().length);
-        });
-      }
-    });
-  }
-
-  ngOnInit(): void {
-    this.paginator = new Paginator();
-    this.paginator.setHiddenInfo(
-      _('({{ count }} hidden request)'),
-      _('({{ count }} hidden requests)')
-    );
-    this.paginator.more$.subscribe((page: number) => {
-      this._requestQuery(page).subscribe((response) => {
-        if (!('hits' in response)) return;
-        this.records.update(r => [...r, ...response.hits.hits]);
-      });
-    });
-  }
-
-  private _initialLoad(): void {
-    if (!this.paginator) return;
-    this._requestQuery(1).subscribe((response) => {
-      if (!('hits' in response)) return;
-      this.paginator.setRecordsCount(response.hits.total.value);
-      this.records.set(response.hits.hits);
-      this.loaded.set(true);
-    });
-  }
-
-  private _reset(): void {
-    if (!this.paginator) return;
-    this.paginator.setRecordsCount(0);
-    this.records.set([]);
-    this.loaded.set(false);
-  }
-
-  private _requestQuery(page: number) {
-    const patronPid = this.store.currentPatron()!.pid;
-    return this.loanApiService.getRequest(patronPid, page, this.paginator.getRecordsPerPage());
+  // COMPONENTS FUNCTIONS =====================================================
+  /** Update the pager; the store loads the selected page automatically. */
+  onPageChange(event: PaginatorState): void {
+    this.store.changeRequestPager(event);
   }
 }

--- a/projects/public-search/src/app/patron-profile/patron-profile.component.html
+++ b/projects/public-search/src/app/patron-profile/patron-profile.component.html
@@ -11,7 +11,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <public-search-patron-profile-menu [patronPid]="patron.pid" />
 </section>
 <section class="ui:mt-4">
-  <p-toast />
   <public-search-patron-profile-message />
 </section>
 

--- a/projects/public-search/src/app/patron-profile/patron-profile.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile.component.ts
@@ -1,32 +1,31 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { APP_BASE_HREF, CurrencyPipe, KeyValue, KeyValuePipe } from '@angular/common';
-import { afterNextRender, Component, effect, inject, model, OnInit, signal, untracked, ChangeDetectionStrategy} from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, effect, inject, model, OnInit, signal, untracked } from '@angular/core';
 import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { RecordService } from '@rero/ng-core';
 import type { EsResult } from '@rero/ng-core';
+import { RecordService } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
 import JsBarcode from 'jsbarcode';
-import { forkJoin, of } from 'rxjs';
 import { BadgeModule } from 'primeng/badge';
 import { TabsModule } from 'primeng/tabs';
-import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
+import { forkJoin, of } from 'rxjs';
 import { IllRequestApiService } from '../api/ill-request-api.service';
 import { LoanApiService } from '../api/loan-api.service';
 import { OperationLogsApiService } from '../api/operation-logs-api.service';
-import { PatronTransactionApiService } from '../api/patron-transaction-api.service';
 import { PatronApiService } from '../api/patron-api.service';
-import { overdueFee } from './patron-profile-fees/types';
-import { PatronProfileStore } from './store/patron-profile.store';
-import { PatronProfileMenuComponent } from './patron-profile-menu/patron-profile-menu.component';
-import { PatronProfileMessageComponent } from './patron-profile-message/patron-profile-message.component';
-import { PatronProfileLoansComponent } from './patron-profile-loans/patron-profile-loans.component';
-import { PatronProfileRequestsComponent } from './patron-profile-requests/patron-profile-requests.component';
+import { PatronTransactionApiService } from '../api/patron-transaction-api.service';
 import { PatronProfileFeesComponent } from './patron-profile-fees/patron-profile-fees.component';
+import { OverdueFee } from './patron-profile-fees/types';
 import { PatronProfileHistoriesComponent } from './patron-profile-histories/patron-profile-histories.component';
 import { PatronProfileIllRequestsComponent } from './patron-profile-ill-requests/patron-profile-ill-requests.component';
+import { PatronProfileLoansComponent } from './patron-profile-loans/patron-profile-loans.component';
+import { PatronProfileMenuComponent } from './patron-profile-menu/patron-profile-menu.component';
+import { PatronProfileMessageComponent } from './patron-profile-message/patron-profile-message.component';
 import { PatronProfilePersonalComponent } from './patron-profile-personal/patron-profile-personal.component';
+import { PatronProfileRequestsComponent } from './patron-profile-requests/patron-profile-requests.component';
+import { PatronProfileStore } from './store/patron-profile.store';
 
 type Tab = {
   loaded?: boolean;
@@ -48,26 +47,25 @@ type Tabs = {
 }
 
 @Component({
-    selector: 'public-search-patron-profile',
-    templateUrl: './patron-profile.component.html',
-    imports: [
-      CurrencyPipe,
-      KeyValuePipe,
-      TranslateDirective,
-      TranslatePipe,
-      BadgeModule,
-      TabsModule,
-      ToastModule,
-      TooltipModule,
-      PatronProfileMenuComponent,
-      PatronProfileMessageComponent,
-      PatronProfileLoansComponent,
-      PatronProfileRequestsComponent,
-      PatronProfileFeesComponent,
-      PatronProfileHistoriesComponent,
-      PatronProfileIllRequestsComponent,
-      PatronProfilePersonalComponent,
-    ],
+  selector: 'public-search-patron-profile',
+  templateUrl: './patron-profile.component.html',
+  imports: [
+    CurrencyPipe,
+    KeyValuePipe,
+    TranslateDirective,
+    TranslatePipe,
+    BadgeModule,
+    TabsModule,
+    TooltipModule,
+    PatronProfileMenuComponent,
+    PatronProfileMessageComponent,
+    PatronProfileLoansComponent,
+    PatronProfileRequestsComponent,
+    PatronProfileFeesComponent,
+    PatronProfileHistoriesComponent,
+    PatronProfileIllRequestsComponent,
+    PatronProfilePersonalComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronProfileComponent implements OnInit {
@@ -76,7 +74,7 @@ export class PatronProfileComponent implements OnInit {
   private loanApiService = inject(LoanApiService);
   private illRequestApiService = inject(IllRequestApiService);
   private appStore = inject(AppStore);
-  private store = inject(PatronProfileStore);
+  protected store = inject(PatronProfileStore);
   private operationLogsApiService = inject(OperationLogsApiService);
   private translateService = inject(TranslateService);
   private patronApiService = inject(PatronApiService);
@@ -221,10 +219,10 @@ export class PatronProfileComponent implements OnInit {
       this.illRequestApiService.getPublicIllRequest(patronPid, 1, 1, undefined, '', { remove_archived: '1' }),
     ]).subscribe((results) => {
       const [loanResponse, requestResponse, feeResponse, overdueResponse, historyResponse, illRequestResponse] =
-        results as [EsResult, EsResult, EsResult, overdueFee[], EsResult, EsResult];
+        results as [EsResult, EsResult, EsResult, OverdueFee[], EsResult, EsResult];
       this.activeTab.set('loan');
       const feeTotal = overdueResponse.reduce(
-        (acc: number, fee: overdueFee) => acc + +fee.fees.total,
+        (acc: number, fee: OverdueFee) => acc + +fee.fees.total,
         (feeResponse.aggregations as any).total.value
       );
       this.tabs.update(t => ({

--- a/projects/public-search/src/app/patron-profile/store/fees-feature.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/fees-feature.spec.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { signalStore, withMethods, withProps } from '@ngrx/signals';
+import { RecordService } from '@rero/ng-core';
+import { of, Subject, throwError } from 'rxjs';
+import { PatronApiService } from '../../api/patron-api.service';
+import { PatronTransactionApiService } from '../../api/patron-transaction-api.service';
+import { withFeesFeature } from './fees-feature';
+
+const FeesFeatureStore = signalStore(
+  withProps(() => ({ patronPid: signal<string | null>(null) })),
+  withMethods(store => ({
+    setPatronPid(patronPid: string | null): void {
+      store.patronPid.set(patronPid);
+    },
+  })),
+  withFeesFeature()
+);
+
+describe('FeesFeature', () => {
+  let store: InstanceType<typeof FeesFeatureStore>;
+  const patronTransactionApiService = { getFees: vi.fn() };
+  const patronApiService = { getOverduePreviewByPatronPid: vi.fn() };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = TestBed.configureTestingModule({
+      providers: [
+        FeesFeatureStore,
+        { provide: PatronTransactionApiService, useValue: patronTransactionApiService },
+        { provide: PatronApiService, useValue: patronApiService },
+      ],
+    }).inject(FeesFeatureStore);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('clears previous fees while a new request is pending', () => {
+    patronTransactionApiService.getFees.mockReturnValueOnce(of({
+      hits: {
+        hits: [{
+          metadata: {
+            type: 'manual',
+            creation_date: '2026-06-01',
+            total_amount: 5,
+          },
+        }],
+      },
+    }));
+    patronApiService.getOverduePreviewByPatronPid.mockReturnValueOnce(of([]));
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+    expect(store.fees()).toHaveLength(1);
+    expect(store.feesLoaded()).toBe(true);
+
+    const feesResponse = new Subject<{ hits: { hits: unknown[] } }>();
+    const overdueResponse = new Subject<unknown[]>();
+    patronTransactionApiService.getFees.mockReturnValueOnce(feesResponse);
+    patronApiService.getOverduePreviewByPatronPid.mockReturnValueOnce(overdueResponse);
+
+    store.setPatronPid('patron-2');
+    TestBed.tick();
+
+    expect(store.fees()).toEqual([]);
+    expect(store.feesLoaded()).toBe(false);
+
+    feesResponse.next({ hits: { hits: [] } });
+    feesResponse.complete();
+    overdueResponse.next([]);
+    overdueResponse.complete();
+  });
+
+  it('groups fee transactions with their overdue fee by loan', () => {
+    patronTransactionApiService.getFees.mockReturnValue(of({
+      hits: {
+        hits: [{
+          metadata: {
+            type: 'manual',
+            creation_date: '2026-06-01',
+            total_amount: 4,
+            note: 'First fee',
+            loan: { pid: 'loan-1' },
+          },
+        }],
+      },
+    }));
+    patronApiService.getOverduePreviewByPatronPid.mockReturnValue(of([{
+      loan: { pid: 'loan-1' },
+      fees: { steps: [], total: 2 },
+    }]));
+
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    expect(patronTransactionApiService.getFees).toHaveBeenCalledWith(
+      'patron-1',
+      'open',
+      1,
+      RecordService.MAX_REST_RESULTS_SIZE
+    );
+    expect(patronApiService.getOverduePreviewByPatronPid).toHaveBeenCalledWith('patron-1');
+    expect(store.feesLoaded()).toBe(true);
+    expect(store.fees()).toHaveLength(1);
+    expect(store.fees()[0]).toMatchObject({
+      type: 'manual',
+      totalAmount: 6,
+      overdue: 2,
+      notes: ['First fee'],
+      loan: { pid: 'loan-1' },
+    });
+  });
+
+  it('ends loading when a backend request fails', () => {
+    const error = new Error('Unable to load fees');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    patronTransactionApiService.getFees.mockReturnValue(throwError(() => error));
+    patronApiService.getOverduePreviewByPatronPid.mockReturnValue(of([]));
+
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    expect(store.fees()).toEqual([]);
+    expect(store.feesLoaded()).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith(error);
+    consoleError.mockRestore();
+  });
+});

--- a/projects/public-search/src/app/patron-profile/store/fees-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/fees-feature.ts
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { inject, type Signal } from '@angular/core';
+import { patchState, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import type { EsResult } from '@rero/ng-core';
+import { RecordService } from '@rero/ng-core';
+import { catchError, finalize, forkJoin, of, pipe, switchMap, tap } from 'rxjs';
+import { PatronApiService } from '../../api/patron-api.service';
+import { PatronTransactionApiService } from '../../api/patron-transaction-api.service';
+import { Fee, OverdueFee } from '../patron-profile-fees/types';
+
+type FeesFeatureState = {
+  fees: Fee[];
+  feesLoaded: boolean;
+};
+
+/**
+ * Merge transaction fees and overdue fees belonging to the same loan.
+ */
+function buildFees(feesResponse: EsResult, overdueResponse: OverdueFee[]): Fee[] {
+  const records: Fee[] = [];
+  feesResponse.hits.hits.map((record: any) => {
+    if (record.metadata?.loan) {
+      const fee = records.find((fee: Fee) => record.metadata?.loan?.pid === fee.loan?.pid);
+      if (fee) {
+        if (record.metadata.note) {
+          fee.notes.push(record.metadata.note);
+        }
+        fee.totalAmount += record.metadata.total_amount;
+        fee.transactions.push(record);
+      } else {
+        records.push(buildFee(record));
+      }
+    } else {
+      records.push(buildFee(record));
+    }
+  });
+  overdueResponse.map((overdue: OverdueFee) => {
+    const fee = records.find((record: Fee) => record.loan?.pid === overdue.loan.pid);
+    if (fee) {
+      fee.totalAmount += overdue.fees.total;
+      fee.overdue = overdue.fees.total;
+    } else {
+      records.push({
+        type: 'overdue',
+        createdAt: new Date(),
+        notes: [],
+        loan: overdue.loan,
+        totalAmount: overdue.fees.total,
+        overdue: overdue.fees.total,
+        transactions: []
+      });
+    }
+  });
+  records.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  return records;
+}
+
+/** Build a fee displayed in the patron profile. */
+function buildFee(record: any): Fee {
+  const result: Fee = {
+    type: record.metadata.type,
+    notes: [],
+    createdAt: new Date(record.metadata.creation_date),
+    totalAmount: record.metadata.total_amount,
+    transactions: [record]
+  };
+  if (record.metadata.note) {
+    result.notes.push(record.metadata.note);
+  }
+  if (record.metadata.loan) {
+    result.loan = record.metadata.loan;
+  }
+  return result;
+}
+
+/** Add fee state and loading methods to the patron profile store. */
+export function withFeesFeature<_>() {
+  return signalStoreFeature(
+    { props: type<{ patronPid: Signal<string | null> }>() },
+    withState<FeesFeatureState>({
+      fees: [],
+      feesLoaded: false,
+    }),
+    withMethods((
+      store,
+      patronTransactionApiService = inject(PatronTransactionApiService),
+      patronApiService = inject(PatronApiService)
+    ) => ({
+      resetFees(): void {
+        patchState(store, {
+          fees: [],
+          feesLoaded: false,
+        });
+      },
+      /**
+       * Load transaction and overdue fees together for the current patron.
+       */
+      loadFees: rxMethod<string | null>(
+        pipe(
+          switchMap(patronPid => {
+            if (!patronPid) return of([]);
+
+            patchState(store, {
+              fees: [],
+              feesLoaded: false,
+            });
+            const queryFees = patronTransactionApiService.getFees(
+              patronPid,
+              'open',
+              1,
+              RecordService.MAX_REST_RESULTS_SIZE
+            );
+            const queryOverdue = patronApiService.getOverduePreviewByPatronPid(patronPid);
+
+            return forkJoin([queryFees, queryOverdue]).pipe(
+              tap(([feesResponse, overdueResponse]) => {
+                if (!('hits' in feesResponse)) {
+                  throw feesResponse;
+                }
+
+                const fees = buildFees(feesResponse, overdueResponse);
+
+                patchState(store, { fees });
+              }),
+              catchError(error => {
+                console.error(error);
+                return of(null);
+              }),
+              finalize(() => patchState(store, { feesLoaded: true }))
+            );
+          })
+        )
+      ),
+    })),
+    withHooks({
+      onInit(store) {
+        store.loadFees(store.patronPid);
+      },
+    })
+  );
+}

--- a/projects/public-search/src/app/patron-profile/store/ill-requests-feature.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/ill-requests-feature.spec.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { patchState, signalStore, withMethods, withProps, withState } from '@ngrx/signals';
+import { BaseApi } from '@rero/shared';
+import { of } from 'rxjs';
+import { IllRequestApiService } from '../../api/ill-request-api.service';
+import { withIllRequestsFeature } from './ill-requests-feature';
+
+const IllRequestsFeatureStore = signalStore(
+  withState({ activeTab: null as string | null }),
+  withProps(() => ({ patronPid: signal<string | null>(null) })),
+  withMethods(store => ({
+    setPatronPid(patronPid: string | null): void {
+      store.patronPid.set(patronPid);
+    },
+    setActiveTab(activeTab: string | null): void {
+      patchState(store, { activeTab });
+    },
+  })),
+  withIllRequestsFeature()
+);
+
+describe('IllRequestsFeature', () => {
+  let store: InstanceType<typeof IllRequestsFeatureStore>;
+  const illRequestApiService = { getPublicIllRequest: vi.fn() };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = TestBed.configureTestingModule({
+      providers: [
+        IllRequestsFeatureStore,
+        { provide: IllRequestApiService, useValue: illRequestApiService },
+      ],
+    }).inject(IllRequestsFeatureStore);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('initializes ILL request pager state', () => {
+    expect(store.illRequestsPager()).toEqual({
+      page: 1,
+      first: 1,
+      rows: 10,
+      rowsPerPageOptions: [10, 20, 50],
+    });
+  });
+
+  it('changes ILL request pager', () => {
+    store.changeIllRequestsPager({ page: 1, first: 10, rows: 10 });
+
+    expect(store.illRequestsPager().page).toBe(2);
+    expect(store.illRequestsPager().first).toBe(11);
+  });
+
+  it('resets ILL request state', () => {
+    store.changeIllRequestsPager({
+      page: 1,
+      first: 10,
+      rows: 10,
+    });
+
+    store.resetIllRequests();
+
+    expect(store.illRequests()).toEqual([]);
+    expect(store.illRequestsTotal()).toBe(0);
+    expect(store.illRequestsLoaded()).toBe(false);
+    expect(store.illRequestsPager().page).toBe(1);
+    expect(store.illRequestsPager().first).toBe(1);
+  });
+
+  it('loads the selected public ILL request page', () => {
+    const request = { metadata: { pid: 'ill-1' } };
+    const secondRequest = { metadata: { pid: 'ill-2' } };
+    illRequestApiService.getPublicIllRequest
+      .mockReturnValueOnce(of({ hits: { hits: [request], total: { value: 2 } } }))
+      .mockReturnValueOnce(of({ hits: { hits: [secondRequest], total: { value: 2 } } }));
+
+    store.setPatronPid('patron-1');
+    store.setActiveTab('illRequest');
+    TestBed.tick();
+    store.changeIllRequestsPager({ page: 1, first: 10, rows: 10 });
+    TestBed.tick();
+
+    expect(illRequestApiService.getPublicIllRequest).toHaveBeenNthCalledWith(
+      1,
+      'patron-1',
+      1,
+      10,
+      BaseApi.reroJsonheaders,
+      '-created',
+      { remove_archived: '1' }
+    );
+    expect(illRequestApiService.getPublicIllRequest).toHaveBeenNthCalledWith(
+      2,
+      'patron-1',
+      2,
+      10,
+      BaseApi.reroJsonheaders,
+      '-created',
+      { remove_archived: '1' }
+    );
+    expect(store.illRequests()).toEqual([secondRequest]);
+    expect(store.illRequestsTotal()).toBe(2);
+    expect(store.illRequestsLoaded()).toBe(true);
+  });
+});

--- a/projects/public-search/src/app/patron-profile/store/ill-requests-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/ill-requests-feature.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { computed, inject, type Signal } from '@angular/core';
+import { patchState, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { BaseApi, nextPager, Pager } from '@rero/shared';
+import { PaginatorState } from 'primeng/paginator';
+import { catchError, finalize, of, pipe, switchMap, tap } from 'rxjs';
+import { IllRequestApiService } from '../../api/ill-request-api.service';
+
+type IllRequestsFeatureState = {
+  illRequests: any[];
+  illRequestsTotal: number;
+  illRequestsLoaded: boolean;
+  illRequestsPager: Pager;
+};
+
+type LoadIllRequestsInput = {
+  patronPid: string | null;
+  active: boolean;
+  page: number;
+  recordsPerPage: number;
+};
+
+const initialIllRequestsPager: Pager = {
+  page: 1,
+  first: 1,
+  rows: 10,
+  rowsPerPageOptions: [10, 20, 50]
+};
+
+/** Add ILL request state and pagination to the patron profile store. */
+export function withIllRequestsFeature<_>() {
+  return signalStoreFeature(
+    {
+      state: type<{ activeTab: string | null }>(),
+      props: type<{
+        patronPid: Signal<string | null>;
+      }>(),
+    },
+    withState<IllRequestsFeatureState>({
+      illRequests: [],
+      illRequestsTotal: 0,
+      illRequestsLoaded: false,
+      illRequestsPager: initialIllRequestsPager,
+    }),
+    withMethods((store, illRequestApiService = inject(IllRequestApiService)) => ({
+      /** Clear ILL requests and restore the first page for another patron. */
+      resetIllRequests(): void {
+        patchState(store, {
+          illRequests: [],
+          illRequestsTotal: 0,
+          illRequestsLoaded: false,
+          illRequestsPager: initialIllRequestsPager,
+        });
+      },
+      /** Store the new page; the reactive loader performs the API call. */
+      changeIllRequestsPager(event: PaginatorState): void {
+        patchState(store, {
+          illRequestsPager: nextPager(store.illRequestsPager(), event),
+        });
+      },
+      /** Load the active ILL request page whenever one of its inputs changes. */
+      loadIllRequests: rxMethod<LoadIllRequestsInput>(
+        pipe(
+          switchMap(({ patronPid, active, page, recordsPerPage }) => {
+            if (!patronPid || !active) return of([]);
+
+            patchState(store, { illRequestsLoaded: false });
+
+            return illRequestApiService.getPublicIllRequest(
+              patronPid,
+              page,
+              recordsPerPage,
+              BaseApi.reroJsonheaders,
+              '-created',
+              { remove_archived: '1' }
+            ).pipe(
+              tap(response => {
+                if (!('hits' in response)) return;
+                patchState(store, {
+                  illRequests: response.hits.hits,
+                  illRequestsTotal: response.hits.total.value,
+                });
+              }),
+              catchError(error => {
+                console.error(error);
+                return of(null);
+              }),
+              finalize(() => patchState(store, { illRequestsLoaded: true }))
+            );
+          })
+        )
+      )
+    })),
+    withHooks({
+      onInit(store) {
+        store.loadIllRequests(computed(() => ({
+          patronPid: store.patronPid(),
+          active: store.activeTab() === 'illRequest',
+          page: store.illRequestsPager().page,
+          recordsPerPage: store.illRequestsPager().rows,
+        })));
+      },
+    })
+  );
+}

--- a/projects/public-search/src/app/patron-profile/store/loans-feature.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/loans-feature.spec.ts
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { signalStore, withMethods, withProps } from '@ngrx/signals';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG } from '@rero/ng-core';
+import { MessageService } from 'primeng/api';
+import { of, Subject, throwError } from 'rxjs';
+import { LoanApiService } from '../../api/loan-api.service';
+import { withLoansFeature } from './loans-feature';
+
+type RenewalResponse = {
+  end_date: string;
+  extension_count: number;
+  is_late: boolean;
+  due_soon_date: string;
+};
+
+const LoansFeatureStore = signalStore(
+  withProps(() => ({ patronPid: signal<string | null>(null) })),
+  withMethods(store => ({
+    setPatronPid(patronPid: string | null): void {
+      store.patronPid.set(patronPid);
+    },
+  })),
+  withLoansFeature()
+);
+
+describe('LoansFeature', () => {
+  let store: InstanceType<typeof LoansFeatureStore>;
+  const loanApiService = {
+    getOnLoan: vi.fn(),
+    canExtend: vi.fn(),
+    renew: vi.fn(),
+  };
+  const translateService = {
+    instant: vi.fn((value: string) => value),
+  };
+  const messageService = {
+    add: vi.fn(),
+  };
+
+  const loan = {
+    metadata: {
+      pid: 'loan-1',
+      item: { pid: 'item-1', location: { pid: 'location-1' } },
+      end_date: '2026-07-02',
+      overdue: 2,
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loanApiService.canExtend.mockReturnValue(of(undefined));
+    store = TestBed.configureTestingModule({
+      providers: [
+        LoansFeatureStore,
+        { provide: LoanApiService, useValue: loanApiService },
+        { provide: TranslateService, useValue: translateService },
+        { provide: MessageService, useValue: messageService },
+      ],
+    }).inject(LoansFeatureStore);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('changes the loan sort criteria', () => {
+    store.changeLoansSortCriteria('-duedate');
+
+    expect(store.loansSortCriteria()).toBe('-duedate');
+  });
+
+  it('loads the first page of loans into store state', () => {
+    loanApiService.getOnLoan.mockReturnValue(of({ hits: { hits: [loan], total: { value: 1 } } }));
+
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    expect(loanApiService.getOnLoan).toHaveBeenCalledWith('patron-1', 1, 9999, undefined, 'duedate');
+    expect(store.loans()).toEqual([loan]);
+    expect(store.loansLoaded()).toBe(true);
+  });
+
+  it('stores can-extend results on the matching loan', () => {
+    const result = { can: true, reasons: {} };
+    loanApiService.getOnLoan.mockReturnValue(of({ hits: { hits: [loan], total: { value: 1 } } }));
+    loanApiService.canExtend.mockReturnValue(of(result));
+
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    expect(loanApiService.canExtend).toHaveBeenCalledWith('loan-1');
+    expect(store.loans()[0].canExtend).toEqual(result);
+    expect(store.renewableLoans()).toEqual([store.loans()[0]]);
+  });
+
+  it('updates the matching loan after a successful renewal', () => {
+    const otherLoan = { metadata: { pid: 'loan-2', overdue: 1 } };
+    loanApiService.getOnLoan.mockReturnValue(of({ hits: { hits: [loan, otherLoan], total: { value: 2 } } }));
+    loanApiService.renew.mockReturnValue(of({
+      end_date: '2026-07-01',
+      extension_count: 2,
+      is_late: false,
+      due_soon_date: '2026-06-30',
+    }));
+    loanApiService.canExtend.mockImplementation((loanPid: string) => of(
+      loanPid === 'loan-1' ? { can: false, reasons: {} } : undefined
+    ));
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    store.renewLoan('loan-1');
+
+    expect(loanApiService.renew).toHaveBeenCalledWith({
+      pid: 'loan-1',
+      item_pid: 'item-1',
+      transaction_location_pid: 'location-1',
+      transaction_user_pid: 'patron-1',
+    });
+    expect(store.loans()[0].metadata).toMatchObject({
+      pid: 'loan-1',
+      end_date: '2026-07-01',
+      extension_count: 2,
+      is_late: false,
+      due_soon_date: '2026-06-30',
+    });
+    expect(store.loans()[0].metadata).not.toHaveProperty('overdue');
+    expect(store.loans()[0].renewed).toBe(true);
+    expect(loanApiService.canExtend).toHaveBeenCalledWith('loan-1');
+    expect(store.loans()[0].canExtend).toEqual({ can: false, reasons: {} });
+    expect(store.renewableLoans()).toEqual([]);
+    expect(store.renewingLoans()).toBe(false);
+    expect(store.renewingLoanPid()).toBeNull();
+    expect(store.loans()[1]).toEqual(otherLoan);
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Success',
+      detail: 'The item has been renewed.',
+      life: CONFIG.MESSAGE_LIFE,
+    });
+  });
+
+  it('handles an error while renewing one loan', () => {
+    loanApiService.getOnLoan.mockReturnValue(of({ hits: { hits: [loan], total: { value: 1 } } }));
+    loanApiService.renew.mockReturnValue(throwError(() => new Error('Renewal failed')));
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    store.renewLoan('loan-1');
+
+    expect(store.renewingLoans()).toBe(false);
+    expect(store.renewingLoanPid()).toBeNull();
+    expect(store.loans()[0].renewed).toBeUndefined();
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'Error during the renewal of the item.',
+      closable: true,
+    });
+  });
+
+  it('renews every stored loan that can be extended sequentially', () => {
+    const renewableLoan = {
+      metadata: {
+        pid: 'loan-2',
+        item: { pid: 'item-2', location: { pid: 'location-2' } },
+        end_date: '2026-07-01',
+      },
+      canExtend: { can: true, reasons: {} },
+    };
+    const nonRenewableLoan = {
+      metadata: {
+        pid: 'loan-3',
+        item: { pid: 'item-3', location: { pid: 'location-3' } },
+      },
+      canExtend: { can: false, reasons: { blocked: 'Blocked' } },
+    };
+    loanApiService.getOnLoan.mockReturnValue(of({
+      hits: { hits: [{ ...loan, canExtend: { can: true, reasons: {} } }, renewableLoan, nonRenewableLoan], total: { value: 3 } },
+    }));
+    const firstRenewal = new Subject<RenewalResponse>();
+    const secondRenewal = new Subject<RenewalResponse>();
+    loanApiService.renew
+      .mockReturnValueOnce(firstRenewal)
+      .mockReturnValueOnce(secondRenewal);
+    loanApiService.canExtend.mockImplementation((loanPid: string) => of(
+      loanPid === 'loan-3'
+        ? { can: false, reasons: { blocked: 'Blocked' } }
+        : { can: true, reasons: {} }
+    ));
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    store.renewAllLoans();
+    store.renewAllLoans();
+
+    expect(loanApiService.renew).toHaveBeenCalledTimes(1);
+    expect(loanApiService.renew).toHaveBeenCalledWith(expect.objectContaining({ pid: 'loan-2' }));
+    expect(store.renewingLoans()).toBe(true);
+
+    firstRenewal.next({
+      end_date: '2026-07-01',
+      extension_count: 1,
+      is_late: false,
+      due_soon_date: '2026-06-30',
+    });
+    firstRenewal.complete();
+
+    expect(loanApiService.renew).toHaveBeenCalledTimes(2);
+    expect(loanApiService.renew).toHaveBeenNthCalledWith(2, expect.objectContaining({ pid: 'loan-1' }));
+
+    secondRenewal.next({
+      end_date: '2026-07-02',
+      extension_count: 1,
+      is_late: false,
+      due_soon_date: '2026-07-01',
+    });
+    secondRenewal.complete();
+
+    expect(store.renewingLoans()).toBe(false);
+    expect(loanApiService.renew).toHaveBeenCalledTimes(2);
+    expect(loanApiService.renew).toHaveBeenCalledWith(expect.objectContaining({ pid: 'loan-1' }));
+    expect(loanApiService.renew).toHaveBeenCalledWith(expect.objectContaining({ pid: 'loan-2' }));
+    expect(loanApiService.renew).not.toHaveBeenCalledWith(expect.objectContaining({ pid: 'loan-3' }));
+    expect(loanApiService.getOnLoan).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues renewing the remaining loans when one renewal fails', () => {
+    const secondLoan = {
+      metadata: {
+        pid: 'loan-2',
+        item: { pid: 'item-2', location: { pid: 'location-2' } },
+        end_date: '2026-07-03',
+      },
+      canExtend: { can: true, reasons: {} },
+    };
+    loanApiService.getOnLoan.mockReturnValue(of({
+      hits: {
+        hits: [
+          { ...loan, canExtend: { can: true, reasons: {} } },
+          secondLoan,
+        ],
+        total: { value: 2 },
+      },
+    }));
+    loanApiService.canExtend.mockReturnValue(of({ can: true, reasons: {} }));
+    loanApiService.renew
+      .mockReturnValueOnce(throwError(() => new Error('Renewal failed')))
+      .mockReturnValueOnce(of({
+        end_date: '2026-08-03',
+        extension_count: 1,
+        is_late: false,
+        due_soon_date: '2026-08-01',
+      }));
+    store.setPatronPid('patron-1');
+    TestBed.tick();
+
+    store.renewAllLoans();
+
+    expect(loanApiService.renew).toHaveBeenCalledTimes(2);
+    expect(loanApiService.renew).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ pid: 'loan-1' })
+    );
+    expect(loanApiService.renew).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pid: 'loan-2' })
+    );
+  });
+
+});

--- a/projects/public-search/src/app/patron-profile/store/loans-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/loans-feature.ts
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { computed, inject, type Signal } from '@angular/core';
+import { patchState, signalStoreFeature, type, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG } from '@rero/ng-core';
+import { MessageService } from 'primeng/api';
+import { catchError, concatMap, exhaustMap, finalize, forkJoin, from, map, of, pipe, switchMap, tap, toArray } from 'rxjs';
+import { LoanApiService } from '../../api/loan-api.service';
+import type { PatronLoan } from '../patron-profile-loans/types';
+
+type LoansFeatureState = {
+  loans: PatronLoan[];
+  loansLoaded: boolean;
+  loansSortCriteria: string;
+  renewingLoans: boolean;
+  renewingLoanPid: string | null;
+};
+
+type LoadLoansInput = {
+  patronPid: string | null;
+  sortCriteria: string;
+};
+
+const loansPerPage = 9999;
+
+export function withLoansFeature<_>() {
+  return signalStoreFeature(
+    { props: type<{ patronPid: Signal<string | null> }>() },
+    withState<LoansFeatureState>({
+      loans: [],
+      loansLoaded: false,
+      loansSortCriteria: 'duedate',
+      renewingLoans: false,
+      renewingLoanPid: null,
+    }),
+    withComputed((state) => ({
+      renewableLoans: computed(() => state.loans().filter((loan) => loan.canExtend?.can)),
+    })),
+    withMethods((
+      store,
+      loanApiService = inject(LoanApiService),
+      translateService = inject(TranslateService),
+      messageService = inject(MessageService)
+    ) => {
+      /** Refresh the renewal permission of one loan after a renewal. */
+      const refreshCanExtend = (loanPid: string) => loanApiService.canExtend(loanPid).pipe(
+        tap(canExtend => {
+          patchState(store, {
+            loans: store.loans().map(loan =>
+              loan.metadata?.pid === loanPid ? { ...loan, canExtend } : loan
+            ),
+          });
+        })
+      );
+
+      /** Renew one loan and update it in the store without reloading the list. */
+      const renewLoan = (record: PatronLoan, patronPid: string) => {
+        const metadata = record?.metadata;
+        return loanApiService.renew({
+          pid: metadata?.pid,
+          item_pid: metadata?.item.pid,
+          transaction_location_pid: metadata?.item.location.pid,
+          transaction_user_pid: patronPid
+        }).pipe(
+          concatMap((extendLoan: any) => {
+            if (extendLoan === undefined || !metadata) return of(extendLoan);
+            patchState(store, {
+              loans: store.loans().map(loan => {
+                if (loan.metadata?.pid !== metadata.pid) return loan;
+                const updatedMetadata = {
+                  ...loan.metadata,
+                  end_date: extendLoan.end_date,
+                  extension_count: extendLoan.extension_count,
+                  is_late: extendLoan.is_late,
+                  due_soon_date: extendLoan.due_soon_date,
+                };
+                if ('overdue' in updatedMetadata) {
+                  delete updatedMetadata.overdue;
+                }
+                return { ...loan, metadata: updatedMetadata, renewed: true };
+              }),
+            });
+            return refreshCanExtend(metadata.pid).pipe(map(() => extendLoan));
+          })
+        );
+      };
+
+      /** Manage the loading state used by an individual renewal button. */
+      const renewSingleLoan = (record: PatronLoan, patronPid: string) => {
+        patchState(store, {
+          renewingLoans: true,
+          renewingLoanPid: record.metadata.pid,
+        });
+        return renewLoan(record, patronPid).pipe(
+          finalize(() => patchState(store, {
+            renewingLoans: false,
+            renewingLoanPid: null,
+          }))
+        );
+      };
+
+      /** Display the result of an individual renewal. */
+      const notifyRenewLoan = (success: boolean) => {
+        if (success) {
+          messageService.add({
+            severity: 'success',
+            summary: translateService.instant('Success'),
+            detail: translateService.instant('The item has been renewed.'),
+            life: CONFIG.MESSAGE_LIFE,
+          });
+        } else {
+          messageService.add({
+            severity: 'error',
+            summary: translateService.instant('Error'),
+            detail: translateService.instant('Error during the renewal of the item.'),
+            closable: true,
+          });
+        }
+      };
+
+      /**
+       * Load all loans, then enrich each loan with its renewal permission.
+       */
+      const loadLoans$ = ({ patronPid, sortCriteria }: LoadLoansInput) => {
+        if (!patronPid) return of([]);
+
+        patchState(store, { loansLoaded: false });
+        return loanApiService
+          .getOnLoan(patronPid, 1, loansPerPage, undefined, sortCriteria)
+          .pipe(
+            switchMap(response => {
+              if (!('hits' in response)) throw response;
+
+              const loans = response.hits.hits.map(loan => {
+                const storedLoan = store.loans().find(
+                  currentLoan => currentLoan.metadata?.pid === loan.metadata?.pid
+                );
+                return storedLoan?.renewed ? { ...loan, renewed: true } : loan;
+              });
+
+              if (!loans.length) {
+                patchState(store, { loans: [] });
+                return of([]);
+              }
+
+              return forkJoin(
+                loans.map(loan =>
+                  loanApiService.canExtend(loan.metadata.pid).pipe(
+                    map(canExtend => canExtend ? { ...loan, canExtend } : loan),
+                    catchError(error => {
+                      console.error(error);
+                      return of(loan);
+                    })
+                  )
+                )
+              ).pipe(
+                tap(loans => patchState(store, { loans }))
+              );
+            }),
+            catchError(error => {
+              console.error(error);
+              return of([]);
+            }),
+            finalize(() => patchState(store, { loansLoaded: true }))
+          );
+      };
+
+      /** Renew renewable loans sequentially to avoid concurrent renewals. */
+      const renewLoans = () => {
+        const patronPid = store.patronPid();
+        if (!patronPid) return of([]);
+
+        const renewableLoans = [...store.renewableLoans()].sort((firstLoan, secondLoan) =>
+          firstLoan.metadata.end_date.localeCompare(secondLoan.metadata.end_date)
+        );
+        if (!renewableLoans.length) return of([]);
+
+        patchState(store, {
+          renewingLoans: true,
+        });
+        return from(renewableLoans).pipe(
+          concatMap(loan => renewLoan(loan, patronPid).pipe(
+            // Keep processing the remaining loans when one renewal fails.
+            catchError(() => of(undefined))
+          )),
+          toArray(),
+          finalize(() => {
+            patchState(store, { renewingLoans: false });
+          })
+        );
+      };
+
+      return {
+        resetLoans(): void {
+          patchState(store, {
+            loans: [],
+            loansLoaded: false,
+            renewingLoans: false,
+            renewingLoanPid: null,
+          });
+        },
+        changeLoansSortCriteria(sortCriteria: string): void {
+          patchState(store, { loansSortCriteria: sortCriteria });
+        },
+        /**
+         * Reload when either the patron or the selected sort criteria changes.
+         */
+        loadLoans: rxMethod<LoadLoansInput>(
+          pipe(
+            switchMap(input => loadLoans$(input))
+          )
+        ),
+        renewLoan: rxMethod<string>(
+          pipe(
+            exhaustMap(recordPid => {
+              const patronPid = store.patronPid();
+              const record = store.loans().find(loan => loan.metadata?.pid === recordPid);
+              if (!patronPid || !record) {
+                notifyRenewLoan(false);
+                return of(undefined);
+              }
+
+              return renewSingleLoan(record, patronPid).pipe(
+                tap(extendLoan => notifyRenewLoan(extendLoan !== undefined)),
+                catchError(() => {
+                  notifyRenewLoan(false);
+                  return of(undefined);
+                })
+              );
+            })
+          )
+        ),
+        renewAllLoans: rxMethod<void>(
+          pipe(
+            exhaustMap(() => renewLoans().pipe(
+              tap(renewedLoans => {
+                const renewedCount = renewedLoans.filter(renewedLoan => renewedLoan !== undefined).length;
+                const failedCount = store.loans().length - renewedCount;
+                const success = failedCount === 0;
+                messageService.add({
+                  severity: success ? 'success' : 'warn',
+                  summary: translateService.instant(success ? 'Success' : 'Warning'),
+                  detail: success
+                    ? `${renewedCount} items were renewed.`
+                    : `${renewedCount} items were renewed ; ${failedCount} items could not be renewed.`,
+                  life: success ? CONFIG.MESSAGE_LIFE : undefined,
+                  closable: !success,
+                });
+              }),
+              catchError(() => {
+                messageService.add({
+                  severity: 'error',
+                  summary: translateService.instant('Error'),
+                  detail: translateService.instant('Error during the renewal of the items.'),
+                  closable: true,
+                });
+                return of([]);
+              }),
+              switchMap(() => loadLoans$({
+                patronPid: store.patronPid(),
+                sortCriteria: store.loansSortCriteria(),
+              }))
+            ))
+          )
+        ),
+      };
+    }),
+    withHooks({
+      onInit(store) {
+        store.loadLoans(computed(() => ({
+          patronPid: store.patronPid(),
+          sortCriteria: store.loansSortCriteria(),
+        })));
+      },
+    })
+  );
+}

--- a/projects/public-search/src/app/patron-profile/store/patron-profile.store.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/patron-profile.store.spec.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 import { testUserPatronMultipleOrganisationsWithSettings, User } from '@rero/shared';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { IllRequestApiService } from '../../api/ill-request-api.service';
+import { LoanApiService } from '../../api/loan-api.service';
+import { PatronApiService } from '../../api/patron-api.service';
+import { PatronTransactionApiService } from '../../api/patron-transaction-api.service';
 import { PatronProfileStore } from './patron-profile.store';
 
 describe('PatronProfileStore', () => {
@@ -9,19 +16,57 @@ describe('PatronProfileStore', () => {
   const user = new User(testUserPatronMultipleOrganisationsWithSettings);
 
   beforeEach(() => {
-    store = TestBed.configureTestingModule({ providers: [PatronProfileStore] })
+    store = TestBed.configureTestingModule({
+      providers: [
+        PatronProfileStore,
+        {
+          provide: LoanApiService,
+          useValue: {
+            getOnLoan: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+            getRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
+        {
+          provide: PatronTransactionApiService,
+          useValue: { getFees: vi.fn().mockReturnValue(of({ hits: { hits: [] } })) },
+        },
+        {
+          provide: PatronApiService,
+          useValue: { getOverduePreviewByPatronPid: vi.fn().mockReturnValue(of([])) },
+        },
+        {
+          provide: IllRequestApiService,
+          useValue: {
+            getPublicIllRequest: vi.fn().mockReturnValue(of({ hits: { hits: [], total: { value: 0 } } })),
+          },
+        },
+        { provide: TranslateService, useValue: { instant: vi.fn((value: string) => value) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    })
       .inject(PatronProfileStore);
   });
 
   it('should have correct initial state', () => {
     expect(store.patrons()).toEqual([]);
     expect(store.currentPatron()).toBeNull();
+    expect(store.patronPid()).toBeNull();
     expect(store.menu()).toEqual([]);
-    expect(store.currentMenu()).toBeNull();
     expect(store.isMultiOrganisation()).toBe(false);
     expect(store.activeTab()).toBeNull();
-    expect(store.loanFeesTotal()).toBe(0);
     expect(store.cancelledRequestPid()).toBeNull();
+    expect(store.cancellingRequestPid()).toBeNull();
+    expect(store.loans()).toEqual([]);
+    expect(store.loansLoaded()).toBe(false);
+    expect(store.loansSortCriteria()).toBe('duedate');
+    expect(store.renewingLoans()).toBe(false);
+    expect(store.renewingLoanPid()).toBeNull();
+    expect(store.requests()).toEqual([]);
+    expect(store.requestsLoaded()).toBe(false);
+    expect(store.fees()).toEqual([]);
+    expect(store.feesLoaded()).toBe(false);
+    expect(store.illRequests()).toEqual([]);
+    expect(store.illRequestsLoaded()).toBe(false);
   });
 
   describe('init()', () => {
@@ -34,10 +79,10 @@ describe('PatronProfileStore', () => {
       ]);
     });
 
-    it('should set currentPatron and currentMenu to first entries', () => {
+    it('should set currentPatron to first entry', () => {
       store.init(user);
       expect(store.currentPatron()?.pid).toBe('1');
-      expect(store.currentMenu()?.value).toBe('1');
+      expect(store.patronPid()).toBe('1');
     });
 
     it('should set isMultiOrganisation to true for multiple patrons', () => {
@@ -46,19 +91,22 @@ describe('PatronProfileStore', () => {
     });
 
     it('should set isMultiOrganisation to false for a single patron', () => {
-      const single = new User({ ...testUserPatronMultipleOrganisationsWithSettings,
-        patrons: [testUserPatronMultipleOrganisationsWithSettings.patrons[0]] });
+      const single = new User({
+        ...testUserPatronMultipleOrganisationsWithSettings,
+        patrons: [testUserPatronMultipleOrganisationsWithSettings.patrons[0]]
+      });
       store.init(single);
       expect(store.isMultiOrganisation()).toBe(false);
     });
 
     it('should handle user with no patron role', () => {
-      const noPatron = new User({ ...testUserPatronMultipleOrganisationsWithSettings,
-        patrons: [{ ...testUserPatronMultipleOrganisationsWithSettings.patrons[0], roles: ['librarian' as const] }] });
+      const noPatron = new User({
+        ...testUserPatronMultipleOrganisationsWithSettings,
+        patrons: [{ ...testUserPatronMultipleOrganisationsWithSettings.patrons[0], roles: ['librarian' as const] }]
+      });
       store.init(noPatron);
       expect(store.patrons()).toHaveLength(0);
       expect(store.currentPatron()).toBeNull();
-      expect(store.currentMenu()).toBeNull();
     });
   });
 
@@ -68,7 +116,7 @@ describe('PatronProfileStore', () => {
     it('should switch to second patron', () => {
       store.changePatron('10');
       expect(store.currentPatron()?.pid).toBe('10');
-      expect(store.currentMenu()?.value).toBe('10');
+      expect(store.patronPid()).toBe('10');
     });
 
     it('should switch back to first patron', () => {
@@ -80,7 +128,7 @@ describe('PatronProfileStore', () => {
     it('should set null for unknown patronPid', () => {
       store.changePatron('unknown');
       expect(store.currentPatron()).toBeNull();
-      expect(store.currentMenu()).toBeNull();
+      expect(store.patronPid()).toBeNull();
     });
   });
 
@@ -97,45 +145,4 @@ describe('PatronProfileStore', () => {
     });
   });
 
-  describe('cancelRequest()', () => {
-    it('should set cancelledRequestPid', () => {
-      store.cancelRequest('pid-123');
-      expect(store.cancelledRequestPid()).toBe('pid-123');
-    });
-
-    it('should overwrite previous cancelled pid', () => {
-      store.cancelRequest('pid-1');
-      store.cancelRequest('pid-2');
-      expect(store.cancelledRequestPid()).toBe('pid-2');
-    });
-  });
-
-  describe('addLoanFees()', () => {
-    it('should accumulate fees', () => {
-      store.addLoanFees(10.5);
-      store.addLoanFees(5);
-      expect(store.loanFeesTotal()).toBe(15.5);
-    });
-
-    it('should handle zero fees', () => {
-      store.addLoanFees(0);
-      expect(store.loanFeesTotal()).toBe(0);
-    });
-  });
-
-  describe('resetLoanFees()', () => {
-    it('should reset total and cancelledRequestPid', () => {
-      store.addLoanFees(20);
-      store.cancelRequest('pid-x');
-      store.resetLoanFees();
-      expect(store.loanFeesTotal()).toBe(0);
-      expect(store.cancelledRequestPid()).toBeNull();
-    });
-
-    it('should be idempotent on initial state', () => {
-      store.resetLoanFees();
-      expect(store.loanFeesTotal()).toBe(0);
-      expect(store.cancelledRequestPid()).toBeNull();
-    });
-  });
 });

--- a/projects/public-search/src/app/patron-profile/store/patron-profile.store.ts
+++ b/projects/public-search/src/app/patron-profile/store/patron-profile.store.ts
@@ -3,6 +3,10 @@
 import { computed } from '@angular/core';
 import { patchState, signalMethod, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 import { IPatron, User } from '@rero/shared';
+import { withLoansFeature } from './loans-feature';
+import { withRequestsFeature } from './request-feature';
+import { withFeesFeature } from './fees-feature';
+import { withIllRequestsFeature } from './ill-requests-feature';
 
 export type IMenu = { value: string; name: string; };
 
@@ -10,10 +14,7 @@ type PatronProfileState = {
   patrons: IPatron[];
   currentPatron: IPatron | null;
   menu: IMenu[];
-  currentMenu: IMenu | null;
   activeTab: string | null;
-  loanFeesTotal: number;
-  cancelledRequestPid: string | null;
 };
 
 export const PatronProfileStore = signalStore(
@@ -22,32 +23,46 @@ export const PatronProfileStore = signalStore(
     patrons: [],
     currentPatron: null,
     menu: [],
-    currentMenu: null,
     activeTab: null,
-    loanFeesTotal: 0,
-    cancelledRequestPid: null,
   }),
-  withComputed(({ menu }) => ({
+  withComputed(({ currentPatron, menu }) => ({
+    patronPid: computed(() => currentPatron()?.pid ?? null),
     isMultiOrganisation: computed(() => menu().length > 1),
   })),
-  withMethods((store) => ({
-    init(user: User): void {
-      const patrons = user.patrons.filter(p => p.roles.includes('patron'));
-      const menu = patrons.map(p => ({ value: p.pid, name: p.organisation.name }));
-      patchState(store, { patrons, menu, currentPatron: patrons[0] ?? null, currentMenu: menu[0] ?? null });
-    },
-    changePatron: signalMethod<string>(patronPid => {
-      const patron = store.patrons().find(p => p.pid === patronPid) ?? null;
-      const menu = store.menu().find(m => m.value === patronPid) ?? null;
-      patchState(store, { currentPatron: patron, currentMenu: menu });
-    }),
-    changeTab: signalMethod<string>(tab => patchState(store, { activeTab: tab })),
-    cancelRequest: signalMethod<string>(pid => patchState(store, { cancelledRequestPid: pid })),
-    addLoanFees(fees: number): void {
-      patchState(store, { loanFeesTotal: store.loanFeesTotal() + fees });
-    },
-    resetLoanFees(): void {
-      patchState(store, { loanFeesTotal: 0, cancelledRequestPid: null });
-    },
-  }))
+  withLoansFeature(),
+  withRequestsFeature(),
+  withFeesFeature(),
+  withIllRequestsFeature(),
+  withMethods((store) => {
+    /** Remove data belonging to the previous patron before changing patronPid. */
+    const resetPatronFeatures = () => {
+      store.resetLoans();
+      store.resetRequests();
+      store.resetFees();
+      store.resetIllRequests();
+    };
+
+    return {
+      init(user: User): void {
+        const patrons = user.patrons.filter(p => p.roles.includes('patron'));
+        const menu = patrons.map(p => ({ value: p.pid, name: p.organisation.name }));
+        resetPatronFeatures();
+        patchState(store, {
+          patrons,
+          menu,
+          currentPatron: patrons[0] ?? null,
+        });
+      },
+      changePatron: signalMethod<string>(patronPid => {
+        const patron = store.patrons().find(p => p.pid === patronPid) ?? null;
+        if (patron?.pid === store.patronPid()) return;
+
+        resetPatronFeatures();
+        patchState(store, {
+          currentPatron: patron,
+        });
+      }),
+      changeTab: signalMethod<string>(tab => patchState(store, { activeTab: tab })),
+    };
+  })
 );

--- a/projects/public-search/src/app/patron-profile/store/request-feature.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/request-feature.spec.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { patchState, signalStore, withMethods, withProps, withState } from '@ngrx/signals';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG } from '@rero/ng-core';
+import { MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+import { LoanApiService } from '../../api/loan-api.service';
+import { withRequestsFeature } from './request-feature';
+
+const RequestsFeatureStore = signalStore(
+  withState({ activeTab: null as string | null }),
+  withProps(() => ({ patronPid: signal<string | null>(null) })),
+  withMethods(store => ({
+    setPatronPid(patronPid: string | null): void {
+      store.patronPid.set(patronPid);
+    },
+    setActiveTab(activeTab: string | null): void {
+      patchState(store, { activeTab });
+    },
+  })),
+  withRequestsFeature()
+);
+
+describe('RequestsFeature', () => {
+  let store: InstanceType<typeof RequestsFeatureStore>;
+  const loanApiService = {
+    getRequest: vi.fn(),
+    cancel: vi.fn(),
+  };
+  const translateService = {
+    instant: vi.fn((value: string) => value),
+  };
+  const messageService = {
+    add: vi.fn(),
+  };
+  const request = {
+    metadata: {
+      pid: 'request-1',
+      item: { location: { pid: 'location-1' } },
+    },
+  };
+  const activateRequests = () => {
+    store.setPatronPid('patron-1');
+    store.setActiveTab('request');
+    TestBed.tick();
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = TestBed.configureTestingModule({
+      providers: [
+        RequestsFeatureStore,
+        { provide: LoanApiService, useValue: loanApiService },
+        { provide: TranslateService, useValue: translateService },
+        { provide: MessageService, useValue: messageService },
+      ],
+    }).inject(RequestsFeatureStore);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('initializes request pager state', () => {
+    expect(store.requestPager()).toEqual({
+      page: 1,
+      first: 1,
+      rows: 10,
+      rowsPerPageOptions: [10, 20, 50],
+    });
+  });
+
+  it('changes request pager', () => {
+    store.changeRequestPager({ page: 1, first: 10, rows: 10 });
+
+    expect(store.requestPager().page).toBe(2);
+    expect(store.requestPager().first).toBe(11);
+  });
+
+  it('resets request state', () => {
+    loanApiService.getRequest.mockReturnValue(of({ hits: { hits: [request], total: { value: 1 } } }));
+    activateRequests();
+    store.changeRequestPager({
+      page: 1,
+      first: 10,
+      rows: 10,
+    });
+
+    store.resetRequests();
+
+    expect(store.requests()).toEqual([]);
+    expect(store.requestsTotal()).toBe(0);
+    expect(store.requestsLoaded()).toBe(false);
+    expect(store.requestPager().page).toBe(1);
+    expect(store.requestPager().first).toBe(1);
+  });
+
+  it('loads the selected request page', () => {
+    const secondRequest = { metadata: { pid: 'request-2' } };
+    loanApiService.getRequest
+      .mockReturnValueOnce(of({ hits: { hits: [request], total: { value: 2 } } }))
+      .mockReturnValueOnce(of({ hits: { hits: [secondRequest], total: { value: 2 } } }));
+
+    activateRequests();
+    store.changeRequestPager({ page: 1, first: 10, rows: 10 });
+    TestBed.tick();
+
+    expect(loanApiService.getRequest).toHaveBeenNthCalledWith(1, 'patron-1', 1, 10);
+    expect(loanApiService.getRequest).toHaveBeenNthCalledWith(2, 'patron-1', 2, 10);
+    expect(store.requests()).toEqual([secondRequest]);
+    expect(store.requestsTotal()).toBe(2);
+    expect(store.requestsLoaded()).toBe(true);
+  });
+
+  it('cancels a request through the API and removes it from state', () => {
+    loanApiService.getRequest.mockReturnValue(of({ hits: { hits: [request], total: { value: 1 } } }));
+    loanApiService.cancel.mockReturnValue(of({ pid: 'request-1' }));
+    activateRequests();
+
+    store.cancelPatronRequest('request-1');
+
+    expect(loanApiService.cancel).toHaveBeenCalledWith({
+      pid: 'request-1',
+      transaction_location_pid: 'location-1',
+      transaction_user_pid: 'patron-1',
+    });
+    expect(store.cancelledRequestPid()).toBe('request-1');
+    expect(store.requests()).toEqual([]);
+    expect(store.requestsTotal()).toBe(0);
+    expect(store.cancellingRequestPid()).toBeNull();
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Success',
+      detail: 'The request has been cancelled.',
+      life: CONFIG.MESSAGE_LIFE,
+    });
+  });
+
+  it('handles an error while cancelling a request', () => {
+    loanApiService.getRequest.mockReturnValue(of({ hits: { hits: [request], total: { value: 1 } } }));
+    loanApiService.cancel.mockReturnValue(throwError(() => new Error('Cancellation failed')));
+    activateRequests();
+
+    store.cancelPatronRequest('request-1');
+
+    expect(store.requests()).toEqual([request]);
+    expect(store.requestsTotal()).toBe(1);
+    expect(store.cancellingRequestPid()).toBeNull();
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'Error during the cancellation of the request.',
+      closable: true,
+    });
+  });
+});

--- a/projects/public-search/src/app/patron-profile/store/request-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/request-feature.ts
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { computed, inject, type Signal } from '@angular/core';
+import { patchState, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG } from '@rero/ng-core';
+import { nextPager, Pager } from '@rero/shared';
+import { MessageService } from 'primeng/api';
+import { PaginatorState } from 'primeng/paginator';
+import { catchError, exhaustMap, finalize, of, pipe, switchMap, tap } from 'rxjs';
+import { LoanApiService } from '../../api/loan-api.service';
+
+type RequestsFeatureState = {
+  requests: any[];
+  requestsTotal: number;
+  requestsLoaded: boolean;
+  cancelledRequestPid: string | null;
+  cancellingRequestPid: string | null;
+  requestPager: Pager;
+};
+
+type LoadRequestsInput = {
+  patronPid: string | null;
+  active: boolean;
+  page: number;
+  recordsPerPage: number;
+};
+
+const initialRequestPager: Pager = {
+  page: 1,
+  first: 1,
+  rows: 10,
+  rowsPerPageOptions: [10, 20, 50]
+};
+
+const notifyCancellation = (
+  success: boolean,
+  translateService: TranslateService,
+  messageService: MessageService
+) => {
+  if (success) {
+    messageService.add({
+      severity: 'success',
+      summary: translateService.instant('Success'),
+      detail: translateService.instant('The request has been cancelled.'),
+      life: CONFIG.MESSAGE_LIFE,
+    });
+  } else {
+    messageService.add({
+      severity: 'error',
+      summary: translateService.instant('Error'),
+      detail: translateService.instant('Error during the cancellation of the request.'),
+      closable: true,
+    });
+  }
+};
+
+/** Add request state, pagination and actions to the patron profile store. */
+export function withRequestsFeature<_>() {
+  return signalStoreFeature(
+    {
+      state: type<{ activeTab: string | null }>(),
+      props: type<{
+        patronPid: Signal<string | null>;
+      }>(),
+    },
+    withState<RequestsFeatureState>({
+      requests: [],
+      requestsTotal: 0,
+      requestsLoaded: false,
+      cancelledRequestPid: null,
+      cancellingRequestPid: null,
+      requestPager: initialRequestPager,
+    }),
+    withMethods((
+      store,
+      loanApiService = inject(LoanApiService),
+      translateService = inject(TranslateService),
+      messageService = inject(MessageService)
+    ) => ({
+      /** Clear requests and restore the first page for another patron. */
+      resetRequests(): void {
+        patchState(store, {
+          requests: [],
+          requestsTotal: 0,
+          requestsLoaded: false,
+          requestPager: initialRequestPager,
+        });
+      },
+      /** Store the new page; the reactive loader performs the API call. */
+      changeRequestPager(event: PaginatorState): void {
+        patchState(store, {
+          requestPager: nextPager(store.requestPager(), event),
+        });
+      },
+      /** Load the active request page whenever one of its inputs changes. */
+      loadRequests: rxMethod<LoadRequestsInput>(
+        pipe(
+          switchMap(({ patronPid, active, page, recordsPerPage }) => {
+            if (!patronPid || !active) return of([]);
+
+            patchState(store, { requestsLoaded: false });
+
+            return loanApiService.getRequest(patronPid, page, recordsPerPage).pipe(
+              tap(response => {
+                if (!('hits' in response)) return;
+                patchState(store, {
+                  requests: response.hits.hits,
+                  requestsTotal: response.hits.total.value,
+                });
+              }),
+              catchError(error => {
+                console.error(error);
+                return of(null);
+              }),
+              finalize(() => patchState(store, { requestsLoaded: true }))
+            );
+          })
+        )
+      ),
+      /** Cancel one patron request and remove it from the current page. */
+      cancelPatronRequest: rxMethod<string>(
+        pipe(
+          exhaustMap(requestPid => {
+            const patronPid = store.patronPid();
+            const request = store.requests().find(request => request.metadata?.pid === requestPid);
+            if (!patronPid || !request) {
+              notifyCancellation(false, translateService, messageService);
+              return of(undefined);
+            }
+
+            patchState(store, { cancellingRequestPid: requestPid });
+            return loanApiService.cancel({
+              pid: requestPid,
+              transaction_location_pid: request.metadata?.item.location.pid,
+              transaction_user_pid: patronPid
+            }).pipe(
+              tap(cancelledRequest => {
+                const success = cancelledRequest !== undefined;
+                if (success) {
+                  patchState(store, {
+                    cancelledRequestPid: requestPid,
+                    requests: store.requests().filter(request => request.metadata.pid !== requestPid),
+                    requestsTotal: Math.max(0, store.requestsTotal() - 1),
+                  });
+                }
+                notifyCancellation(success, translateService, messageService);
+              }),
+              catchError(() => {
+                notifyCancellation(false, translateService, messageService);
+                return of(undefined);
+              }),
+              finalize(() => patchState(store, { cancellingRequestPid: null }))
+            );
+          })
+        )
+      ),
+    })),
+    withHooks({
+      onInit(store) {
+        store.loadRequests(computed(() => ({
+          patronPid: store.patronPid(),
+          active: store.activeTab() === 'request',
+          page: store.requestPager().page,
+          recordsPerPage: store.requestPager().rows,
+        })));
+      },
+    })
+  );
+}

--- a/projects/shared/src/lib/store/paginator-feature.spec.ts
+++ b/projects/shared/src/lib/store/paginator-feature.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { TestBed } from '@angular/core/testing';
 import { signalStore } from '@ngrx/signals';
-import { withPaginator } from './paginator-feature';
+import { nextPager, withPaginator } from './paginator-feature';
 import { Pager } from '../component/paginator/model/paginator-model';
 import { PaginatorState } from 'primeng/paginator';
 
@@ -85,5 +85,23 @@ describe('PaginatorFeature', () => {
     expect(store.pager().page).toBe(3); // 2 + 1
     expect(store.pager().rows).toBe(initialPager.rows); // Should fallback to initialPager.rows (10)
     expect(store.pager().first).toBe(21); // 2 * 10 + 1
+  });
+
+  it('should not mutate the paginator event', () => {
+    const event: PaginatorState = {
+      page: 1,
+      first: 10,
+      rows: 20,
+      pageCount: 3
+    };
+
+    nextPager(initialPager, event);
+
+    expect(event).toEqual({
+      page: 1,
+      first: 10,
+      rows: 20,
+      pageCount: 3
+    });
   });
 });

--- a/projects/shared/src/lib/store/paginator-feature.ts
+++ b/projects/shared/src/lib/store/paginator-feature.ts
@@ -4,6 +4,23 @@ import { patchState, signalMethod, signalStoreFeature, withMethods, withState } 
 import { PaginatorState } from "primeng/paginator";
 import { Pager, Paginator } from "../component/paginator/model/paginator-model";
 
+/**
+ * Build the next pager without modifying the PrimeNG event.
+ * PrimeNG pages are zero-based while API pages and first records are one-based.
+ * Changing the page size returns to the first page.
+ */
+export function nextPager(current: Pager, event: PaginatorState): Pager {
+  const rows = event.rows ?? current.rows;
+  const page = rows !== current.rows ? 0 : (event.page ?? 0);
+
+  return {
+    page: page + 1,
+    first: page * rows + 1,
+    rows,
+    rowsPerPageOptions: current.rowsPerPageOptions
+  };
+}
+
 export function withPaginator(pager: Pager) {
   return signalStoreFeature(
     withState<Paginator>({
@@ -11,17 +28,8 @@ export function withPaginator(pager: Pager) {
     }),
     withMethods(store => ({
       changePage: signalMethod<PaginatorState>(event => {
-        if ((event.rows || pager.rows) !== store.pager.rows()) {
-          event.page = 0;
-          event.first = 1;
-        }
         patchState(store, {
-          pager: {
-            page: event.page + 1,
-            first: event.page * (event.rows || pager.rows) + 1,
-            rows: (event.rows || pager.rows),
-            rowsPerPageOptions: store.pager().rowsPerPageOptions
-          }
+          pager: nextPager(store.pager(), event)
         });
       })
     }))


### PR DESCRIPTION
* Moves loans, requests, fees and ILL state and actions into SignalStore
  features to keep components focused on UI.
* Derives the patron PID from the current patron and reactively reloads data
  when the patron, active tab, sorting or pagination changes.
* Adds independent request and ILL paginators with shared typed calculations.
* Adds sequential renewal of all eligible loans with loading state and
  success/error feedback.
* Loads the complete loan list so bulk renewal includes every eligible loan.
* Improves loan typing and error handling and prevents duplicate renewal
  notifications.
* Closes rero/rero-ils#2334.