### PR TITLE
fix(circulation): clear loan tab when switching

### DIFF
--- a/projects/admin/src/app/circulation/patron/loan/loan.component.ts
+++ b/projects/admin/src/app/circulation/patron/loan/loan.component.ts
@@ -71,6 +71,7 @@ export class LoanComponent {
   constructor() {
     toObservable(this.store.patron).pipe(
       takeUntilDestroyed(),
+      tap(() => this._resetPatronLoanState()),
       filter((patron): patron is User => !!patron?.pid)
     ).subscribe(patron => {
       const loanedItems$ = this.patronService.getItems(patron.pid!, this.sortCriteria());
@@ -460,5 +461,13 @@ export class LoanComponent {
     this.searchInputDisabled.set(false);
     this.searchText.set('');
     setTimeout(() => this.searchInputFocus.set(true));
+  }
+
+  private _resetPatronLoanState(): void {
+    this.checkedOutItems.set([]);
+    this.checkedInItems.set([]);
+    this.pickupItems.set([]);
+    this.searchText.set('');
+    this.searchInputDisabled.set(false);
   }
 }


### PR DESCRIPTION
* Clears checked-in and checked-out item lists on patron changes.
* Resets pickup item sand search input state before loading the next patron.
* Prevents previous patron check-in rows to remain in the on-loan tab.
* Closes rero/rero-ils#3589