### PR TITLE
fix(files): nest label under metadata when updating a file

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { TestBed } from '@angular/core/testing';
+import { ResourcesFilesService } from '@app/admin/service/resources-files.service';
+import { TranslateService } from '@ngx-translate/core';
+import { NgxSpinnerService } from 'ngx-spinner';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+import { UploadedFile, UploadFilesComponent } from './upload-files.component';
+
+describe('UploadFilesComponent', () => {
+  let component: UploadFilesComponent;
+
+  const fileServiceSpy = { updateMetadata: vi.fn() };
+
+  /** Build a fully typed file fixture, overriding only the relevant fields. */
+  const createFile = (overrides: Partial<UploadedFile>): UploadedFile => ({
+    key: 'test_file.pdf',
+    label: '',
+    created: '',
+    updated: '',
+    size: 0,
+    metadata: null,
+    links: {},
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UploadFilesComponent],
+      providers: [
+        { provide: ResourcesFilesService, useValue: fileServiceSpy },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: ConfirmationService, useValue: { confirm: vi.fn() } },
+        { provide: NgxSpinnerService, useValue: { show: vi.fn(), hide: vi.fn() } },
+        { provide: TranslateService, useValue: { instant: (key: string) => key } },
+      ],
+    });
+    // do not trigger change detection: avoids rendering the template and running
+    // the constructor effect (which would call getFiles).
+    component = TestBed.createComponent(UploadFilesComponent).componentInstance;
+    component.parentRecord.set({ id: 'recid', metadata: {} });
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should send the label nested under metadata, never at the root', () => {
+    // a file as returned by the server after a page reload: metadata holds the label
+    const file = createFile({ label: 'old', metadata: { label: 'old' } });
+    fileServiceSpy.updateMetadata.mockReturnValue(of({ metadata: { label: 'Café résumé' } }));
+
+    component.updateLabel(file, 'Café résumé');
+
+    const payload = fileServiceSpy.updateMetadata.mock.calls[0][2];
+    expect(payload).toEqual({ metadata: { label: 'Café résumé' } });
+    // the regression we are guarding against: no top-level `label`
+    expect(payload).not.toHaveProperty('label');
+  });
+
+  it('should not call the service when the label is unchanged', () => {
+    fileServiceSpy.updateMetadata.mockClear();
+    const file = createFile({ label: 'same', metadata: { label: 'same' } });
+
+    component.updateLabel(file, 'same');
+
+    expect(fileServiceSpy.updateMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/files-collections/upload-files/upload-files.component.ts
@@ -25,7 +25,7 @@ type ParentRecord = {
   metadata: Record<string, unknown>;
 };
 
-type UploadedFile = {
+export type UploadedFile = {
   key: string;
   label: string;
   created: string;
@@ -114,7 +114,7 @@ export class UploadFilesComponent {
       return;
     }
     this.fileService
-      .updateMetadata(this.parentRecord()!.id, file.key, { ...(file.metadata ?? {}), metadata: { label } })
+      .updateMetadata(this.parentRecord()!.id, file.key, { metadata: { ...(file.metadata ?? {}), label } })
       .subscribe((res) => {
         const newLabel = res.metadata.label as string;
         this.files.update(files =>


### PR DESCRIPTION
The file label update sent the existing `file.metadata` (which contains `label`) spread at the root of the PUT body, producing a top-level `label` field that the backend FileSchema rejects (`unknown = RAISE`). This broke every label edit after the first one, once a label was already stored.

Nest everything under `metadata` so the label is never sent at the root.