### PR TITLE
feat(shortcut): add result list search shortcut

### DIFF
--- a/projects/admin/src/app/service/keyboard-shortcuts.service.spec.ts
+++ b/projects/admin/src/app/service/keyboard-shortcuts.service.spec.ts
@@ -35,4 +35,20 @@ describe('KeyboardShortcutsService', () => {
     service.initializeShortcuts();
     expect(hotkeys.getShortcuts().length > 0).toBe(true);
   });
+
+  it('should define a shortcut to focus the result list search input', () => {
+    service.initializeShortcuts();
+    const shortcuts = hotkeys.getHotkeys();
+    expect(shortcuts.some(shortcut => shortcut.keys === 'q')).toBe(true);
+  });
+
+  it('should focus the search input with the q shortcut', () => {
+    document.body.innerHTML = '<input id="search" />';
+    const input = document.querySelector('#search') as HTMLInputElement;
+
+    service.initializeShortcuts();
+    document.documentElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'q' }));
+
+    expect(document.activeElement).toBe(input);
+  });
 });

--- a/projects/admin/src/app/service/keyboard-shortcuts.service.ts
+++ b/projects/admin/src/app/service/keyboard-shortcuts.service.ts
@@ -40,6 +40,18 @@ export class KeyboardShortcutsService {
     });
 
     this.hotKeys.addShortcut({
+      keys: 'q',
+      group: this.translateService.instant('Global shortcuts'),
+      description: this.translateService.instant('Set focus on the result list search input')
+    }).subscribe(_e => {
+      const inputField = document.querySelector(
+        '#search'
+      ) as HTMLInputElement | null;
+
+      inputField?.focus();
+    });
+
+    this.hotKeys.addShortcut({
       keys: 'h',
       group: this.translateService.instant('Global shortcuts'),
       description: this.translateService.instant('Open the global help page')


### PR DESCRIPTION
* Adds global `q` shortcut to focus the professional result list search.
* Does not conflict with existing `s` shortcut.
* Adds shortcut to the shorcuts help modal.
* Closes rero/rero-ils#4150.