### PR TITLE
fix(documents): refresh delete status

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail/document-detail.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail/document-detail.component.html
@@ -3,6 +3,16 @@ SPDX-FileCopyrightText: Fondation RERO+
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <div>
+  <p-confirmDialog
+    key="document-detail-child-delete"
+    [acceptLabel]="'Delete' | translate"
+    [rejectLabel]="'Cancel' | translate"
+    [message]="'Do you really want to delete this record?' | translate"
+    [header]="'Confirmation' | translate"
+    icon="fa fa-exclamation-triangle fa-2x core:text-red-500"
+    acceptButtonStyleClass="core:bg-red-500 core:border-red-500"
+    rejectButtonStyleClass="p-button-text"
+  />
   @if (record()) {
     <ng-core-detail-button
       [record]="record() ?? null"
@@ -10,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       [adminMode]="adminMode()"
       [useStatus]="useStatus()"
       [updateStatus]="updateStatus()"
-      [deleteStatus]="deleteStatus()"
+      [deleteStatus]="refreshedDeleteStatus()"
       (recordEvent)="recordEvent($event)"
       (deleteMessageEvent)="showDeleteMessage($event)"
     >

--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail/document-detail.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail/document-detail.component.ts
@@ -8,24 +8,29 @@ import { DetailButtonComponent, DetailComponent, ErrorComponent } from '@rero/ng
 import { AppStore, IPermissions, OperationLogsDialogComponent, PERMISSIONS, PermissionsDirective } from '@rero/shared';
 import { cloneDeep } from 'lodash-es';
 import { Bind } from 'primeng/bind';
-import { Button, ButtonDirective } from 'primeng/button';
+import { Button } from 'primeng/button';
+import { ConfirmDialog } from 'primeng/confirmdialog';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { DialogImportComponent } from '../dialog-import/dialog-import.component';
+import { DocumentDetailStore } from '../store/document-detail.store';
 
 @Component({
-    selector: 'admin-document-detail',
-    templateUrl: './document-detail.component.html',
-    imports: [DetailButtonComponent, OperationLogsDialogComponent, Bind, Button, PermissionsDirective, RouterLink, ErrorComponent, TranslatePipe, ButtonDirective],
+  selector: 'admin-document-detail',
+  templateUrl: './document-detail.component.html',
+  providers: [DocumentDetailStore],
+  imports: [DetailButtonComponent, OperationLogsDialogComponent, Bind, Button, ConfirmDialog, PermissionsDirective, RouterLink, ErrorComponent, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DocumentDetailComponent extends DetailComponent implements OnInit {
 
   private dialogService: DialogService = inject(DialogService);
+  private documentDetailStore = inject(DocumentDetailStore);
   protected appStore = inject(AppStore);
 
   fileTitle = 'files';
   /** return all available permissions for current user */
   permissions: IPermissions = PERMISSIONS;
+  readonly refreshedDeleteStatus = this.documentDetailStore.refreshedDeleteStatus(this.record, this.deleteStatus);
 
   /** Mapping types for import */
   private mappingTypes = {
@@ -169,4 +174,5 @@ export class DocumentDetailComponent extends DetailComponent implements OnInit {
     }
     return `(${query.join(' AND ')})`;
   }
+
 }

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/default-holding-item/default-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/default-holding-item/default-holding-item.component.html
@@ -127,8 +127,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           [title]="'Delete'|translate"
           [pTooltip]="tooltipContent"
           tooltipPosition="top"
-          [disabled]="!permissions().delete?.can"
-          [tooltipDisabled]="permissions().delete?.can"
+          [disabled]="documentDetailStore.isDeletingChild() || !permissions().delete?.can"
+          [tooltipDisabled]="documentDetailStore.isDeletingChild() || permissions().delete?.can"
           (onClick)="delete()"
         />
         <ng-template #tooltipContent>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/default-holding-item/default-holding-item.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/default-holding-item/default-holding-item.component.ts
@@ -13,6 +13,7 @@ import { cloneDeep } from 'lodash-es';
 import { forkJoin } from 'rxjs';
 import { ItemRequestComponent } from '../../item-request/item-request.component';
 import { RecordMaskedComponent } from '../../../record-masked/record-masked.component';
+import { DocumentDetailStore } from '../../store/document-detail.store';
 import { RouterLink } from '@angular/router';
 import { HoldingItemNoteComponent } from '../holding-item-note/holding-item-note.component';
 import { HoldingItemTemporaryItemTypeComponent } from '../holding-item-temporary-item-type/holding-item-temporary-item-type.component';
@@ -36,6 +37,7 @@ export class DefaultHoldingItemComponent implements OnInit {
   protected appStore = inject(AppStore);
   protected itemService: ItemsService = inject(ItemsService);
   protected translateService: TranslateService = inject(TranslateService);
+  protected documentDetailStore = inject(DocumentDetailStore);
   private dialogService: DialogService = inject(DialogService);
 
   // COMPONENT ATTRIBUTES =====================================================

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.html
@@ -64,8 +64,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           (onClick)="delete()"
           [pTooltip]="tooltipContent"
           tooltipPosition="top"
-          [disabled]="!permissions().delete?.can"
-          [tooltipDisabled]="permissions().delete?.can"
+          [disabled]="documentDetailStore.isDeletingChild() || !permissions().delete?.can"
+          [tooltipDisabled]="documentDetailStore.isDeletingChild() || permissions().delete?.can"
         />
         <ng-template #tooltipContent>
           <span [innerHTML]="deleteInfoMessage | nl2br"></span>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holding-header/holding-header.component.ts
@@ -15,6 +15,7 @@ import { RouterLink } from '@angular/router';
 import { Tooltip } from 'primeng/tooltip';
 import { HoldingDetailComponent } from '../holding-detail/holding-detail.component';
 import { Nl2brPipe } from '@rero/ng-core';
+import { DocumentDetailStore } from '../../store/document-detail.store';
 
 @Component({
     selector: 'admin-holding-header',
@@ -28,6 +29,7 @@ export class HoldingHeaderComponent implements OnInit {
   private appStore = inject(AppStore);
   private translateService: TranslateService = inject(TranslateService);
   private dialogService: DialogService = inject(DialogService);
+  protected documentDetailStore = inject(DocumentDetailStore);
 
   holding = input.required<EsRecord>();
   isCurrentOrganisation = input.required<boolean>();

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/serial-holding-item/serial-holding-item.component.html
@@ -66,8 +66,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               outlined
               [pTooltip]="deleteTooltipContent"
               tooltipPosition="top"
-              [disabled]="!permissions().delete?.can"
-              [tooltipDisabled]="permissions().delete?.can"
+              [disabled]="documentDetailStore.isDeletingChild() || !permissions().delete?.can"
+              [tooltipDisabled]="documentDetailStore.isDeletingChild() || permissions().delete?.can"
               (onClick)="delete()"
             />
             <ng-template #deleteTooltipContent>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.spec.ts
@@ -5,21 +5,33 @@ import { provideHttpClient } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { TranslateModule } from "@ngx-translate/core";
-import { Error, RecordUiService } from "@rero/ng-core";
+import { Error } from "@rero/ng-core";
 import type { EsResult } from "@rero/ng-core";
 import { AppStore, testUserLibrarianWithSettings, User } from "@rero/shared";
 import { ConfirmationService, MessageService } from "primeng/api";
 import { Observable, of, Subject } from "rxjs";
 import { HoldingsApiService } from "../../../../../api/holdings-api.service";
+import { DocumentDetailStore } from "../../store/document-detail.store";
 import { HoldingsStore } from "./holdings-store";
 
 describe('Holdings Store', () => {
+  let deleteResult$: Subject<boolean>;
+  let documentDetailStore: {
+    setHoldingsTotal: ReturnType<typeof vi.fn>;
+    deleteChildRecord: ReturnType<typeof vi.fn>;
+  };
+
   beforeEach(() => {
     vi.useFakeTimers();
+    deleteResult$ = new Subject<boolean>();
+    documentDetailStore = {
+      setHoldingsTotal: vi.fn(),
+      deleteChildRecord: vi.fn().mockReturnValue(deleteResult$),
+    };
     TestBed.configureTestingModule({
       providers: [
         HoldingsStore,
-        { provide: RecordUiService, useValue: { deleteRecord: vi.fn().mockReturnValue(new Subject()) } },
+        { provide: DocumentDetailStore, useValue: documentDetailStore },
         ConfirmationService,
         MessageService,
         UserServiceMock,
@@ -49,6 +61,7 @@ describe('Holdings Store', () => {
     expect(store.holdingsCurrentOrganisation()).toHaveLength(9);
     expect(store.holdingsOtherOrganisation()).toHaveLength(3);
     expect(store.filter()).toHaveLength(2);
+    expect(documentDetailStore.setHoldingsTotal).toHaveBeenCalledWith(12);
   });
 
   it('should return the filtered holdings', async () => {
@@ -77,6 +90,46 @@ describe('Holdings Store', () => {
     const record = store.holdings()[2];
     store.delete(record);
     expect(store.record()).toEqual(record);
+    expect(documentDetailStore.deleteChildRecord).toHaveBeenCalledOnce();
+    expect(documentDetailStore.deleteChildRecord).toHaveBeenCalledWith('holdings', record.metadata.pid);
+  });
+
+  it('should notify document detail when holding delete succeeds', async () => {
+    const store = TestBed.inject(HoldingsStore);
+    store.setDocument(document);
+    await vi.advanceTimersByTimeAsync(500);
+    const record = store.holdings()[2];
+    store.delete(record);
+    deleteResult$.next(true);
+    deleteResult$.complete();
+    expect(store.holdings()).toHaveLength(11);
+    expect(store.total()).toEqual(11);
+    expect(store.record()).toBeUndefined();
+    expect(documentDetailStore.setHoldingsTotal).toHaveBeenCalledWith(11);
+  });
+
+  it('should remove a hidden standard holding and update document holdings total', async () => {
+    const store = TestBed.inject(HoldingsStore);
+    store.setDocument(document);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(store.holdings()).toHaveLength(12);
+    store.removeHiddenStandardHolding(store.holdings()[2].metadata.pid);
+    expect(store.holdings()).toHaveLength(11);
+    expect(store.total()).toEqual(11);
+    expect(documentDetailStore.setHoldingsTotal).toHaveBeenCalledWith(11);
+  });
+
+  it('should not notify document detail when holding delete fails', async () => {
+    const store = TestBed.inject(HoldingsStore);
+    store.setDocument(document);
+    await vi.advanceTimersByTimeAsync(500);
+    const record = store.holdings()[2];
+    store.delete(record);
+    deleteResult$.next(false);
+    deleteResult$.complete();
+    expect(store.holdings()).toHaveLength(12);
+    expect(store.record()).toEqual(record);
+    expect(documentDetailStore.setHoldingsTotal).not.toHaveBeenCalledWith(11);
   });
 });
 

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.ts
@@ -4,11 +4,11 @@ import { computed, inject } from "@angular/core";
 import { toObservable } from "@angular/core/rxjs-interop";
 import { patchState, signalStore, withComputed, withHooks, withMethods, withProps, withState } from "@ngrx/signals";
 import { rxMethod } from "@ngrx/signals/rxjs-interop";
-import { RecordUiService } from "@rero/ng-core";
 import { AppStore, EsRecord, nonNullable, setFulfilled, setPending, withRequestStatus } from "@rero/shared";
 import { MultiSelectChangeEvent } from "primeng/multiselect";
 import { pipe, switchMap, tap } from "rxjs";
 import { HoldingsApiService } from "../../../../../api/holdings-api.service";
+import { DocumentDetailStore } from "../../store/document-detail.store";
 
 type HoldingsState = {
   document: EsRecord | undefined;
@@ -31,21 +31,21 @@ export const HoldingsStore = signalStore(
   withRequestStatus(),
   withProps(() => ({
     appStore: inject(AppStore),
+    documentDetailStore: inject(DocumentDetailStore),
     holdingsApiService: inject(HoldingsApiService),
-    recordUiService: inject(RecordUiService),
   })),
   withComputed((store) => ({
     isDocumentHarvested: computed(() => ('harvested' in store.document().metadata)),
     holdingsCurrentOrganisation: computed(
       () => store.holdings().filter(h => (store.filteredLibrary().length === 0)
-          ? h.metadata.organisation.pid === store.appStore.currentOrganisationPid()
-          : h.metadata.organisation.pid === store.appStore.currentOrganisationPid() && store.filteredLibrary().includes(h.metadata.library.pid)
+        ? h.metadata.organisation.pid === store.appStore.currentOrganisationPid()
+        : h.metadata.organisation.pid === store.appStore.currentOrganisationPid() && store.filteredLibrary().includes(h.metadata.library.pid)
       )
     ),
     holdingsOtherOrganisation: computed(
       () => store.holdings().filter(h => (store.filteredLibrary().length === 0)
-          ? h.metadata.organisation.pid !== store.appStore.currentOrganisationPid()
-          : h.metadata.organisation.pid !== store.appStore.currentOrganisationPid() && store.filteredLibrary().includes(h.metadata.library.pid)
+        ? h.metadata.organisation.pid !== store.appStore.currentOrganisationPid()
+        : h.metadata.organisation.pid !== store.appStore.currentOrganisationPid() && store.filteredLibrary().includes(h.metadata.library.pid)
       )
     ),
     filter: computed(() => {
@@ -59,12 +59,12 @@ export const HoldingsStore = signalStore(
       // Unique libraries for current organisation and sort.
       const currentOrganisationLibraries = [
         ...new Map(libraries.filter(l => l.organisationPid === store.appStore.currentOrganisationPid())
-        .map(lib => [JSON.stringify(lib), lib])).values()
+          .map(lib => [JSON.stringify(lib), lib])).values()
       ].sort((a, b) => a.name.localeCompare(b.name));
       // Unique libraries for other organisation(s) and sort.
       const otherOrganisationLibraries = [
         ...new Map(libraries.filter(l => l.organisationPid !== store.appStore.currentOrganisationPid())
-        .map(lib => [JSON.stringify(lib), lib])).values()
+          .map(lib => [JSON.stringify(lib), lib])).values()
       ].sort((a, b) => a.name.localeCompare(b.name));
 
       return [...currentOrganisationLibraries, ...otherOrganisationLibraries];
@@ -77,20 +77,36 @@ export const HoldingsStore = signalStore(
     setLibraryFilter(filter: MultiSelectChangeEvent) {
       patchState(store, { filteredLibrary: filter.value });
     },
+    removeHiddenStandardHolding(holdingPid: string) {
+      const holdings = store.holdings().filter((h: EsRecord) => h.metadata.pid !== holdingPid);
+      const total = holdings.length;
+      patchState(store, {
+        holdings,
+        total
+      });
+      store.documentDetailStore.setHoldingsTotal(total);
+    },
     load: rxMethod<void>(
       pipe(
         tap(() => patchState(store, setPending())),
         switchMap(() => store.holdingsApiService.getHoldingsByDocumentPid(store.document().metadata.pid)),
-        tap((result: any) => patchState(store, { holdings: result.hits.hits, total: result.hits.total.value }, setFulfilled()))
+        tap((result: any) => {
+          const total = result.hits.total.value;
+          patchState(store, { holdings: result.hits.hits, total }, setFulfilled());
+          store.documentDetailStore.setHoldingsTotal(total);
+        })
       )
     ),
     delete: rxMethod<EsRecord>(
       pipe(
         tap((record: EsRecord) => patchState(store, { record })),
-        switchMap(() => store.recordUiService.deleteRecord('holdings', store.record().metadata.pid)),
+        switchMap(() => store.documentDetailStore.deleteChildRecord('holdings', store.record().metadata.pid)),
         tap((success: boolean) => {
           if (success) {
-            patchState(store, { holdings: store.holdings().filter((h: EsRecord) => h.metadata.pid !== store.record().metadata.pid), record: null });
+            const holdings = store.holdings().filter((h: EsRecord) => h.metadata.pid !== store.record().metadata.pid);
+            const total = holdings.length;
+            patchState(store, { holdings, total, record: undefined });
+            store.documentDetailStore.setHoldingsTotal(total);
           }
         })
       )

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/items-store.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/items-store.spec.ts
@@ -5,20 +5,31 @@ import { provideHttpClient } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { TranslateModule } from "@ngx-translate/core";
-import { RecordUiService } from "@rero/ng-core";
 import { EsRecord, EsResult } from "@rero/shared";
 import { ConfirmationService, MessageService } from "primeng/api";
 import { Observable, of } from "rxjs";
 import { ItemApiService } from "../../../../../api/item-api.service";
+import { DocumentDetailStore } from "../../store/document-detail.store";
+import { HoldingsStore } from "./holdings-store";
 import { ItemsStore } from "./items-store";
 
 describe('Items Store', () => {
+  let documentDetailStore: {
+    deleteChildRecord: ReturnType<typeof vi.fn>;
+  };
+  let holdingsStore: { removeHiddenStandardHolding: ReturnType<typeof vi.fn> };
+
   beforeEach(() => {
     vi.useFakeTimers();
+    documentDetailStore = {
+      deleteChildRecord: vi.fn().mockReturnValue(of(true)),
+    };
+    holdingsStore = { removeHiddenStandardHolding: vi.fn() };
     TestBed.configureTestingModule({
       providers: [
         ItemsStore,
-        { provide: RecordUiService, useValue: { deleteRecord: vi.fn().mockReturnValue(of(true)) } },
+        { provide: DocumentDetailStore, useValue: documentDetailStore },
+        { provide: HoldingsStore, useValue: holdingsStore },
         ConfirmationService,
         MessageService,
         ItemApiServiceMock,
@@ -80,6 +91,35 @@ describe('Items Store', () => {
     expect(store.filterTotal()).toEqual(11);
     expect(store.record()).toBeUndefined();
     expect(store.pager.page()).toEqual(1);
+    expect(holdingsStore.removeHiddenStandardHolding).not.toHaveBeenCalled();
+    expect(documentDetailStore.deleteChildRecord).toHaveBeenCalledOnce();
+    expect(documentDetailStore.deleteChildRecord).toHaveBeenCalledWith('items', record.metadata.pid);
+  });
+
+  it('should remove the hidden holding when last item of a standard holding is deleted', async () => {
+    TestBed.inject(ItemApiServiceMock).itemsCount = 1;
+    const store = TestBed.inject(ItemsStore);
+    store.setHoldings(holdings);
+    await vi.advanceTimersByTimeAsync(500);
+    store.delete(store.items()[0]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.total()).toEqual(0);
+    expect(holdingsStore.removeHiddenStandardHolding).toHaveBeenCalledOnce();
+    expect(holdingsStore.removeHiddenStandardHolding).toHaveBeenCalledWith('199');
+  });
+
+  it('should not notify document detail when item delete fails', async () => {
+    documentDetailStore.deleteChildRecord.mockReturnValue(of(false));
+    const store = TestBed.inject(ItemsStore);
+    store.setHoldings(holdings);
+    await vi.advanceTimersByTimeAsync(500);
+    const record = store.items()[2];
+    store.delete(record);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.items()).toHaveLength(10);
+    expect(store.total()).toEqual(12);
+    expect(holdingsStore.removeHiddenStandardHolding).not.toHaveBeenCalled();
+    expect(documentDetailStore.deleteChildRecord).toHaveBeenCalledOnce();
   });
 
   it('should go back to previous page when last item on page is deleted', async () => {
@@ -146,9 +186,11 @@ const holdings = {
 };
 
 class ItemApiServiceMock {
+  itemsCount = 12;
+
   getItemsByHoldings(holdings: Partial<EsRecord>, page: number, itemsPerPage = 10, filter = ''): Observable<EsResult> {
     const items = [];
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < this.itemsCount; i++) {
       items.push({
         "created": "2025-11-03T12:46:25.825446+00:00",
         "id": `${i}`,

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/items-store.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/items-store.ts
@@ -4,11 +4,12 @@ import { computed, inject } from "@angular/core";
 import { toObservable } from "@angular/core/rxjs-interop";
 import { patchState, signalMethod, signalStore, withComputed, withHooks, withMethods, withProps, withState } from "@ngrx/signals";
 import { rxMethod } from "@ngrx/signals/rxjs-interop";
-import { RecordUiService } from "@rero/ng-core";
 import { EsRecord, EsResult, nonNullable, Pager, setFulfilled, setPending, withPaginator, withRequestStatus } from "@rero/shared";
 import { PaginatorState } from "primeng/paginator";
 import { debounceTime, pipe, switchMap, tap } from "rxjs";
 import { ItemApiService } from "../../../../../api/item-api.service";
+import { DocumentDetailStore } from "../../store/document-detail.store";
+import { HoldingsStore } from "./holdings-store";
 
 type ItemsState = {
   items: EsRecord[],
@@ -40,7 +41,8 @@ export const ItemsStore = signalStore(
   withPaginator(initialPagerConfig),
   withRequestStatus(),
   withProps(() => ({
-    recordUiService: inject(RecordUiService),
+    documentDetailStore: inject(DocumentDetailStore),
+    holdingsStore: inject(HoldingsStore),
     itemsApiService: inject(ItemApiService),
   })),
   withComputed((store) => ({
@@ -88,21 +90,26 @@ export const ItemsStore = signalStore(
     delete: rxMethod<EsRecord>(
       pipe(
         tap((record: EsRecord) => patchState(store, { record })),
-        switchMap(() => store.recordUiService.deleteRecord('items', store.record().metadata.pid)),
+        switchMap(() => store.documentDetailStore.deleteChildRecord('items', store.record().metadata.pid)),
         tap((success: boolean) => {
           if (success) {
             const rows = store.pager.rows();
+            const total = store.total() - 1;
             const newTotal = store.filterTotal() - 1;
             const lastPage = Math.max(1, Math.ceil(newTotal / rows));
             const page = Math.min(store.pager.page(), lastPage);
             const deletedPid = store.record()?.metadata.pid;
+            const holdingBecomesHidden = store.holdingType() === 'standard' && total === 0;
             patchState(store, {
               items: store.items().filter((h: EsRecord) => h.metadata.pid !== deletedPid),
-              total: store.total() - 1,
+              total,
               filterTotal: newTotal,
               record: undefined,
               pager: { ...store.pager(), page, first: (page - 1) * rows + 1 }
             });
+            if (holdingBecomesHidden) {
+              store.holdingsStore.removeHiddenStandardHolding(store.holdings().metadata.pid);
+            }
           }
         })
       )

--- a/projects/admin/src/app/record/detail-view/document-detail-view/store/document-detail.store.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/store/document-detail.store.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { inject, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { RecordPermissions } from '@app/admin/classes/permissions';
+import { RecordPermissionService } from '@app/admin/service/record-permission.service';
+import { patchState, signalStore, withMethods, withProps, withState } from '@ngrx/signals';
+import { TranslateService } from '@ngx-translate/core';
+import { ActionStatus, CONFIG, RecordService } from '@rero/ng-core';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { combineLatest, filter, finalize, map, Observable, of, Subject, switchMap, take, tap } from 'rxjs';
+
+type DocumentDetailState = {
+  holdingsTotal: number | null;
+  isDeletingChild: boolean;
+};
+
+const initialState: DocumentDetailState = {
+  holdingsTotal: null,
+  isDeletingChild: false,
+};
+
+export const DocumentDetailStore = signalStore(
+  withState<DocumentDetailState>(initialState),
+  withProps(() => ({
+    confirmationService: inject(ConfirmationService),
+    messageService: inject(MessageService),
+    recordPermissionService: inject(RecordPermissionService),
+    recordService: inject(RecordService),
+    translateService: inject(TranslateService),
+  })),
+  withMethods((store) => ({
+    clearHoldingsTotal(): void {
+      patchState(store, { holdingsTotal: null });
+    },
+    setHoldingsTotal(total: number): void {
+      patchState(store, { holdingsTotal: total });
+    },
+    setChildDeletePending(): void {
+      patchState(store, { isDeletingChild: true });
+    },
+    setChildDeleteDone(): void {
+      patchState(store, { isDeletingChild: false });
+    },
+    deleteChildRecord(type: string, pid: string): Observable<boolean> {
+      const delete$ = new Subject<boolean>();
+      store.confirmationService.confirm({
+        key: 'document-detail-child-delete',
+        accept: () => {
+          patchState(store, { isDeletingChild: true });
+          store.recordService.delete(type, pid).pipe(
+            take(1),
+            finalize(() => patchState(store, { isDeletingChild: false }))
+          ).subscribe({
+            next: () => {
+              delete$.next(true);
+              delete$.complete();
+              store.messageService.add({
+                severity: 'info',
+                summary: store.translateService.instant('Confirmed'),
+                detail: store.translateService.instant('Record deleted.'),
+                life: CONFIG.MESSAGE_LIFE,
+              });
+            },
+            error: (error) => {
+              delete$.next(false);
+              delete$.complete();
+              store.messageService.add({
+                severity: 'error',
+                summary: store.translateService.instant('Error'),
+                detail: store.translateService.instant(error.title),
+                sticky: true,
+                closable: true,
+              });
+            },
+          });
+        },
+        reject: () => {
+          delete$.next(false);
+          delete$.complete();
+        },
+      });
+      return delete$.asObservable();
+    },
+  })),
+  withMethods((store) => {
+    let activeDocumentPid: string | null = null;
+
+    const _clearHoldingsTotalOnDocumentChange = (pid: any): void => {
+      const documentPid = pid == null ? null : String(pid);
+      if (documentPid !== activeDocumentPid) {
+        activeDocumentPid = documentPid;
+        store.clearHoldingsTotal();
+      }
+    };
+
+    const _deletePermissionToActionStatus = (permission: RecordPermissions): ActionStatus => {
+      const canDelete = permission.delete?.can ?? false;
+      return {
+        can: canDelete,
+        message: canDelete
+          ? ''
+          : store.recordPermissionService.generateTooltipMessage(permission.delete?.reasons, 'delete'),
+      };
+    };
+
+    return {
+      refreshedDeleteStatus(
+        recordSignal: Signal<any>,
+        deleteStatus: Signal<ActionStatus>
+      ): Signal<ActionStatus> {
+        return toSignal(
+          combineLatest([
+            toObservable(recordSignal).pipe(
+              tap((record) => _clearHoldingsTotalOnDocumentChange(record?.metadata?.pid))
+            ),
+            toObservable(store.holdingsTotal),
+          ]).pipe(
+            filter(([record, holdingsTotal]) => !record?.metadata?.pid || holdingsTotal != null),
+            switchMap(([record, holdingsTotal]) => {
+              const pid = record?.metadata?.pid;
+              if (!pid) {
+                return of(deleteStatus());
+              }
+              if (holdingsTotal! > 0) {
+                return of({
+                  can: false,
+                  message: store.recordPermissionService.generateTooltipMessage(
+                    { links: { holdings: holdingsTotal! } },
+                    'delete'
+                  ),
+                });
+              }
+              return store.recordPermissionService
+                .getPermission('documents', String(pid))
+                .pipe(map((permission) => _deletePermissionToActionStatus(permission)));
+            })
+          ),
+          { initialValue: { can: false, message: '' } }
+        );
+      },
+    };
+  }),
+);


### PR DESCRIPTION
* Adds document detail store to track linked holdings state.
* Updates holdings count after holding deletion.
* Updates holdings count when deleting the last item of a holding.
* Syncs holding accordion after item deletion.
* Recomputes document delete status without manually refreshing the page.
* Closes rero/rero-ils#2979.

Must have this backend change: 
- https://github.com/rero/rero-ils/pull/4205