### PR TITLE
feat(translate): allow language config override

### DIFF
--- a/.ai/project-context.md
+++ b/.ai/project-context.md
@@ -61,6 +61,16 @@ utils/
 - stores: signal-based state management
 - utils: framework-independent helpers
 
+## Git commit conventions
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+- Format: `type(scope): description`
+- **Title**: 50 characters maximum
+- **Body lines**: 72 characters maximum
+- **Body bullet points**: use `*` (asterisk), not `-` (dash)
+- Common types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `style`
+
 ## Testing philosophy
 
 - Use Karma + Jasmine for tests (current standard).

--- a/.ng-core-ref
+++ b/.ng-core-ref
@@ -2,4 +2,4 @@
 #   published                    — use published npm version (default, staging)
 #   feat/my-branch               — branch on rero/ng-core
 #   owner/ng-core@branch-or-sha  — fork + branch or SHA
-published
+staging

--- a/angular.json
+++ b/angular.json
@@ -38,6 +38,16 @@
                 "glob": "**/*.json",
                 "input": "projects/shared/src/assets",
                 "output": "/assets/"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/rero-ils-ui/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/rero-ils-ui/ng-core/languages"
               }
             ],
             "styles": [
@@ -179,6 +189,16 @@
                 "glob": "**/*.json",
                 "input": "projects/shared/src/assets",
                 "output": "/assets/"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/rero-ils-ui/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/rero-ils-ui/ng-core/languages"
               }
             ],
             "styles": [
@@ -319,6 +339,16 @@
                 "glob": "**/*.json",
                 "input": "projects/shared/src/assets",
                 "output": "/assets/"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/rero-ils-ui/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/rero-ils-ui/ng-core/languages"
               }
             ],
             "styles": [
@@ -463,6 +493,16 @@
                 "glob": "**/*.json",
                 "input": "projects/shared/src/assets",
                 "output": "/assets/"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/rero-ils-ui/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/rero-ils-ui/ng-core/languages"
               }
             ],
             "styles": [
@@ -637,6 +677,16 @@
                 "glob": "**/*.json",
                 "input": "projects/shared/src/assets",
                 "output": "/assets/"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/rero-ils-ui/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/rero-ils-ui/ng-core/languages"
               }
             ],
             "styles": [

--- a/projects/admin/src/app/app.config.ts
+++ b/projects/admin/src/app/app.config.ts
@@ -18,16 +18,16 @@ import {
   ComponentCanDeactivateGuard,
   CoreConfigService,
   RecordHandleErrorService as CoreRecordHandleErrorService,
-  CoreTranslateLoader,
   httpPendingInterceptor,
   NgCoreTranslateService,
   PasswordGeneratorComponent,
   primeNGConfig,
   provideCore,
   RemoteAutocompleteService,
-  TruncateTextPipe,
+  TranslateLanguageService,
+  TruncateTextPipe
 } from '@rero/ng-core';
-import { ItemHoldingsCallNumberPipe, MainTitlePipe } from '@rero/shared';
+import { AppTranslateLanguageService, AppTranslateLoader, AppTranslateService, ItemHoldingsCallNumberPipe, MainTitlePipe } from '@rero/shared';
 import { providePrimeNG } from 'primeng/config';
 import { SelectAccountEditorWidgetComponent } from './acquisition/components/editor/widget/select-account-editor-widget/select-account-editor-widget.component';
 import { registerFormlyExtension } from './acquisition/formly/extension';
@@ -94,7 +94,7 @@ export const appConfig: ApplicationConfig = {
     ComponentCanDeactivateGuard,
     providePrimeNG(primeNGConfig),
     provideTranslateService({
-      loader: provideTranslateLoader(CoreTranslateLoader),
+      loader: provideTranslateLoader(AppTranslateLoader),
     }),
     importProvidersFrom(
       FormlyModule.forChild({
@@ -116,5 +116,7 @@ export const appConfig: ApplicationConfig = {
       }),
       LoadingBarHttpClientModule
     ),
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
   ],
 };

--- a/projects/admin/src/app/menu/store/menu.store.spec.ts
+++ b/projects/admin/src/app/menu/store/menu.store.spec.ts
@@ -35,6 +35,7 @@ describe('MenuStore', () => {
     canAccess: vi.fn(),
     setCurrentLibrary: vi.fn(),
     permissions: vi.fn(),
+    availableLanguageCodes: vi.fn(),
   };
 
   const libraryApiSpy = {
@@ -66,6 +67,7 @@ describe('MenuStore', () => {
     appStoreSpy.canAccess.mockReturnValue(true);
     appStoreSpy.setCurrentLibrary.mockReset();
     appStoreSpy.permissions.mockReturnValue(testPermissions);
+    appStoreSpy.availableLanguageCodes.mockReturnValue(coreConfigServiceSpy.languages);
     libraryApiSpy.findByLibrariesPidAndOrderBy$.mockReturnValue(of(esResult));
     librarySwitchStorageSpy.has.mockReturnValue(false);
     librarySwitchStorageSpy.save.mockReset();

--- a/projects/admin/src/app/menu/store/menu.store.ts
+++ b/projects/admin/src/app/menu/store/menu.store.ts
@@ -4,7 +4,6 @@ import { HttpClient } from '@angular/common/http';
 import { computed, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
-import { CoreConfigService } from '@rero/ng-core';
 import type { EsResult } from '@rero/ng-core';
 import { AppStore, PERMISSION_OPERATOR } from '@rero/shared';
 import { patchState, signalStore, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
@@ -107,7 +106,6 @@ export const MenuStore = signalStore(
     librarySwitchStorageService = inject(LibrarySwitchStorageService),
     libraryApiService = inject(LibraryApiService),
     translateService = inject(TranslateService),
-    configService = inject(CoreConfigService),
     httpClient = inject(HttpClient)
   ) => {
     const libraryKeys = ['library', 'owner_library', 'owning_library'];
@@ -188,7 +186,7 @@ export const MenuStore = signalStore(
 
       generateMenuLanguages(): MenuItem[] {
         const currentLanguage = translateService.getCurrentLang();
-        return (configService.languages as string[])
+        return appStore.availableLanguageCodes()
           .map((language: string) => ({
             label: translateService.instant(`ui_language_${language}`),
             translateLabel: `ui_language_${language}`,

--- a/projects/admin/src/app/service/app-config.service.ts
+++ b/projects/admin/src/app/service/app-config.service.ts
@@ -21,10 +21,10 @@ export class AppConfigService extends CoreConfigService {
     this.apiBaseUrl = environment.apiBaseUrl;
     this.$refPrefix = environment.$refPrefix;
     this.schemaFormEndpoint = '/schemas';
-    this.languages = environment.languages;
     this.defaultLanguage = environment.defaultLanguage;
     this.adminRoles = environment.adminRoles;
     this.translationsURLs = environment.translationsURLs;
+    this.ngCoreAssetsUrl = environment.ngCoreAssetsUrl ?? '';
     this.librarySwitchCheckParamsUrl = environment.librarySwitchCheckParamsUrl;
   }
 }

--- a/projects/admin/src/app/service/app-initializer.ts
+++ b/projects/admin/src/app/service/app-initializer.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject } from '@angular/core';
 import { NgCoreTranslateService } from '@rero/ng-core';
-import { AppStore, User } from '@rero/shared';
-import { Observable } from 'rxjs';
+import { AppStore, AppTranslateLanguageService, User } from '@rero/shared';
+import { from, Observable } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import { AppConfigService } from './app-config.service';
 import { RemoteAutocompleteFactoryService } from '../record/editor/formly/primeng/remote-autocomplete/remote-autocomplete-factory.service';
@@ -13,13 +13,14 @@ export function initializeApp(): Observable<any> {
   const appStore = inject(AppStore);
   const appConfigService = inject(AppConfigService);
   const translateService = inject(NgCoreTranslateService);
+  const translateLanguageService = inject(AppTranslateLanguageService);
   const remoteAutocompleteFactoryService = inject(RemoteAutocompleteFactoryService);
   const librarySwitchStorageService = inject(LibrarySwitchStorageService);
 
   return appStore.load().pipe(
-    tap((user: User) => {
+    tap((user: User | null) => {
       remoteAutocompleteFactoryService.init();
-      if (user.hasAdminUiAccess) {
+      if (user?.hasAdminUiAccess) {
         const libraries = user.patronLibrarian?.libraries ?? [];
         const library = libraries[0];
         if (librarySwitchStorageService.has()) {
@@ -44,11 +45,13 @@ export function initializeApp(): Observable<any> {
       let language = appStore.settings()?.language;
       if (language == null) {
         const browserLang = translateService.getBrowserLang();
-        language = (browserLang && browserLang.match(appConfigService.languages.join('|')))
+        language = (browserLang && appStore.availableLanguageCodes().includes(browserLang))
           ? browserLang
           : appConfigService.defaultLanguage;
       }
-      return translateService.use(language);
+      return from(translateLanguageService.loadLanguageNow(language)).pipe(
+        switchMap(() => translateService.use(language))
+      );
     })
   );
 }

--- a/projects/admin/src/environments/environment.prod.ts
+++ b/projects/admin/src/environments/environment.prod.ts
@@ -6,7 +6,6 @@ export const environment = {
   projectTitle: 'Admin',
   apiBaseUrl: '',
   $refPrefix: 'https://bib.rero.ch',
-  languages: ['fr', 'de', 'it', 'en'],
   defaultLanguage: 'en',
   adminRoles: ['system_librarian', 'librarian'],
   translationsURLs: [
@@ -14,5 +13,6 @@ export const environment = {
     '/static/node_modules/@rero/rero-ils-ui/dist/admin/browser/assets/rero-ils-ui/admin/i18n/${lang}.json',
     '/api/translations/${lang}.json'
   ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/rero-ils-ui/dist/admin/browser',
   librarySwitchCheckParamsUrl: ['new', 'edit']
 };

--- a/projects/admin/src/environments/environment.ts
+++ b/projects/admin/src/environments/environment.ts
@@ -10,7 +10,6 @@ export const environment = {
   projectTitle: 'Admin',
   apiBaseUrl: '',
   $refPrefix: 'https://bib.rero.ch',
-  languages: ['fr', 'de', 'it', 'en'],
   defaultLanguage: 'en',
   adminRoles: ['system_librarian', 'librarian'],
   translationsURLs: [
@@ -18,5 +17,6 @@ export const environment = {
     '/assets/rero-ils-ui/admin/i18n/${lang}.json',
     '/api/translations/${lang}.json'
   ],
-  librarySwitchCheckParamsUrl: ['new', 'edit']
+  librarySwitchCheckParamsUrl: ['new', 'edit'],
+  ngCoreAssetsUrl: '',
 };

--- a/projects/public-holdings-items/src/app/app-config-service.service.ts
+++ b/projects/public-holdings-items/src/app/app-config-service.service.ts
@@ -24,8 +24,8 @@ export class AppConfigService extends CoreConfigService {
     this.production = environment.production;
     this.apiBaseUrl = environment.apiBaseUrl;
     this.$refPrefix = environment.$refPrefix;
-    this.languages = environment.languages;
     this.globalViewName = environment.globalViewName;
     this.translationsURLs = environment.translationsURLs;
+    this.ngCoreAssetsUrl = environment.ngCoreAssetsUrl ?? '';
   }
 }

--- a/projects/public-holdings-items/src/app/app-initializer.service.spec.ts
+++ b/projects/public-holdings-items/src/app/app-initializer.service.spec.ts
@@ -5,7 +5,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { AppStore } from '@rero/shared';
+import { AppStore, AppTranslateLanguageService } from '@rero/shared';
 import { of } from 'rxjs';
 
 import { AppInitializerService } from './app-initializer.service';
@@ -23,7 +23,8 @@ describe('AppInitializerService', () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
-        { provide: AppStore, useValue: { load: vi.fn().mockReturnValue(of(null)), settings: vi.fn().mockReturnValue({ language: 'en' }) } }
+        { provide: AppStore, useValue: { load: vi.fn().mockReturnValue(of(null)), settings: vi.fn().mockReturnValue({ language: 'en' }) } },
+        { provide: AppTranslateLanguageService, useValue: { loadLanguageNow: vi.fn().mockResolvedValue(undefined) } }
       ]
     });
     appInitializerService = TestBed.inject(AppInitializerService);

--- a/projects/public-holdings-items/src/app/app-initializer.service.ts
+++ b/projects/public-holdings-items/src/app/app-initializer.service.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Injectable, inject } from '@angular/core';
-import { AppStore } from '@rero/shared';
-import { Observable } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { AppStore, AppTranslateLanguageService } from '@rero/shared';
+import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { AppConfigService } from './app-config-service.service';
-import { TranslateService } from '@ngx-translate/core';
 
 @Injectable({
   providedIn: 'root'
@@ -15,6 +15,7 @@ export class AppInitializerService {
 
   private translateService = inject(TranslateService);
   private appStore = inject<InstanceType<typeof AppStore>>(AppStore);
+  private translateLanguageService = inject(AppTranslateLanguageService);
   private appConfigService = inject(AppConfigService);
 
   load(): Observable<any> {
@@ -27,10 +28,12 @@ export class AppInitializerService {
     let language = this.appStore.settings()?.language;
     if (language == null) {
       const browserLang = this.translateService.getBrowserLang();
-      language = browserLang.match(this.appConfigService.languages.join('|'))
+      language = (browserLang && this.appStore.availableLanguageCodes().includes(browserLang))
         ? browserLang
         : this.appConfigService.defaultLanguage;
     }
-    return this.translateService.use(language);
+    return from(this.translateLanguageService.loadLanguageNow(language)).pipe(
+      switchMap(() => this.translateService.use(language))
+    );
   }
 }

--- a/projects/public-holdings-items/src/app/app.config.ts
+++ b/projects/public-holdings-items/src/app/app.config.ts
@@ -9,7 +9,8 @@ import { withFormlyPrimeNG } from '@ngx-formly/primeng';
 import { provideLoadingBar } from '@ngx-loading-bar/core';
 import { provideLoadingBarInterceptor } from '@ngx-loading-bar/http-client';
 import { TranslateService, provideTranslateLoader, provideTranslateService } from '@ngx-translate/core';
-import { CoreConfigService, CoreTranslateLoader, NgCoreTranslateService, primeNGConfig, provideCore } from '@rero/ng-core';
+import { CoreConfigService, NgCoreTranslateService, TranslateLanguageService, primeNGConfig, provideCore } from '@rero/ng-core';
+import { AppTranslateLanguageService, AppTranslateLoader, AppTranslateService } from '@rero/shared';
 import { providePrimeNG } from 'primeng/config';
 import { AppConfigService } from './app-config-service.service';
 import { AppInitializerService } from './app-initializer.service';
@@ -21,9 +22,11 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(),
     providePrimeNG(primeNGConfig),
     provideTranslateService({
-      loader: provideTranslateLoader(CoreTranslateLoader),
+      loader: provideTranslateLoader(AppTranslateLoader),
     }),
     { provide: TranslateService, useExisting: NgCoreTranslateService },
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
     provideFormlyCore(withFormlyPrimeNG()),
     provideLoadingBar({}),
     provideLoadingBarInterceptor(),

--- a/projects/public-holdings-items/src/environments/environment.prod.ts
+++ b/projects/public-holdings-items/src/environments/environment.prod.ts
@@ -2,11 +2,11 @@ export const environment = {
   production: true,
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/static/node_modules/@rero/rero-ils-ui/dist/public-holdings-items/browser/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/static/node_modules/@rero/rero-ils-ui/dist/public-holdings-items/browser/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/rero-ils-ui/dist/public-holdings-items/browser',
 };

--- a/projects/public-holdings-items/src/environments/environment.ts
+++ b/projects/public-holdings-items/src/environments/environment.ts
@@ -6,11 +6,11 @@ export const environment = {
   production: false,
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '',
 };

--- a/projects/public-patron-profile/src/app/app-initializer.service.spec.ts
+++ b/projects/public-patron-profile/src/app/app-initializer.service.spec.ts
@@ -6,7 +6,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgCoreTranslateService } from '@rero/ng-core';
-import { AppStore } from '@rero/shared';
+import { AppStore, AppTranslateLanguageService } from '@rero/shared';
 
 import { AppConfigService } from '@app/admin/service/app-config.service';
 import { of } from 'rxjs';
@@ -40,6 +40,7 @@ describe('AppInitializerService', () => {
         { provide: AppStore, useValue: { load: vi.fn().mockReturnValue(of(null)), settings: vi.fn().mockReturnValue({ language: 'en' }), user: vi.fn().mockReturnValue(null) } },
         { provide: PatronProfileStore, useValue: { init: vi.fn() } },
         { provide: NgCoreTranslateService, useValue: ngCoreTranslateServiceSpy },
+        { provide: AppTranslateLanguageService, useValue: { loadLanguageNow: vi.fn().mockResolvedValue(undefined) } },
         { provide: AppConfigService, useValue: appConfigServiceSpy }
       ]
     });

--- a/projects/public-patron-profile/src/app/app-initializer.service.ts
+++ b/projects/public-patron-profile/src/app/app-initializer.service.ts
@@ -3,10 +3,10 @@
 
 import { inject, Injectable } from '@angular/core';
 import { NgCoreTranslateService } from '@rero/ng-core';
-import { AppStore } from '@rero/shared';
 import { AppConfigService } from '@app/admin/service/app-config.service';
 import { PatronProfileStore } from '@app/public-search/patron-profile/store/patron-profile.store';
-import { Observable } from 'rxjs';
+import { AppStore, AppTranslateLanguageService } from '@rero/shared';
+import { from, Observable } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 
 @Injectable({
@@ -17,6 +17,7 @@ export class AppInitializerService {
   private appStore = inject(AppStore);
   private store = inject(PatronProfileStore);
   private translateService = inject(NgCoreTranslateService);
+  private translateLanguageService = inject(AppTranslateLanguageService);
   private appConfigService = inject(AppConfigService);
 
   load(): Observable<any> {
@@ -33,10 +34,12 @@ export class AppInitializerService {
     let language = this.appStore.settings()?.language;
     if (language == null) {
       const browserLang = this.translateService.getBrowserLang() ?? '';
-      language = browserLang.match(this.appConfigService.languages.join('|'))
+      language = (browserLang && this.appStore.availableLanguageCodes().includes(browserLang))
         ? browserLang
         : this.appConfigService.defaultLanguage;
     }
-    return this.translateService.use(language);
+    return from(this.translateLanguageService.loadLanguageNow(language)).pipe(
+      switchMap(() => this.translateService.use(language))
+    );
   }
 }

--- a/projects/public-patron-profile/src/app/app.config.ts
+++ b/projects/public-patron-profile/src/app/app.config.ts
@@ -13,7 +13,8 @@ import { patronProfileRoutes } from '@app/public-search/routes/patron-profile-ro
 import { FORMLY_CONFIG, provideFormlyCore } from '@ngx-formly/core';
 import { provideLoadingBarInterceptor } from '@ngx-loading-bar/http-client';
 import { TranslateService, provideTranslateLoader, provideTranslateService } from '@ngx-translate/core';
-import { CoreConfigService, CoreTranslateLoader, NgCoreTranslateService, primeNGConfig, registerNgCoreFormlyExtension, withNgCoreFormly } from '@rero/ng-core';
+import { CoreConfigService, NgCoreTranslateService, TranslateLanguageService, primeNGConfig, registerNgCoreFormlyExtension, withNgCoreFormly } from '@rero/ng-core';
+import { AppTranslateLanguageService, AppTranslateLoader, AppTranslateService } from '@rero/shared';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { providePrimeNG } from 'primeng/config';
 import { AppConfigService } from './app-config-service.service';
@@ -46,8 +47,10 @@ export const appConfig: ApplicationConfig = {
     },
     providePrimeNG(primeNGConfig),
     provideTranslateService({
-      loader: provideTranslateLoader(CoreTranslateLoader),
+      loader: provideTranslateLoader(AppTranslateLoader),
     }),
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
     provideLoadingBarInterceptor(),
     provideAppInitializer(() => {
       const appInitializerService = inject(AppInitializerService);

--- a/projects/public-patron-profile/src/environments/environment.prod.ts
+++ b/projects/public-patron-profile/src/environments/environment.prod.ts
@@ -5,11 +5,11 @@ export const environment = {
   projectTitle: 'RERO ILS',
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/static/node_modules/@rero/rero-ils-ui/dist/public-patron-profile/browser/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/static/node_modules/@rero/rero-ils-ui/dist/public-patron-profile/browser/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/rero-ils-ui/dist/public-patron-profile/browser',
 };

--- a/projects/public-patron-profile/src/environments/environment.ts
+++ b/projects/public-patron-profile/src/environments/environment.ts
@@ -10,11 +10,11 @@ export const environment = {
   projectTitle: 'RERO ILS',
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '',
 };

--- a/projects/public-search/src/app/app-config.service.ts
+++ b/projects/public-search/src/app/app-config.service.ts
@@ -27,8 +27,8 @@ export class AppConfigService extends CoreConfigService {
     this.projectTitle = environment.projectTitle;
     this.apiBaseUrl = environment.apiBaseUrl;
     this.$refPrefix = environment.$refPrefix;
-    this.languages = environment.languages;
     this.globalViewName = environment.globalViewName;
     this.translationsURLs = environment.translationsURLs;
+    this.ngCoreAssetsUrl = environment.ngCoreAssetsUrl ?? '';
   }
 }

--- a/projects/public-search/src/app/app-initializer.service.spec.ts
+++ b/projects/public-search/src/app/app-initializer.service.spec.ts
@@ -5,7 +5,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { NgCoreTranslateService } from '@rero/ng-core';
-import { AppStore, testUserPatronWithSettings, User } from '@rero/shared';
+import { AppStore, AppTranslateLanguageService, testUserPatronWithSettings, User } from '@rero/shared';
 import { of } from 'rxjs';
 import { AppConfigService } from './app-config.service';
 import { AppInitializerService } from './app-initializer.service';
@@ -22,6 +22,7 @@ describe('AppInitializerService', () => {
       provideHttpClientTesting(),
       { provide: AppStore, useValue: appStoreSpy },
       { provide: NgCoreTranslateService, useValue: { getBrowserLang: vi.fn().mockReturnValue('en'), initialize: vi.fn(), use: vi.fn().mockReturnValue(of(null)) } },
+      { provide: AppTranslateLanguageService, useValue: { loadLanguageNow: vi.fn().mockResolvedValue(undefined) } },
       { provide: AppConfigService, useValue: { languages: ['en', 'fr', 'de', 'it'], defaultLanguage: 'en' } }
     ]
   }));

--- a/projects/public-search/src/app/app-initializer.service.ts
+++ b/projects/public-search/src/app/app-initializer.service.ts
@@ -4,8 +4,8 @@
 import { inject, Injectable } from '@angular/core';
 import { InterpolatableTranslationObject } from '@ngx-translate/core';
 import { NgCoreTranslateService } from '@rero/ng-core';
-import { AppStore } from '@rero/shared';
-import { Observable } from 'rxjs';
+import { AppStore, AppTranslateLanguageService } from '@rero/shared';
+import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { AppConfigService } from './app-config.service';
 
@@ -15,8 +15,9 @@ import { AppConfigService } from './app-config.service';
 export class AppInitializerService {
 
   private appStore = inject(AppStore);
-  private translateService: NgCoreTranslateService = inject(NgCoreTranslateService);
-  private appConfigService: AppConfigService = inject(AppConfigService);
+  private translateService = inject(NgCoreTranslateService);
+  private translateLanguageService = inject(AppTranslateLanguageService);
+  private appConfigService = inject(AppConfigService);
 
   load(): Observable<InterpolatableTranslationObject> {
     return this.appStore.load().pipe(
@@ -30,11 +31,13 @@ export class AppInitializerService {
       language = this.appConfigService.defaultLanguage;
       const browserLang = this.translateService.getBrowserLang();
       if (browserLang) {
-        language = browserLang.match(this.appConfigService.languages.join('|'))
+        language = this.appStore.availableLanguageCodes().includes(browserLang)
           ? browserLang
           : this.appConfigService.defaultLanguage;
       }
     }
-    return this.translateService.use(language);
+    return from(this.translateLanguageService.loadLanguageNow(language)).pipe(
+      switchMap(() => this.translateService.use(language))
+    );
   }
 }

--- a/projects/public-search/src/app/app.config.ts
+++ b/projects/public-search/src/app/app.config.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { ApplicationConfig, importProvidersFrom, inject, LOCALE_ID, provideAppInitializer, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { FormlyModule, provideFormlyCore } from '@ngx-formly/core';
-import { TranslateLoader as BaseCoreTranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
-import { CoreConfigService, CoreTranslateLoader, httpPendingInterceptor, NgCoreTranslateService, primeNGConfig, TruncateTextPipe, withNgCoreFormly } from '@rero/ng-core';
-import { MainTitlePipe } from '@rero/shared';
+import { provideTranslateLoader, provideTranslateService, TranslateService } from '@ngx-translate/core';
+import { CoreConfigService, httpPendingInterceptor, NgCoreTranslateService, primeNGConfig, TranslateLanguageService, TruncateTextPipe, withNgCoreFormly } from '@rero/ng-core';
+import { AppTranslateLanguageService, AppTranslateLoader, AppTranslateService, MainTitlePipe } from '@rero/shared';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { providePrimeNG } from 'primeng/config';
 import { AppConfigService } from './app-config.service';
@@ -18,16 +18,9 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(APP_ROUTES),
     provideHttpClient(withInterceptors([httpPendingInterceptor])),
-    importProvidersFrom(
-      TranslateModule.forRoot({
-        loader: {
-          provide: BaseCoreTranslateLoader,
-          useClass: CoreTranslateLoader,
-          deps: [CoreConfigService, HttpClient],
-        },
-        isolate: false,
-      })
-    ),
+    provideTranslateService({
+      loader: provideTranslateLoader(AppTranslateLoader),
+    }),
     provideFormlyCore(withNgCoreFormly() as any),
     importProvidersFrom(FormlyModule.forChild({})),
     providePrimeNG(primeNGConfig),
@@ -37,6 +30,8 @@ export const appConfig: ApplicationConfig = {
     }),
     { provide: CoreConfigService, useClass: AppConfigService },
     { provide: TranslateService, useExisting: NgCoreTranslateService },
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
     { provide: LOCALE_ID, useFactory: (translate: TranslateService) => translate.getCurrentLang(), deps: [TranslateService] },
     MainTitlePipe,
     TruncateTextPipe,

--- a/projects/public-search/src/app/patron-profile/patron-profile-personal-editor/patron-profile-personal-editor.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-personal-editor/patron-profile-personal-editor.component.ts
@@ -78,7 +78,7 @@ export class PatronProfilePersonalEditorComponent implements OnInit, OnDestroy {
                   ? this._cssConfig[fkey]
                   : this._cssConfig.default;
                 // Deactivation of the fields if we have a patron record
-                if ((this.appStore.user()?.roles.length > 0) && (field.key !== undefined && disabledFields.includes(fkey))) {
+                if ((this.appStore.user()?.profile.roles.length > 0) && (field.key !== undefined && disabledFields.includes(fkey))) {
                   field.props!.disabled = true;
                 }
                 // Hide password field

--- a/projects/public-search/src/app/patron-profile/patron-profile-personal/patron-profile-personal.component.spec.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-personal/patron-profile-personal.component.spec.ts
@@ -79,7 +79,7 @@ describe('PatronProfilePersonalComponent', () => {
     fixture = TestBed.createComponent(PatronProfilePersonalComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('patron', testUserPatronWithSettings.patrons[0]);
-    fixture.componentRef.setInput('user', testUserPatronWithSettings);
+    fixture.componentRef.setInput('user', testUserPatronWithSettings.user);
     fixture.detectChanges();
   });
 
@@ -105,7 +105,7 @@ describe('PatronProfilePersonalComponent', () => {
       'The loan history is visible in your patron account.'
     );
 
-    const user = cloneDeep(testUserPatronWithSettings);
+    const user = cloneDeep(testUserPatronWithSettings.user);
     user.keep_history = false;
     fixture.componentRef.setInput('user', user);
     fixture.detectChanges();

--- a/projects/public-search/src/app/patron-profile/store/patron-profile.store.spec.ts
+++ b/projects/public-search/src/app/patron-profile/store/patron-profile.store.spec.ts
@@ -54,7 +54,7 @@ describe('PatronProfileStore', () => {
 
     it('should handle user with no patron role', () => {
       const noPatron = new User({ ...testUserPatronMultipleOrganisationsWithSettings,
-        patrons: [{ ...testUserPatronMultipleOrganisationsWithSettings.patrons[0], roles: ['librarian'] }] });
+        patrons: [{ ...testUserPatronMultipleOrganisationsWithSettings.patrons[0], roles: ['librarian' as const] }] });
       store.init(noPatron);
       expect(store.patrons()).toHaveLength(0);
       expect(store.currentPatron()).toBeNull();

--- a/projects/public-search/src/app/patron-profile/store/patron-profile.store.ts
+++ b/projects/public-search/src/app/patron-profile/store/patron-profile.store.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { computed } from '@angular/core';
 import { patchState, signalMethod, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
-import { IPatron, IUser } from '@rero/shared';
+import { IPatron, User } from '@rero/shared';
 
 export type IMenu = { value: string; name: string; };
 
@@ -31,7 +31,7 @@ export const PatronProfileStore = signalStore(
     isMultiOrganisation: computed(() => menu().length > 1),
   })),
   withMethods((store) => ({
-    init(user: IUser): void {
+    init(user: User): void {
       const patrons = user.patrons.filter(p => p.roles.includes('patron'));
       const menu = patrons.map(p => ({ value: p.pid, name: p.organisation.name }));
       patchState(store, { patrons, menu, currentPatron: patrons[0] ?? null, currentMenu: menu[0] ?? null });

--- a/projects/public-search/src/environments/environment.prod.ts
+++ b/projects/public-search/src/environments/environment.prod.ts
@@ -5,11 +5,11 @@ export const environment = {
   projectTitle: 'RERO ILS',
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/static/node_modules/@rero/rero-ils-ui/dist/public-search/browser/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/static/node_modules/@rero/rero-ils-ui/dist/public-search/browser/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/rero-ils-ui/dist/public-search/browser',
 };

--- a/projects/public-search/src/environments/environment.ts
+++ b/projects/public-search/src/environments/environment.ts
@@ -10,11 +10,11 @@ export const environment = {
   projectTitle: 'RERO ILS',
   apiBaseUrl: "",
   $refPrefix: "https://bib.rero.ch",
-  languages: ["fr", "de", "it", "en"],
   globalViewName: "global",
   translationsURLs: [
     "/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '',
 };

--- a/projects/search-bar/src/app/app-config.service.ts
+++ b/projects/search-bar/src/app/app-config.service.ts
@@ -4,29 +4,14 @@ import { Injectable } from '@angular/core';
 import { CoreConfigService } from '@rero/ng-core';
 import { environment } from '../environments/environment';
 
-
 @Injectable({
   providedIn: 'root'
 })
 export class AppConfigService extends CoreConfigService {
 
-  /** Global View Name */
-  globalViewName: string;
-
-  /** Translation urls */
-  translationsURLs: string[];
-
-  /**
-   * Constructor
-   */
   constructor() {
     super();
     this.production = environment.production;
-    this.projectTitle = environment.projectTitle;
-    this.apiBaseUrl = environment.apiBaseUrl;
-    this.$refPrefix = environment.$refPrefix;
-    this.schemaFormEndpoint = '/schemas';
-    this.globalViewName = environment.globalViewName;
     this.translationsURLs = environment.translationsURLs;
     this.ngCoreAssetsUrl = environment.ngCoreAssetsUrl ?? '';
   }

--- a/projects/search-bar/src/app/app.config.ts
+++ b/projects/search-bar/src/app/app.config.ts
@@ -5,20 +5,24 @@ import { provideHttpClient } from '@angular/common/http';
 import { ApplicationConfig, inject, provideAppInitializer, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { TranslateService, provideTranslateLoader, provideTranslateService } from '@ngx-translate/core';
-import { CoreTranslateLoader, NgCoreTranslateService, TruncateTextPipe, primeNGConfig } from '@rero/ng-core';
-import { AppStore, MainTitlePipe } from '@rero/shared';
+import { CoreConfigService, NgCoreTranslateService, TranslateLanguageService, TruncateTextPipe, primeNGConfig } from '@rero/ng-core';
+import { AppStore, AppTranslateLanguageService, AppTranslateLoader, AppTranslateService, MainTitlePipe } from '@rero/shared';
 import { providePrimeNG } from 'primeng/config';
+import { AppConfigService } from './app-config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter([]),
+    { provide: CoreConfigService, useExisting: AppConfigService },
     provideZonelessChangeDetection(),
     provideHttpClient(),
     providePrimeNG(primeNGConfig),
     provideTranslateService({
-      loader: provideTranslateLoader(CoreTranslateLoader),
+      loader: provideTranslateLoader(AppTranslateLoader),
     }),
     { provide: TranslateService, useExisting: NgCoreTranslateService },
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
     provideAppInitializer(() => {
       return inject(AppStore).load();
     }),

--- a/projects/search-bar/src/environments/environment.prod.ts
+++ b/projects/search-bar/src/environments/environment.prod.ts
@@ -5,4 +5,5 @@ export const environment = {
     "/static/node_modules/@rero/rero-ils-ui/dist/search-bar/browser/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
   ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/rero-ils-ui/dist/search-bar/browser',
 };

--- a/projects/search-bar/src/environments/environment.ts
+++ b/projects/search-bar/src/environments/environment.ts
@@ -8,5 +8,6 @@ export const environment = {
     "/assets/rero-ils-ui/shared/i18n/${lang}.json",
     "/assets/rero-ils-ui/public-search/i18n/${lang}.json",
     "/api/translations/${lang}.json",
-  ]
+  ],
+  ngCoreAssetsUrl: '',
 };

--- a/projects/shared/src/lib/classes/user.spec.ts
+++ b/projects/shared/src/lib/classes/user.spec.ts
@@ -1,14 +1,16 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 import { cloneDeep } from 'lodash-es';
 import { testUserPatronLibrarian } from '../../tests/user';
-import { User } from './user';
+import { User, UserConstructorData } from './user';
+
+const testUserData: UserConstructorData = testUserPatronLibrarian;
 
 describe('User', () => {
   let user: User;
+
   beforeEach(() => {
-    user = new User(testUserPatronLibrarian);
+    user = new User(testUserData);
   });
 
   it('should create an instance', () => {
@@ -16,52 +18,48 @@ describe('User', () => {
   });
 
   it('should return false if the user is not present', () => {
-    user = new User({});
+    user = new User({ user: { ...testUserPatronLibrarian.user, username: '' }, patrons: [], permissions: [] });
     expect(user.isAuthenticated).toBeFalsy();
   });
 
-  it('Should return true if the user is present', () => {
+  it('should return true if the user is present', () => {
     expect(user.isAuthenticated).toBeTruthy();
   });
 
-  it('Should return the parameter displayPatronMode', () => {
+  it('should return the parameter displayPatronMode', () => {
     expect(user.displayPatronMode).toBeTruthy();
     user.displayPatronMode = false;
     expect(user.displayPatronMode).toBeFalsy();
   });
 
-  it('Should return the parameter hasAdminUIAccess', () => {
+  it('should return the parameter hasAdminUIAccess', () => {
     expect(user.hasAdminUiAccess).toBeTruthy();
   });
 
-  it('Should return the parameter patronLibrarian', () => {
+  it('should return the parameter patronLibrarian', () => {
     expect(user.patronLibrarian).toEqual(testUserPatronLibrarian.patrons![1]);
   });
 
-  it('Should return the parameter isPatron', () => {
-    const user1 = cloneDeep(testUserPatronLibrarian);
-    const user2 = cloneDeep(testUserPatronLibrarian);
-    user1.patrons = user1.patrons!.splice(0, 1);
-    user = new User(user1);
-    expect(user.isPatron).toBeTruthy();
-    user2.patrons = user2.patrons!.splice(1, 1);
-    user = new User(user2);
-    expect(user.isPatron).toBeFalsy();
+  it('should return the parameter isPatron', () => {
+    const data1 = { ...testUserData, patrons: cloneDeep(testUserPatronLibrarian.patrons!).splice(0, 1) };
+    expect(new User(data1).isPatron).toBeTruthy();
+    const data2 = { ...testUserData, patrons: cloneDeep(testUserPatronLibrarian.patrons!).splice(1, 1) };
+    expect(new User(data2).isPatron).toBeFalsy();
   });
 
-  it('Should return the current library', () => {
+  it('should return the current library', () => {
     expect(user.currentLibrary).toBeUndefined();
     user.currentLibrary = '2';
     expect(user.currentLibrary).toEqual('2');
   });
 
-  it('Should return the current organisation', () => {
+  it('should return the current organisation', () => {
     expect(user.currentOrganisation).toBeUndefined();
     user.currentOrganisation = '1';
     expect(user.currentOrganisation).toEqual('1');
   });
 
-  it('Should return a boolean for hasRoles', () => {
+  it('should return a boolean for hasRoles', () => {
     expect(user.hasRoles(['patron', 'librarian'])).toBeTruthy();
     expect(user.hasRoles(['patron', 'medium'])).toBeFalsy();
     expect(user.hasRoles(['patron', 'medium'], 'or')).toBeTruthy();
@@ -74,5 +72,11 @@ describe('User', () => {
   it('should return the patron according to the organisation pid', () => {
     expect(user.getPatronByOrganisationPid('2')).toEqual(testUserPatronLibrarian.patrons![0]);
     expect(user.getPatronByOrganisationPid('unknown')).toBeUndefined();
+  });
+
+  it('should expose profile, patrons and permissions', () => {
+    expect(user.profile).toEqual(testUserPatronLibrarian.user);
+    expect(user.patrons).toEqual(testUserData.patrons);
+    expect(user.permissions).toEqual(testUserData.permissions);
   });
 });

--- a/projects/shared/src/lib/classes/user.ts
+++ b/projects/shared/src/lib/classes/user.ts
@@ -1,13 +1,134 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 import { PERMISSIONS } from "../util/permissions";
 
-export class User implements IUser {
+export class User {
 
   /** Logged user API url */
   static readonly LOGGED_URL = '/patrons/logged_user?resolve';
 
+  readonly profile: IUserProfile;
+  readonly patrons: IPatron[];
+  readonly permissions: string[];
+
+  private _isAuthenticated = false;
+  private _displayPatronMode = true;
+  private _currentLibrary?: string;
+  private _currentOrganisation?: string;
+  private _patronLibrarian?: IPatron;
+  private _symbolName: string;
+  private _patronRoles: string[];
+
+  get id(): number {
+    return this.profile.id;
+  }
+
+  get pid(): string | undefined {
+    return this.profile.pid;
+  }
+
+  get keep_history(): boolean {
+    return this.profile.keep_history;
+  }
+
+  get isAuthenticated(): boolean {
+    return this._isAuthenticated;
+  }
+
+  set displayPatronMode(mode: boolean) {
+    this._displayPatronMode = mode;
+  }
+
+  get displayPatronMode(): boolean {
+    return this._displayPatronMode;
+  }
+
+  get hasAdminUiAccess(): boolean {
+    return this.permissions.includes(PERMISSIONS.UI_ACCESS);
+  }
+
+  get patronLibrarian(): IPatron | undefined {
+    return this._patronLibrarian;
+  }
+
+  get symbolName(): string {
+    return this._symbolName;
+  }
+
+  get isPatron(): boolean {
+    return this.patrons.some((patron: IPatron) => 'patron' in patron);
+  }
+
+  set currentLibrary(library: string) {
+    this._currentLibrary = library;
+  }
+
+  get currentLibrary(): string | undefined {
+    return this._currentLibrary;
+  }
+
+  set currentOrganisation(organisation: string) {
+    this._currentOrganisation = organisation;
+  }
+
+  get currentOrganisation(): string | undefined {
+    return this._currentOrganisation;
+  }
+
+  get patronRoles(): string[] {
+    return this._patronRoles;
+  }
+
+  constructor({ user, patrons, permissions }: UserConstructorData) {
+    this.profile = user;
+    this.patrons = patrons;
+    this.permissions = permissions;
+    this._isAuthenticated = Boolean(user.username);
+    this._patronLibrarian = this._extractLibrarian();
+    this._symbolName = this._generateSymbolName();
+    this._patronRoles = this._extractPatronRoles();
+  }
+
+  getPatronByOrganisationPid(pid: string): IPatron | undefined {
+    return this.patrons.find(
+      (patron: IPatron) => 'patron' in patron && patron.organisation?.pid === pid
+    );
+  }
+
+  hasRoles(roles: string[], operator: 'and' | 'or' = 'and'): boolean {
+    const intersection = roles.filter(role => this._patronRoles.includes(role));
+    return operator === 'and'
+      ? intersection.length === roles.length
+      : intersection.length > 0;
+  }
+
+  private _extractLibrarian(): IPatron | undefined {
+    return this.patrons.find((patron: IPatron) => (patron.libraries?.length ?? 0) > 0);
+  }
+
+  private _generateSymbolName(): string {
+    const { first_name, last_name } = this.profile;
+    if (!first_name && !last_name) {
+      return 'AN';
+    }
+    return (first_name && last_name)
+      ? (first_name[0] + last_name[0]).toUpperCase()
+      : (first_name || last_name).slice(0, 2).toUpperCase();
+  }
+
+  private _extractPatronRoles(): string[] {
+    const roles = this.patrons.flatMap((patron: IPatron) => patron.roles);
+    return [...new Set(roles)].sort();
+  }
+}
+
+export type UserConstructorData = {
+  user: IUserProfile;
+  patrons: IPatron[];
+  permissions: string[];
+};
+
+export type IUserProfile = {
   id: number;
   pid?: string;
   first_name: string;
@@ -25,249 +146,15 @@ export class User implements IUser {
   other_phone?: string;
   keep_history: boolean;
   email?: string;
-  roles: string[] = [];
-  patrons?: IPatron[] = [];
-  permissions: string[];
-
-  /** private _isLogged */
-  private _isAuthenticated = false;
-
-  /** Display Patron Mode */
-  private _displayPatronMode = true;
-
-  /** Current library */
-  private _currentLibrary?: string;
-
-  /** Current organisation */
-  private _currentOrganisation?: string;
-
-  /** Current budget for the organisation */
-  currentBudget?: string;
-
-  /** Librarian (patron record) */
-  private _patronLibrarian?: IPatron;
-
-  /** User symbol name (2 letters) */
-  private _symbolName: string;
-
-  /** All patron roles */
-  private _patronRoles: string[];
-
-  /**
-   * Is authenticated
-   * @return boolean
-   */
-  get isAuthenticated(): boolean {
-    return this._isAuthenticated;
-  }
-
-  /**
-   * Set display patron mode
-   * @param mode - boolean
-   */
-  set displayPatronMode(mode: boolean) {
-    this._displayPatronMode = mode;
-  }
-
-  /**
-   * Get display patron mode
-   * @return boolean
-   */
-  get displayPatronMode(): boolean {
-    return this._displayPatronMode;
-  }
-
-  /**
-   * Is granted to access to admin UI
-   * @return boolean
-   */
-  get hasAdminUiAccess(): boolean {
-    return this.permissions.includes(PERMISSIONS.UI_ACCESS);
-  }
-
-  /**
-   * Get patron record librarian
-   * @return IPatron
-   */
-  get patronLibrarian(): IPatron {
-    return this._patronLibrarian;
-  }
-
-  /**
-   * Get user symbol name (2 letters)
-   * @return string
-   */
-  get symbolName(): string {
-    return this._symbolName;
-  }
-
-  /**
-   * Is the user a patron
-   * @return boolean
-   */
-  get isPatron(): boolean {
-    return this.patrons?.some((patron: IPatron) => 'patron' in patron);
-  }
-
-  /**
-   * Set current library
-   * @param library - string
-   */
-  set currentLibrary(library: string) {
-    this._currentLibrary = library;
-  }
-
-  /**
-   * Get current library
-   * @return string
-   */
-  get currentLibrary(): string {
-    return this._currentLibrary;
-  }
-
-  /**
-   * Set current organisation
-   * @param organisation - string
-   */
-  set currentOrganisation(organisation: string) {
-    this._currentOrganisation = organisation;
-  }
-
-  /**
-   * Get current organisation
-   * @retun string
-   */
-  get currentOrganisation(): string {
-    return this._currentOrganisation;
-  }
-
-  /**
-   * Get all patrons roles
-   * @return array of role
-   */
-  get patronRoles(): string[] {
-    return this._patronRoles;
-  }
-
-  /**
-   * Constructor
-   * @param user - object | User
-   */
-  constructor(user: any) {
-    // Check if the user is authenticated
-    // by looking if keys exist in the object
-    const keys = Object.keys(user);
-    if (keys.length > 0) {
-      this._isAuthenticated = keys.includes('username');
-      this._initialize(user);
-    }
-  }
-
-  /**
-   * Get patron by organisation pid
-   * @param pid - string
-   * @return IPatron or undefined
-   */
-   getPatronByOrganisationPid(pid: string): IPatron | undefined {
-    if (this.patrons && this.patrons.length > 0) {
-      const patrons = this.patrons.filter(
-        (patron: IPatron) => 'patron' in patron && patron.organisation!.pid === pid
-      );
-      return (patrons.length === 1) ? patrons[0] : undefined;
-    }
-    return undefined;
-  }
-
-  /**
-   * Check if the user has specific roles.
-   * @param roles: array of role to check
-   * @param operator: If 'and', then the user need to have all requested roles.
-   *                  If 'or', then the user need to have at least one of requested roles.
-   * @return boolean
-   */
-   hasRoles(roles: string[], operator: 'and' | 'or' = 'and'): boolean {
-    const intersection = roles.filter(role => this._patronRoles.includes(role));
-    return (operator === 'and')
-      ? intersection.length === roles.length  // all requested roles are present into user roles.
-      : intersection.length > 0; // at least one requested roles are present into user roles.
-  }
-
-  /**
-   * Initialize user object
-   * @param user - IUser
-   */
-  private _initialize(user: IUser): void {
-    Object.assign(this, user);
-    this._patronLibrarian = this._extractLibrarian();
-    this._symbolName = this._generateSymbolName();
-    this._patronRoles = this._extractPatronRoles();
-  }
-
-  /**
-   * Extract librarian (patron record)
-   * @return IPatron or undefined
-   */
-  private _extractLibrarian(): IPatron | undefined {
-    const patrons = this.patrons.filter((patron: IPatron) => {
-      if (patron.libraries?.length > 0) {
-        return patron;
-      }
-    });
-    return patrons.length > 0 ? patrons[0] : undefined;
-  }
-
-  /**
-   * Generate Symbol name
-   * @returns initials of the connected user
-   */
-   private _generateSymbolName(): string {
-    // If user isn't connected return 'AN' for 'Anonymous user'
-    if (!this.first_name && !this.last_name) {
-      return 'AN';
-    }
-    return (this.first_name)
-      ? (this.first_name[0]+this.last_name[0]).toUpperCase()
-      : this.last_name.slice(0, 2).toUpperCase();
-  }
-
-  /**
-   * Extract all roles for current user
-   * @returns array of roles
-   */
-  private _extractPatronRoles() {
-    let roles = [];
-    this.patrons.forEach((patron: IPatron) => {
-      roles = [...roles, ...patron.roles];
-    });
-    // Deduplicate roles
-    return roles.filter((item, pos) => roles.indexOf(item) === pos).sort();
-  }
-}
-
-/** Interface for user */
-export type IUser = {
-  id: number;
-  first_name: string;
-  last_name: string;
-  birth_date: string;
-  gender: string;
-  username: string;
-  street?: string;
-  postal_code?: string;
-  city?: string;
-  country?: string;
-  home_phone?: string;
-  business_phone?: string;
-  mobile_phone?: string;
-  other_phone?: string;
-  keep_history: boolean;
-  email?: string;
   roles: string[];
-  patrons?: IPatron[];
-  permissions: string[]
-}
+};
 
-/** Interface for patron */
+/** @deprecated Use IUserProfile */
+export type IUser = IUserProfile & {
+  patrons?: IPatron[];
+  permissions: string[];
+};
+
 export type IPatron = {
   pid: string;
   source?: string;
@@ -276,7 +163,7 @@ export type IPatron = {
     street?: string;
     postal_code?: string;
     city?: string;
-    country?: string
+    country?: string;
   };
   patron?: {
     barcode: string[];
@@ -288,12 +175,8 @@ export type IPatron = {
     subscriptions?: {
       start_date: Date;
       end_date: Date;
-      patron_type: {
-        pid: string;
-      };
-      patron_transaction?: {
-        pid: string;
-      }
+      patron_type: { pid: string };
+      patron_transaction?: { pid: string };
     };
     blocked?: boolean;
     blocked_note?: string;
@@ -303,25 +186,22 @@ export type IPatron = {
   libraries?: ILibrary[];
   organisation?: IOrganisation;
   roles: string[];
-}
+};
 
-/** Interface for organisation */
 export type IOrganisation = {
   pid: string;
   code?: string;
   name?: string;
   currency?: string;
-  budget?: {pid: string};
-}
+  budget?: { pid: string };
+};
 
-/** Interface for library */
 export type ILibrary = {
   pid: string;
   organisation: IOrganisation;
-}
+};
 
-/** Interface for patron type */
 export type IPatronType = {
   pid: string;
   type?: string;
-}
+};

--- a/projects/shared/src/lib/component/remote-search/remote-search.component.ts
+++ b/projects/shared/src/lib/component/remote-search/remote-search.component.ts
@@ -33,7 +33,7 @@ export class RemoteSearchComponent implements OnInit, OnDestroy {
   readonly placeholder = input('search');
   readonly viewcode = input<string | undefined>(undefined);
   readonly language = input(undefined);
-  readonly inputstyleclass = input<string | undefined>(undefined);
+  readonly inputstyleclass = input<string|undefined>();
   readonly styleclass = input<string | undefined>(undefined);
   readonly internalRoutingBaseURL = input<string | undefined>(undefined);
 

--- a/projects/shared/src/lib/pipe/extract-source-field.pipe.spec.ts
+++ b/projects/shared/src/lib/pipe/extract-source-field.pipe.spec.ts
@@ -10,7 +10,7 @@ import { ExtractSourceFieldPipe } from './extract-source-field.pipe';
 describe('Pipe: ExtractFieldSource', () => {
 
   let extractSourceFieldPipe: ExtractSourceFieldPipe;
-  let settings = testUserPatronWithSettings.settings;
+  const {settings} = testUserPatronWithSettings;
 
   const metadata = {
     idref: {
@@ -43,7 +43,6 @@ describe('Pipe: ExtractFieldSource', () => {
     });
 
     extractSourceFieldPipe = TestBed.inject(ExtractSourceFieldPipe);
-    settings = testUserPatronWithSettings.settings;
   });
 
   it('create an instance', () => {

--- a/projects/shared/src/lib/store/app.store.spec.ts
+++ b/projects/shared/src/lib/store/app.store.spec.ts
@@ -72,6 +72,10 @@ describe('AppStore', () => {
     it('isAuthenticated should be false', () => {
       expect(store.isAuthenticated()).toBe(false);
     });
+
+    it('availableLanguageCodes should be empty before load', () => {
+      expect(store.availableLanguageCodes()).toEqual([]);
+    });
   });
 
   describe('load()', () => {
@@ -203,6 +207,68 @@ describe('AppStore', () => {
     it('should return false for a resource absent from operationLogs settings', async () => {
       await firstValueFrom(store.load());
       expect(store.isLogVisible('patrons')).toBe(false);
+    });
+  });
+
+  describe('availableLanguageCodes', () => {
+    it('should return codes from settings after load', async () => {
+      await firstValueFrom(store.load());
+      expect(store.availableLanguageCodes()).toEqual(['fr']);
+    });
+
+    it('should reflect multiple languages when settings has several', async () => {
+      userApiServiceSpy.getLoggedUser.mockReturnValue(of({
+        ...testUserLibrarianWithSettings,
+        settings: {
+          ...testUserLibrarianWithSettings.settings,
+          availableLanguages: [
+            { code: 'fr', name: 'French' },
+            { code: 'de', name: 'German' },
+            { code: 'it', name: 'Italian' },
+          ]
+        }
+      }));
+      await firstValueFrom(store.load());
+      expect(store.availableLanguageCodes()).toEqual(['fr', 'de', 'it']);
+    });
+  });
+
+  describe('validateLibraryPermissions()', () => {
+    const fullPermissions = {
+      create: { can: true, reasons: {} },
+      read:   { can: true, reasons: {} },
+      update: { can: true, reasons: {} },
+      delete: { can: true, reasons: {} },
+      list:   { can: true, reasons: {} },
+    };
+
+    it('should not modify permissions when current library matches owner', () => {
+      store.setCurrentLibrary('lib1');
+      const result = store.validateLibraryPermissions({ ...fullPermissions }, 'lib1');
+      expect(result.create.can).toBe(true);
+      expect(result.update.can).toBe(true);
+      expect(result.delete.can).toBe(true);
+    });
+
+    it('should disable create, update and delete when library does not match', () => {
+      store.setCurrentLibrary('lib1');
+      const result = store.validateLibraryPermissions({ ...fullPermissions }, 'lib2');
+      expect(result.create.can).toBe(false);
+      expect(result.update.can).toBe(false);
+      expect(result.delete.can).toBe(false);
+    });
+
+    it('should keep read permission unchanged when library does not match', () => {
+      store.setCurrentLibrary('lib1');
+      const result = store.validateLibraryPermissions({ ...fullPermissions }, 'lib2');
+      expect(result.read.can).toBe(true);
+    });
+
+    it('should disable permissions when no library is set', () => {
+      const result = store.validateLibraryPermissions({ ...fullPermissions }, 'lib1');
+      expect(result.create.can).toBe(false);
+      expect(result.update.can).toBe(false);
+      expect(result.delete.can).toBe(false);
     });
   });
 

--- a/projects/shared/src/lib/store/app.store.ts
+++ b/projects/shared/src/lib/store/app.store.ts
@@ -11,9 +11,16 @@ import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { UserApiService } from '../api/user-api.service';
 import { Organisation } from '../classes/core';
 import { RecordPermission, RecordPermissions } from '../classes/permissions';
-import { User } from '../classes/user';
+import { IPatron, IUserProfile, User } from '../classes/user';
 import { PERMISSION_OPERATOR, PERMISSIONS } from '../util/permissions';
 import { setError, setFulfilled, setPending, withRequestStatus } from './request-status-feature';
+
+export type LoggedUserResponse = {
+  settings: ISettings;
+  permissions: string[];
+  user?: IUserProfile;
+  patrons?: IPatron[];
+};
 
 export type ISettings = {
   baseUrl: string;
@@ -28,6 +35,7 @@ export type ISettings = {
     readOnly: boolean;
     readOnlyFields: string[];
   };
+  availableLanguages: { code: string; name: string }[];
 };
 
 export type AppState = {
@@ -57,19 +65,22 @@ export const AppStore = signalStore(
   withComputed((store) => ({
     isLogged: () => store.user() !== null,
     isAuthenticated: () => store.user()?.isAuthenticated ?? false,
+    availableLanguageCodes: () => store.settings()?.availableLanguages.map(l => l.code) ?? [],
   })),
   withMethods((store, userApiService = inject(UserApiService), recordService = inject(RecordService)) => ({
-    load(): Observable<User> {
+    load(): Observable<User | null> {
       patchState(store, setPending());
       return userApiService.getLoggedUser().pipe(
-        tap((loggedUser: any) => {
-          const settings: ISettings = loggedUser.settings;
-          const permissions: string[] = loggedUser.permissions ?? [];
-          delete loggedUser['settings'];
-          const user = new User(loggedUser);
+        tap((loggedUser: LoggedUserResponse) => {
+          const { settings, permissions = [], user: profile, patrons = [] } = loggedUser;
+          if (!profile) {
+            patchState(store, { user: null, settings, permissions }, setFulfilled());
+            return;
+          }
+          const user = new User({ user: profile, patrons, permissions });
           patchState(store, { user, settings, permissions }, setFulfilled());
         }),
-        map(() => store.user()!),
+        map(() => store.user()),
         catchError((error: unknown) => {
           patchState(store, setError(String(error)));
           return EMPTY;

--- a/projects/shared/src/lib/translate/app-translate-language-service.spec.ts
+++ b/projects/shared/src/lib/translate/app-translate-language-service.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { TranslateLanguageService } from '@rero/ng-core';
+import { AppTranslateLanguageService, ngCoreLanguage } from './app-translate-language-service';
+
+describe('AppTranslateLanguageService', () => {
+  const frData = { fre: 'français', deu: 'allemand' };
+  const deData = { fre: 'Französisch', deu: 'Deutsch' };
+
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url: RequestInfo | URL) => {
+      const lang = String(url).match(/\/(\w+)\.json$/)?.[1];
+      const data = lang === 'fr' ? frData : lang === 'de' ? deData : {};
+      return Promise.resolve({ json: () => Promise.resolve(data) } as Response);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be a subclass of TranslateLanguageService', () => {
+    expect(AppTranslateLanguageService.prototype).toBeInstanceOf(TranslateLanguageService);
+  });
+
+  describe('ngCoreLanguage loaders', () => {
+    it('de loader should fetch from ng-core languages assets', async () => {
+      const result = await ngCoreLanguage('', 'de')();
+      expect(fetch).toHaveBeenCalledWith('/assets/rero-ils-ui/ng-core/languages/de.json');
+      expect(result).toEqual(deData);
+    });
+
+    it('fr loader should fetch from ng-core languages assets', async () => {
+      const result = await ngCoreLanguage('', 'fr')();
+      expect(fetch).toHaveBeenCalledWith('/assets/rero-ils-ui/ng-core/languages/fr.json');
+      expect(result).toEqual(frData);
+    });
+
+    it('should prefix the fetch URL with the given base', async () => {
+      await ngCoreLanguage('https://cdn.example', 'it')();
+      expect(fetch).toHaveBeenCalledWith('https://cdn.example/assets/rero-ils-ui/ng-core/languages/it.json');
+    });
+  });
+});

--- a/projects/shared/src/lib/translate/app-translate-language-service.ts
+++ b/projects/shared/src/lib/translate/app-translate-language-service.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { inject, Injectable } from '@angular/core';
+import { CoreConfigService, LanguageLoaderFn, TranslateLanguageService } from '@rero/ng-core';
+
+const SUPPORTED_LANGUAGES = ['de', 'fr', 'it'];
+
+export const ngCoreLanguage = (base: string, lang: string): LanguageLoaderFn =>
+  () => fetch(`${base}/assets/rero-ils-ui/ng-core/languages/${lang}.json`).then(r => r.json());
+
+@Injectable({ providedIn: 'root' })
+export class AppTranslateLanguageService extends TranslateLanguageService {
+  private coreConfigService = inject(CoreConfigService);
+
+  constructor() {
+    super();
+    this.translateService.onLangChange.subscribe(({ lang }) => {
+      if (SUPPORTED_LANGUAGES.includes(lang) && !(lang in this.availableLanguages)) {
+        const base = this.coreConfigService.ngCoreAssetsUrl ?? '';
+        this.loadLanguages({ [lang]: ngCoreLanguage(base, lang) }).catch(() => {
+          // Swallow to avoid breaking the language switch on asset load failure
+        });
+      }
+    });
+  }
+
+  loadLanguageNow(lang: string): Promise<void> {
+    if (SUPPORTED_LANGUAGES.includes(lang) && !(lang in this.availableLanguages)) {
+      const base = this.coreConfigService.ngCoreAssetsUrl ?? '';
+      return this.loadLanguages({ [lang]: ngCoreLanguage(base, lang) }).catch(() => undefined);
+    }
+    return Promise.resolve();
+  }
+}

--- a/projects/shared/src/lib/translate/app-translate-loader.spec.ts
+++ b/projects/shared/src/lib/translate/app-translate-loader.spec.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { CoreTranslateLoader } from '@rero/ng-core';
+import { AppTranslateLoader, ngCoreI18n } from './app-translate-loader';
+
+describe('AppTranslateLoader', () => {
+  it('should be a subclass of CoreTranslateLoader', () => {
+    expect(AppTranslateLoader.prototype).toBeInstanceOf(CoreTranslateLoader);
+  });
+
+  describe('ngCoreI18n loaders', () => {
+    it('de loader should fetch from ng-core i18n assets', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: () => Promise.resolve({ greeting: 'Hallo' }),
+      } as Response);
+
+      const result = await ngCoreI18n('', 'de')();
+
+      expect(fetchSpy).toHaveBeenCalledWith('/assets/rero-ils-ui/ng-core/i18n/de.json');
+      expect(result).toEqual({ default: { greeting: 'Hallo' } });
+    });
+
+    it('fr loader should fetch from ng-core i18n assets', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: () => Promise.resolve({ bonjour: 'Bonjour' }),
+      } as Response);
+
+      const result = await ngCoreI18n('', 'fr')();
+
+      expect(fetchSpy).toHaveBeenCalledWith('/assets/rero-ils-ui/ng-core/i18n/fr.json');
+      expect(result).toEqual({ default: { bonjour: 'Bonjour' } });
+    });
+
+    it('it loader should fetch from ng-core i18n assets', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: () => Promise.resolve({ saluto: 'Ciao' }),
+      } as Response);
+
+      const result = await ngCoreI18n('', 'it')();
+
+      expect(fetchSpy).toHaveBeenCalledWith('/assets/rero-ils-ui/ng-core/i18n/it.json');
+      expect(result).toEqual({ default: { saluto: 'Ciao' } });
+    });
+  });
+});

--- a/projects/shared/src/lib/translate/app-translate-loader.ts
+++ b/projects/shared/src/lib/translate/app-translate-loader.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { inject, Injectable } from '@angular/core';
+import { CORE_TRANSLATION_LOADERS, CoreConfigService, CoreTranslateLoader, TranslationLoaderFn } from '@rero/ng-core';
+
+export const ngCoreI18n = (base: string, lang: string): TranslationLoaderFn =>
+  () => fetch(`${base}/assets/rero-ils-ui/ng-core/i18n/${lang}.json`)
+    .then(r => r.json())
+    .then(data => ({ default: data }));
+
+@Injectable()
+export class AppTranslateLoader extends CoreTranslateLoader {
+  constructor() {
+    super();
+    const base = inject(CoreConfigService).ngCoreAssetsUrl ?? '';
+    this.coreTranslationLoaders = {
+      ...CORE_TRANSLATION_LOADERS,
+      de: ngCoreI18n(base, 'de'),
+      fr: ngCoreI18n(base, 'fr'),
+      it: ngCoreI18n(base, 'it'),
+    };
+  }
+}

--- a/projects/shared/src/lib/translate/app-translate-service.spec.ts
+++ b/projects/shared/src/lib/translate/app-translate-service.spec.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
+import { CORE_LOCALES, NgCoreTranslateService } from '@rero/ng-core';
+import { de } from 'primelocale/js/de.js';
+import { fr } from 'primelocale/js/fr.js';
+import { it as itLocale } from 'primelocale/js/it.js';
+import { AppTranslateService } from './app-translate-service';
+
+describe('AppTranslateService', () => {
+  it('should be a subclass of NgCoreTranslateService', () => {
+    expect(AppTranslateService.prototype).toBeInstanceOf(NgCoreTranslateService);
+  });
+
+  it('should declare locale data for de, fr and it', () => {
+    expect(localeDe).toBeDefined();
+    expect(localeFr).toBeDefined();
+    expect(localeIt).toBeDefined();
+    expect(de).toBeDefined();
+    expect(fr).toBeDefined();
+    expect(itLocale).toBeDefined();
+  });
+
+  it('CORE_LOCALES should contain at least one language', () => {
+    expect(Object.keys(CORE_LOCALES).length).toBeGreaterThan(0);
+  });
+});

--- a/projects/shared/src/lib/translate/app-translate-service.ts
+++ b/projects/shared/src/lib/translate/app-translate-service.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
+import { Injectable } from '@angular/core';
+import { CORE_LOCALES, Locales, NgCoreTranslateService } from '@rero/ng-core';
+import { de } from 'primelocale/js/de.js';
+import { fr } from 'primelocale/js/fr.js';
+import { it } from 'primelocale/js/it.js';
+
+@Injectable({ providedIn: 'root' })
+export class AppTranslateService extends NgCoreTranslateService {
+  override locales: Locales = {
+    ...CORE_LOCALES,
+    de: { angular: localeDe, primeng: de },
+    fr: { angular: localeFr, primeng: fr },
+    it: { angular: localeIt, primeng: it },
+  };
+}

--- a/projects/shared/src/public-api.ts
+++ b/projects/shared/src/public-api.ts
@@ -52,6 +52,9 @@ export * from './lib/pipe/url-active.pipe';
 export * from './lib/service/i-availability.service';
 
 export * from './lib/store/app.store';
+export * from './lib/translate/app-translate-language-service';
+export * from './lib/translate/app-translate-loader';
+export * from './lib/translate/app-translate-service';
 export * from './lib/store/paginator-feature';
 export * from './lib/store/request-status-feature';
 export * from './lib/store/viewcode-feature';

--- a/projects/shared/src/tests/user.ts
+++ b/projects/shared/src/tests/user.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { IUser } from '../lib/classes/user';
+import { User, UserConstructorData } from '../lib/classes/user';
+
+export function makeUser(data: UserConstructorData): User {
+  return new User(data);
+}
 
 export const testPermissions = [
   "acac-create",
@@ -61,372 +65,217 @@ export const testPermissions = [
 
 /** User with 2 patrons record */
 export const testUserPatronWithSettings = {
-  birth_date: '1969-06-07',
-  business_phone: '+39324993588',
-  city: 'Aosta',
-  country: 'it',
-  email: 'reroilstest+simonetta@gmail.com',
-  first_name: 'Simonetta',
-  gender: 'female',
-  home_phone: '+39324993585',
-  id: 8,
-  keep_history: true,
-  last_name: 'Casalini',
+  settings: {
+    baseUrl: 'https://bib.rero.ch',
+    agentSources: ['idref', 'gnd', 'rero'],
+    agentAgentTypes: { 'bf:Person': 'persons', 'bf:Organisation': 'corporate-bodies' },
+    agentLabelOrder: { de: ['gnd', 'idref', 'rero'], fallback: 'fr', fr: ['idref', 'rero', 'gnd'] },
+    globalView: 'global',
+    language: 'fr',
+    operationLogs: { documents: 'doc', holdings: 'hold', items: 'item' },
+    documentAdvancedSearch: false,
+    userProfile: { readOnly: false, readOnlyFields: [] },
+    availableLanguages: [{ code: 'fr', name: 'French' }]
+  },
+  permissions: testPermissions,
+  user: {
+    id: 8,
+    birth_date: '1969-06-07',
+    business_phone: '+39324993588',
+    city: 'Aosta',
+    country: 'it',
+    email: 'reroilstest+simonetta@gmail.com',
+    first_name: 'Simonetta',
+    gender: 'female',
+    home_phone: '+39324993585',
+    keep_history: true,
+    last_name: 'Casalini',
+    postal_code: '11100',
+    roles: ['patron'],
+    street: 'Via Croix Noire 3',
+    username: 'simonetta',
+  },
   patrons: [
     {
       pid: '1',
-      second_address: {
-        street: 'Rue des Remparts',
-        postal_code: '1950',
-        city: 'Sion',
-        country: 'sw'
-      },
+      second_address: { street: 'Rue des Remparts', postal_code: '1950', city: 'Sion', country: 'sw' },
       patron: {
         barcode: ['2010023488'],
-        type: {
-          pid: '2'
-        },
+        type: { pid: '2' },
         expiration_date: new Date('2024-01-01'),
         communication_channel: 'email',
         communication_language: 'fra',
         blocked: false,
-        libraries: [
-          {
-            pid: '1',
-            organisation: {
-              pid: '2',
-              code: 'org1',
-              name: 'Organisation 1',
-              currency: 'CHF'
-            }
-          }
-        ]
+        libraries: [{ pid: '1', organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' } }]
       },
-      organisation: {
-        pid: '2',
-        code: 'org1',
-        name: 'Organisation 1',
-        currency: 'CHF'
-      },
+      organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' },
       roles: ['patron']
     },
     {
       pid: '2',
-      libraries: [
-        {
-          organisation: {
-            pid: '1'
-          },
-          pid: '4'
-        }
-      ],
-      organisation: {
-        code: 'aoste',
-        currency: 'EUR',
-        name: 'R\u00e9seau des biblioth\u00e8ques du Canton d\'Aoste',
-        pid: '1'
-      },
-      roles: [
-        'system_librarian',
-        'librarian'
-      ]
+      libraries: [{ organisation: { pid: '1' }, pid: '4' }],
+      organisation: { code: 'aoste', currency: 'EUR', name: 'R\u00e9seau des biblioth\u00e8ques du Canton d\'Aoste', pid: '1' },
+      roles: ['system_librarian', 'librarian']
     }
   ],
-  postal_code: '11100',
-  roles: [
-    'patron'
-  ],
-  settings: {
-    baseUrl: 'https://bib.rero.ch',
-    agentSources: [
-      'idref',
-      'gnd',
-      'rero'
-    ],
-    agentAgentTypes: {
-      'bf:Person': 'persons',
-      'bf:Organisation': 'corporate-bodies'
-    },
-    agentLabelOrder: {
-      de: [
-        'gnd',
-        'idref',
-        'rero'
-      ],
-      fallback: 'fr',
-      fr: [
-        'idref',
-        'rero',
-        'gnd'
-      ]
-    },
-    globalView: 'global',
-    language: 'fr',
-    operationLogs: {
-      documents: 'doc',
-      holdings: 'hold',
-      items: 'item'
-    },
-    documentAdvancedSearch: false,
-    userProfile: {
-      readOnly: false,
-      readOnlyFields: []
-    }
-  },
-  street: 'Via Croix Noire 3',
-  username: 'simonetta',
-  permissions: testPermissions
 };
 
 /** User with 2 patron records (patron and librarian, system_librarian) */
-export const testUserPatronLibrarian: IUser = {
-  id: 1,
-  first_name: 'first_name',
-  last_name: 'last_name',
-  birth_date: '1966-01-01',
-  gender: 'male',
-  username: 'first_last',
-  street: 'Av. de la Gare',
-  postal_code: '1920',
-  city: 'Martigny',
-  country: 'sw',
-  keep_history: false,
-  email: 'foo@bar.com',
-  roles: ['patron'],
+export const testUserPatronLibrarian: UserConstructorData = {
+  user: {
+    id: 1,
+    first_name: 'first_name',
+    last_name: 'last_name',
+    birth_date: '1966-01-01',
+    gender: 'male',
+    username: 'first_last',
+    street: 'Av. de la Gare',
+    postal_code: '1920',
+    city: 'Martigny',
+    country: 'sw',
+    keep_history: false,
+    email: 'foo@bar.com',
+    roles: ['patron'],
+  },
   patrons: [
     {
       pid: '1',
-      second_address: {
-        street: 'Rue des Remparts',
-        postal_code: '1950',
-        city: 'Sion',
-        country: 'sw'
-      },
+      second_address: { street: 'Rue des Remparts', postal_code: '1950', city: 'Sion', country: 'sw' },
       patron: {
         barcode: ['2010023488'],
-        type: {
-          pid: '2'
-        },
+        type: { pid: '2' },
         expiration_date: new Date('2024-01-01'),
         communication_channel: 'email',
         communication_language: 'fra',
         blocked: false,
-        libraries: [
-          {
-            pid: '1',
-            organisation: {
-              pid: '2',
-              code: 'org1',
-              name: 'Organisation 1',
-              currency: 'CHF'
-            }
-          }
-        ]
+        libraries: [{ pid: '1', organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' } }]
       },
-      organisation: {
-        pid: '2',
-        code: 'org1',
-        name: 'Organisation 1',
-        currency: 'CHF'
-      },
+      organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' },
       roles: ['patron']
     },
     {
       pid: '1',
-      libraries: [
-        {
-          organisation: {
-            pid: '1'
-          },
-          pid: '4'
-        }
-      ],
-      organisation: {
-        code: 'aoste',
-        currency: 'EUR',
-        name: 'R\u00e9seau des biblioth\u00e8ques du Canton d\'Aoste',
-        pid: '1'
-      },
-      roles: [
-        'system_librarian',
-        'librarian'
-      ]
+      libraries: [{ organisation: { pid: '1' }, pid: '4' }],
+      organisation: { code: 'aoste', currency: 'EUR', name: 'R\u00e9seau des biblioth\u00e8ques du Canton d\'Aoste', pid: '1' },
+      roles: ['system_librarian', 'librarian']
     }
   ],
-  permissions: testPermissions
+  permissions: testPermissions,
 };
 
 
 /** User with 2 patrons record (multiple organisation) */
 export const testUserPatronMultipleOrganisationsWithSettings = {
-  birth_date: '1969-06-07',
-  business_phone: '+39324993588',
-  city: 'Aosta',
-  country: 'it',
-  email: 'reroilstest+simonetta@gmail.com',
-  first_name: 'Simonetta',
-  gender: 'female',
-  home_phone: '+39324993585',
-  id: 8,
-  keep_history: true,
-  last_name: 'Casalini',
+  settings: {
+    baseUrl: 'https://bib.rero.ch',
+    agentSources: ['idref', 'gnd', 'rero'],
+    agentAgentTypes: { 'bf:Person': 'persons', 'bf:Organisation': 'corporate-bodies' },
+    agentLabelOrder: { de: ['gnd', 'idref', 'rero'], fallback: 'fr', fr: ['idref', 'rero', 'gnd'] },
+    globalView: 'global',
+    language: 'fr',
+    operationLogs: { documents: 'doc', holdings: 'hold', items: 'item' },
+    documentAdvancedSearch: false,
+    userProfile: { readOnly: false, readOnlyFields: [] },
+    availableLanguages: [{ code: 'fr', name: 'French' }]
+  },
+  permissions: [],
+  user: {
+    id: 8,
+    birth_date: '1969-06-07',
+    business_phone: '+39324993588',
+    city: 'Aosta',
+    country: 'it',
+    email: 'reroilstest+simonetta@gmail.com',
+    first_name: 'Simonetta',
+    gender: 'female',
+    home_phone: '+39324993585',
+    keep_history: true,
+    last_name: 'Casalini',
+    postal_code: '11100',
+    roles: ['patron'],
+    street: 'Via Croix Noire 3',
+    username: 'simonetta',
+  },
   patrons: [
     {
       pid: '1',
-      second_address: {
-        street: 'Rue des Remparts',
-        postal_code: '1950',
-        city: 'Sion',
-        country: 'sw'
-      },
+      second_address: { street: 'Rue des Remparts', postal_code: '1950', city: 'Sion', country: 'sw' },
       patron: {
         barcode: ['2010023488'],
-        type: {
-          pid: '2'
-        },
+        type: { pid: '2' },
         expiration_date: new Date('2024-01-01'),
         communication_channel: 'email',
         communication_language: 'fra',
         blocked: false,
-        libraries: [
-          {
-            pid: '1',
-            organisation: {
-              pid: '2',
-              code: 'org1',
-              name: 'Organisation 1',
-              currency: 'CHF'
-            }
-          }
-        ]
+        libraries: [{ pid: '1', organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' } }]
       },
-      organisation: {
-        pid: '2',
-        code: 'org1',
-        name: 'Organisation 1',
-        currency: 'CHF'
-      },
+      organisation: { pid: '2', code: 'org1', name: 'Organisation 1', currency: 'CHF' },
       roles: ['patron']
     },
     {
       pid: '10',
-      second_address: {
-        street: 'Rue des Remparts',
-        postal_code: '1950',
-        city: 'Sion',
-        country: 'sw'
-      },
+      second_address: { street: 'Rue des Remparts', postal_code: '1950', city: 'Sion', country: 'sw' },
       patron: {
         barcode: ['2010023489'],
-        type: {
-          pid: '2'
-        },
+        type: { pid: '2' },
         expiration_date: new Date('2025-01-01'),
         communication_channel: 'email',
         communication_language: 'fra',
         blocked: false,
-        libraries: [
-          {
-            pid: '1',
-            organisation: {
-              pid: '3',
-              code: 'org2',
-              name: 'Organisation 2',
-              currency: 'CHF'
-            }
-          }
-        ]
+        libraries: [{ pid: '1', organisation: { pid: '3', code: 'org2', name: 'Organisation 2', currency: 'CHF' } }]
       },
-      organisation: {
-        pid: '3',
-        code: 'org2',
-        name: 'Organisation 2',
-        currency: 'CHF'
-      },
+      organisation: { pid: '3', code: 'org2', name: 'Organisation 2', currency: 'CHF' },
       roles: ['patron']
     },
   ],
-  postal_code: '11100',
-  roles: [
-    'patron'
-  ],
+};
+
+
+export const testUserLibrarianWithSettings = {
   settings: {
     baseUrl: 'https://bib.rero.ch',
-    agentSources: [
-      'idref',
-      'gnd',
-      'rero'
-    ],
+    agentSources: ['idref', 'gnd', 'rero'],
     agentAgentTypes: {
       'bf:Person': 'persons',
       'bf:Organisation': 'corporate-bodies'
     },
     agentLabelOrder: {
-      de: [
-        'gnd',
-        'idref',
-        'rero'
-      ],
+      de: ['gnd', 'idref', 'rero'],
       fallback: 'fr',
-      fr: [
-        'idref',
-        'rero',
-        'gnd'
-      ]
+      fr: ['idref', 'rero', 'gnd']
     },
     globalView: 'global',
     language: 'fr',
-    operationLogs: {
-      documents: 'doc',
-      holdings: 'hold',
-      items: 'item'
-    },
+    operationLogs: { documents: 'doc', holdings: 'hold', items: 'item' },
     documentAdvancedSearch: false,
-    userProfile: {
-      readOnly: false,
-      readOnlyFields: []
-    }
+    userProfile: { readOnly: false, readOnlyFields: [] },
+    availableLanguages: [{ code: 'fr', name: 'French' }]
   },
-  street: 'Via Croix Noire 3',
-  username: 'simonetta',
-  permissions: []
-};
-
-
-export const testUserLibrarianWithSettings = {
-  birth_date: '1969-06-07',
-  business_phone: '+39324993588',
-  city: 'Aosta',
-  country: 'it',
-  email: 'reroilstest+simonetta@gmail.com',
-  first_name: 'Simonetta',
-  gender: 'female',
-  home_phone: '+39324993585',
-  id: '8',
-  keep_history: true,
-  last_name: 'Casalini',
+  permissions: testPermissions,
+  user: {
+    id: 8,
+    birth_date: '1969-06-07',
+    business_phone: '+39324993588',
+    city: 'Aosta',
+    country: 'it',
+    email: 'reroilstest+simonetta@gmail.com',
+    first_name: 'Simonetta',
+    gender: 'female',
+    home_phone: '+39324993585',
+    keep_history: true,
+    last_name: 'Casalini',
+    postal_code: '11100',
+    roles: ['patron'],
+    street: 'Via Croix Noire 3',
+    username: 'simonetta',
+  },
   patrons: [
     {
       pid: '2',
       libraries: [
-        {
-          organisation: {
-            pid: '1'
-          },
-          pid: '2'
-        },
-        {
-          organisation: {
-            pid: '1'
-          },
-          pid: '3'
-        },
-        {
-          organisation: {
-            pid: '1'
-          },
-          pid: '4'
-        }
+        { organisation: { pid: '1' }, pid: '2' },
+        { organisation: { pid: '1' }, pid: '3' },
+        { organisation: { pid: '1' }, pid: '4' }
       ],
       organisation: {
         code: 'aoste',
@@ -434,55 +283,9 @@ export const testUserLibrarianWithSettings = {
         name: 'R\u00e9seau des biblioth\u00e8ques du Canton d\'Aoste',
         pid: '1'
       },
-      roles: [
-        'librarian'
-      ]
+      roles: ['librarian']
     }
   ],
-  postal_code: '11100',
-  roles: [
-    'patron'
-  ],
-  settings: {
-    baseUrl: 'https://bib.rero.ch',
-    agentSources: [
-      'idref',
-      'gnd',
-      'rero'
-    ],
-    agentAgentTypes: {
-      'bf:Person': 'persons',
-      'bf:Organisation': 'corporate-bodies'
-    },
-    agentLabelOrder: {
-      de: [
-        'gnd',
-        'idref',
-        'rero'
-      ],
-      fallback: 'fr',
-      fr: [
-        'idref',
-        'rero',
-        'gnd'
-      ]
-    },
-    globalView: 'global',
-    language: 'fr',
-    operationLogs: {
-      documents: 'doc',
-      holdings: 'hold',
-      items: 'item'
-    },
-    documentAdvancedSearch: false,
-    userProfile: {
-      readOnly: false,
-      readOnlyFields: []
-    }
-  },
-  street: 'Via Croix Noire 3',
-  username: 'simonetta',
-  permissions: testPermissions
 };
 
 export const testPatron = {


### PR DESCRIPTION
* Move `AppTranslateLoader`, `AppTranslateLanguageService`, `AppTranslateService` from `admin/translate/` to `shared/lib/translate/` and export from `public-api.ts`
* Add `ngCoreAssetsUrl` to `CoreConfigService` (ng-core) to configure the base URL for ng-core i18n and language JSON assets — needed when apps are served from a sub-path (e.g. Flask/Invenio static files)
* Set `ngCoreAssetsUrl` in each project's `AppConfigService` from environment; prod uses the absolute static path, dev uses empty string
* Wire `AppTranslateLoader`, `AppTranslateService` and `AppTranslateLanguageService` into `app.config.ts` of `public-search`, `public-holdings-items`, `public-patron-profile` and `search-bar`; call `loadLanguageNow()` before `translateService.use()` in each initializer
* Create `AppConfigService` for `search-bar` (previously missing) to carry `ngCoreAssetsUrl` into `CoreConfigService`
* Add ng-core i18n and languages asset globs to `angular.json` for all consumer projects
* Fix `shared-remote-search` placeholder not updating on language change: replace `| translate` pipe (broken with `OnPush`) with a `computed` signal driven by `onLangChange`
* Closes rero/rero-ils#3982.