### PR TITLE
feat(operation log) sort and add paginator

### DIFF
--- a/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail/patron-detail.component.html
+++ b/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail/patron-detail.component.html
@@ -17,7 +17,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <ng-container beforeButton>
         @if (record()) {
           @if (appStore.isLogVisible('patrons') && record()!.metadata.pid) {
-            <shared-operation-logs-dialog resourceType="patrons" [resourcePid]="$any(record()!.metadata.pid)" />
+            <shared-operation-logs-dialog
+              resourceType="patrons"
+              [resourcePid]="$any(record()!.metadata.pid)"
+              [sortCriteria]="sortCriteria()"
+              [sortOptions]="sortOptions()"
+            />
           }
         }
       </ng-container>

--- a/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail/patron-detail.component.ts
+++ b/projects/admin/src/app/record/detail-view/patron-detail-view/patron-detail/patron-detail.component.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { _ } from '@ngx-translate/core';
 import { DetailButtonComponent, DetailComponent, ErrorComponent } from '@rero/ng-core';
-import { AppStore, OperationLogsDialogComponent } from '@rero/shared';
+import { AppStore, OperationLogsDialogComponent, sortOptionType } from '@rero/shared';
 
 @Component({
   selector: 'admin-patron-detail',
@@ -13,4 +14,11 @@ import { AppStore, OperationLogsDialogComponent } from '@rero/shared';
 export class PatronDetailComponent extends DetailComponent {
 
   protected appStore = inject(AppStore);
+
+  protected sortCriteria = signal<string>('operation_date_mostrecent');
+
+  protected sortOptions = signal<sortOptionType[]>([
+    { value: 'operation_date_mostrecent', label: _('Date (newest)'), icon: 'fa fa-sort-amount-desc' },
+    { value: 'operation_date_created', label: _('Date (oldest)'), icon: 'fa fa-sort-amount-asc' }
+  ]);
 }

--- a/projects/shared/src/lib/api/operation-logs-api.service.spec.ts
+++ b/projects/shared/src/lib/api/operation-logs-api.service.spec.ts
@@ -10,6 +10,7 @@ import { provideHttpClient } from '@angular/common/http';
 
 describe('OperationLogsService', () => {
   let service: OperationLogsApiService;
+  let recordServiceSpy: any;
 
   const responseRecords = {
     aggregations: {},
@@ -29,12 +30,11 @@ describe('OperationLogsService', () => {
     links: {}
   };
 
-  const recordServiceSpy = {
-    getRecords: vi.fn().mockReturnValue(of(responseRecords)),
-    totalHits: vi.fn().mockReturnValue(0)
-  };
-
   beforeEach(() => {
+    recordServiceSpy = {
+      getRecords: vi.fn().mockReturnValue(of(responseRecords)),
+      totalHits: vi.fn().mockReturnValue(0)
+    };
     TestBed.configureTestingModule({
     imports: [],
     providers: [
@@ -52,9 +52,41 @@ describe('OperationLogsService', () => {
 
   it('should return a list of operations on a record', () => {
     service
-      .getLogs('documents', '1', 'create', 1)
+      .getLogs('documents', '1', 1)
       .subscribe({
         next: (response: any) => expect(response).toEqual(responseRecords)
+    });
+  });
+
+  it('should return resource operation logs sorted by most recent', () => {
+    service
+      .getLogs('documents', '1', 1)
+      .subscribe({
+        next: (response: any) => expect(response).toEqual(responseRecords)
+    });
+
+    expect(recordServiceSpy.getRecords).toHaveBeenCalledWith('operation_logs', {
+      query: 'record.type:documents AND record.value:1',
+      page: 1,
+      itemsPerPage: 10,
+      headers: OperationLogsApiService.reroJsonheaders,
+      sort: 'mostrecent'
+    });
+  });
+
+  it('should return resource operation logs with a custom sort', () => {
+    service
+      .getLogs('documents', '1', 2, 20, 'created')
+      .subscribe({
+        next: (response: any) => expect(response).toEqual(responseRecords)
+    });
+
+    expect(recordServiceSpy.getRecords).toHaveBeenCalledWith('operation_logs', {
+      query: 'record.type:documents AND record.value:1',
+      page: 2,
+      itemsPerPage: 20,
+      headers: OperationLogsApiService.reroJsonheaders,
+      sort: 'created'
     });
   });
 

--- a/projects/shared/src/lib/api/operation-logs-api.service.ts
+++ b/projects/shared/src/lib/api/operation-logs-api.service.ts
@@ -17,20 +17,20 @@ export class OperationLogsApiService extends BaseApi {
   private recordService: RecordService = inject(RecordService);
 
   /**
-   * Get Operation logs by resource type and resource pid
+   * Get resource operation logs by resource type and resource pid.
    * @param resourceType - string
    * @param resourcePid - string
-   * @param action - string
    * @param page - number
-   * @param itemPerPage - number
+   * @param itemsPerPage - number
    * @param sort - string
    * @return Observable
    */
   getLogs(
-    resourceType: string, resourcePid: string, action: 'create'|'update',
-    page: number, itemPerPage = 5, sort = 'mostrecent'): Observable<EsResult | Error> {
-    const query = `record.type:${resourceType} AND record.value:${resourcePid} AND operation:${action}`;
-    return this.recordService.getRecords('operation_logs', { query, page, itemsPerPage: itemPerPage, headers: BaseApi.reroJsonheaders, sort });
+    resourceType: string, resourcePid: string, page: number,
+    itemsPerPage = 10, sort = 'mostrecent'): Observable<EsResult | Error> {
+    const query = `record.type:${resourceType} AND record.value:${resourcePid}`;
+    return this.recordService.getRecords(
+      'operation_logs', { query, page, itemsPerPage, headers: BaseApi.reroJsonheaders, sort });
   }
 
   /**

--- a/projects/shared/src/lib/component/operation-logs/operation-logs-dialog/operation-logs-dialog.component.ts
+++ b/projects/shared/src/lib/component/operation-logs/operation-logs-dialog/operation-logs-dialog.component.ts
@@ -3,8 +3,8 @@
 import { Component, inject, input, ChangeDetectionStrategy} from '@angular/core';
 import { IPermissions, PERMISSIONS } from '../../../util/permissions';
 import { DialogService } from 'primeng/dynamicdialog';
-import { OperationLogsComponent } from '../operation-logs.component';
-import { TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { OperationLogsComponent, sortOptionType } from '../operation-logs.component';
+import { TranslateService, TranslatePipe, _ } from '@ngx-translate/core';
 import { Bind } from 'primeng/bind';
 import { Button } from 'primeng/button';
 import { PermissionsDirective } from '../../../directive/permissions.directive';
@@ -26,6 +26,13 @@ export class OperationLogsDialogComponent {
   /** Resource pid */
   readonly resourcePid = input<string>();
 
+  readonly sortCriteria = input<string>('mostrecent');
+
+  readonly sortOptions = input<sortOptionType[]>([
+    { value: 'mostrecent', label: _('Date (newest)'), icon: 'fa fa-sort-amount-desc' },
+    { value: 'created', label: _('Date (oldest)'), icon: 'fa fa-sort-amount-asc' }
+  ]);
+
   /** return all permissions */
   permissions: IPermissions = PERMISSIONS;
 
@@ -36,10 +43,13 @@ export class OperationLogsDialogComponent {
       modal: true,
       closable: true,
       width: '60vw',
+      contentStyle: { 'min-height': '10rem' },
       position: 'top',
       data: {
         resourceType: this.resourceType(),
-        resourcePid: this.resourcePid()
+        resourcePid: this.resourcePid(),
+        sortCriteria: this.sortCriteria(),
+        sortOptions: this.sortOptions()
       }
     });
   }

--- a/projects/shared/src/lib/component/operation-logs/operation-logs.component.html
+++ b/projects/shared/src/lib/component/operation-logs/operation-logs.component.html
@@ -3,11 +3,32 @@ SPDX-FileCopyrightText: Fondation RERO+
 SPDX-FileCopyrightText: UCLouvain
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-@if (!loadedRecord()) {
+@if (!operationLogsResult()) {
   <i class="fa-solid fa-spinner fa-pulse"></i>
 } @else if (records().length === 0) {
   <p>{{ "No operation log found." | translate }}</p>
 } @else {
+  <div class="ui:flex ui:justify-end ui:mb-2">
+    <p-select
+      appendTo="body"
+      [ngModel]="sortCriteria()"
+      [options]="sortOptions()"
+      (onChange)="sortChange($event)"
+    >
+      <ng-template #selectedItem let-item>
+        <div class="ui:flex ui:items-center ui:gap-2">
+          <i [class]="item.icon"></i>
+          <span>{{ item.label | translate }}</span>
+        </div>
+      </ng-template>
+      <ng-template #item let-item>
+        <div class="ui:flex ui:items-center ui:gap-2">
+          <i [class]="item.icon"></i>
+          <span>{{ item.label | translate }}</span>
+        </div>
+      </ng-template>
+    </p-select>
+  </div>
   <p-table stripedRows [value]="records()" [tableStyle]="{ 'min-width': '50rem' }" size="small">
     <ng-template #body let-record>
       <tr>
@@ -26,12 +47,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </tr>
     </ng-template>
   </p-table>
-  @if (isLinkShowMore()) {
-    <p-button severity="secondary" [text]="true" (onClick)="showMore()">
-      <div>
-        <i class="fa-regular fa-square-plus"></i>&nbsp;{{ "Show more" | translate }}&nbsp;
-        <small>({{ hiddenOperationLogs() }})</small>
-      </div>
-    </p-button>
-  }
+  <shared-paginator
+    [pager]="pager()"
+    [total]="recordTotals()"
+    (pageChange)="pageChange($event)"
+  />
+
 }

--- a/projects/shared/src/lib/component/operation-logs/operation-logs.component.spec.ts
+++ b/projects/shared/src/lib/component/operation-logs/operation-logs.component.spec.ts
@@ -4,14 +4,21 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Pipe, PipeTransform } from '@angular/core';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { NgCoreTranslateService } from '@rero/ng-core';
+import { DateTranslatePipe, NgCoreTranslateService } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TableModule } from 'primeng/table';
 class FakeLoader implements TranslateLoader {
   getTranslation(_lang: string): Observable<any> { return of({}); }
+}
+@Pipe({
+  name: 'dateTranslate'
+})
+class MockDateTranslatePipe implements PipeTransform {
+  transform(value: string): string { return value; }
 }
 import { OperationLogsApiService } from '../../api/operation-logs-api.service';
 import { AppStore } from '../../store/app.store';
@@ -20,10 +27,13 @@ import { OperationLogsComponent } from './operation-logs.component';
 describe('OperationLogsComponent', () => {
   let component: OperationLogsComponent;
   let fixture: ComponentFixture<OperationLogsComponent>;
+  let appStoreSpy: any;
+  let operationLogsApiServiceSpy: any;
+  let dynamicDialogConfig: { data: any };
 
   const records = [
     {
-      medatadata: {
+      metadata: {
         date: '2021-01-10 12:00:00',
         operation: 'create',
         user_name: 'system'
@@ -31,20 +41,24 @@ describe('OperationLogsComponent', () => {
     }
   ];
 
-  const appStoreSpy = {
-    getResourceKeyByResourceName: vi.fn().mockReturnValue('doc')
-  };
-
-  const operationLogsApiServiceSpy = {
-    getLogs: vi.fn().mockReturnValue(of({
-      aggregations: [],
-      hits: { total: { value: 1 }, hits: records },
-      links: [],
-      total: { value: 1 }
-    }))
-  };
-
   beforeEach(async () => {
+    appStoreSpy = {
+      getResourceKeyByResourceName: vi.fn().mockReturnValue('doc')
+    };
+    operationLogsApiServiceSpy = {
+      getLogs: vi.fn().mockReturnValue(of({
+        aggregations: [],
+        hits: { total: { value: 1 }, hits: records },
+        links: [],
+        total: { value: 1 }
+      }))
+    };
+    dynamicDialogConfig = {
+      data: {
+        resourceType: 'documents',
+        resourcePid: '1'
+      }
+    };
     await TestBed.configureTestingModule({
     imports: [
         TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: FakeLoader } }),
@@ -61,21 +75,182 @@ describe('OperationLogsComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         DynamicDialogRef,
-        DynamicDialogConfig
+        {
+          provide: DynamicDialogConfig,
+          useValue: dynamicDialogConfig
+        }
     ]
-}).compileComponents();
+    })
+    .overrideComponent(OperationLogsComponent, {
+      remove: { imports: [DateTranslatePipe] },
+      add: { imports: [MockDateTranslatePipe] }
+    })
+    .compileComponents();
   });
 
-  beforeEach(() => {
+  const createComponent = () => {
     fixture = TestBed.createComponent(OperationLogsComponent);
     component = fixture.componentInstance;
-  });
+  };
 
   it('should create', () => {
+    createComponent();
+
     expect(component).toBeTruthy();
   });
 
   it('should have a native element', () => {
+    createComponent();
+
     expect(fixture.nativeElement).toBeDefined();
+  });
+
+  it('should load the first page of resource operation logs', async () => {
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(operationLogsApiServiceSpy.getLogs).toHaveBeenCalledWith('doc', '1', 1, 10, 'mostrecent');
+    expect(component.records()).toEqual(records);
+    expect(component.recordTotals()).toBe(1);
+  });
+
+  it('should use configured sort criteria and options', async () => {
+    dynamicDialogConfig.data.sortCriteria = 'operation_date_mostrecent';
+    dynamicDialogConfig.data.sortOptions = [
+      { value: 'operation_date_mostrecent', label: 'Date (newest)', icon: 'fa fa-sort-amount-desc' },
+      { value: 'operation_date_created', label: 'Date (oldest)', icon: 'fa fa-sort-amount-asc' }
+    ];
+
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.sortCriteria()).toBe('operation_date_mostrecent');
+    expect(component.sortOptions()).toEqual(dynamicDialogConfig.data.sortOptions);
+    expect(operationLogsApiServiceSpy.getLogs).toHaveBeenCalledWith('doc', '1', 1, 10, 'operation_date_mostrecent');
+  });
+
+  it('should hide the paginator when operation logs fit on one page', async () => {
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('shared-paginator')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('p-paginator').style.display).toBe('none');
+  });
+
+  it('should display the paginator when operation logs exceed one page', async () => {
+    operationLogsApiServiceSpy.getLogs.mockReturnValueOnce(of({
+      aggregations: [],
+      hits: { total: { value: 11 }, hits: records },
+      links: [],
+      total: { value: 11 }
+    }));
+
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('shared-paginator')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('p-paginator').style.display).not.toBe('none');
+  });
+
+  it('should replace records on page change', async () => {
+    const nextRecords = [
+      {
+        metadata: {
+          date: '2021-01-09 12:00:00',
+          operation: 'update',
+          user_name: 'system'
+        }
+      }
+    ];
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    TestBed.tick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    operationLogsApiServiceSpy.getLogs.mockClear();
+    operationLogsApiServiceSpy.getLogs.mockReturnValueOnce(of({
+      aggregations: [],
+      hits: { total: { value: 11 }, hits: nextRecords },
+      links: [],
+      total: { value: 11 }
+    }));
+    component.pageChange({ page: 1, first: 10, rows: 10, pageCount: 2 });
+    expect(component.pager().page).toBe(2);
+    TestBed.tick();
+    await fixture.whenStable();
+
+    expect(operationLogsApiServiceSpy.getLogs).toHaveBeenLastCalledWith('doc', '1', 2, 10, 'mostrecent');
+    expect(component.records()).toEqual(nextRecords);
+    expect(component.recordTotals()).toBe(11);
+  });
+
+  it('should reset to the first page and load oldest records on sort change', async () => {
+    const oldestRecords = [
+      {
+        metadata: {
+          date: '2021-01-01 12:00:00',
+          operation: 'create',
+          user_name: 'system'
+        }
+      }
+    ];
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    operationLogsApiServiceSpy.getLogs.mockReturnValueOnce(of({
+      aggregations: [],
+      hits: { total: { value: 11 }, hits: oldestRecords },
+      links: [],
+      total: { value: 11 }
+    }));
+    component.pageChange({ page: 1, first: 10, rows: 10, pageCount: 2 });
+    TestBed.tick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    operationLogsApiServiceSpy.getLogs.mockReturnValueOnce(of({
+      aggregations: [],
+      hits: { total: { value: 11 }, hits: oldestRecords },
+      links: [],
+      total: { value: 11 }
+    }));
+
+    component.sortChange({ originalEvent: undefined, value: 'created' });
+    TestBed.tick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.sortCriteria()).toBe('created');
+    expect(component.pager().page).toBe(1);
+    expect(component.pager().first).toBe(1);
+    expect(operationLogsApiServiceSpy.getLogs).toHaveBeenLastCalledWith('doc', '1', 1, 10, 'created');
+    expect(component.records()).toEqual(oldestRecords);
+  });
+
+  it('should support empty results', async () => {
+    operationLogsApiServiceSpy.getLogs.mockReturnValueOnce(of({
+      aggregations: [],
+      hits: { total: { value: 0 }, hits: [] },
+      links: [],
+      total: { value: 0 }
+    }));
+
+    createComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.records()).toEqual([]);
+    expect(component.recordTotals()).toBe(0);
+    expect(fixture.nativeElement.textContent).toContain('No operation log found.');
   });
 });

--- a/projects/shared/src/lib/component/operation-logs/operation-logs.component.ts
+++ b/projects/shared/src/lib/component/operation-logs/operation-logs.component.ts
@@ -1,74 +1,94 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, Injector, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { _, TranslatePipe } from "@ngx-translate/core";
 import type { EsResult, RecordData } from '@rero/ng-core';
-import { DateTranslatePipe, NgCoreTranslateService } from '@rero/ng-core';
+import { DateTranslatePipe } from '@rero/ng-core';
 import { Bind } from 'primeng/bind';
-import { Button } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { PaginatorState } from 'primeng/paginator';
+import { SelectChangeEvent, SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
-import { forkJoin, Observable } from 'rxjs';
-import { finalize } from 'rxjs/operators';
 import { OperationLogsApiService } from '../../api/operation-logs-api.service';
+import { Pager } from '../paginator/model/paginator-model';
+import { PaginatorComponent } from '../paginator/paginator.component';
 import { AppStore } from '../../store/app.store';
+
+export type sortOptionType = {
+  value: string;
+  label: string;
+  icon: string;
+};
 
 @Component({
     selector: 'shared-operation-logs',
     templateUrl: './operation-logs.component.html',
-    imports: [Bind, TableModule, Button, DateTranslatePipe, TranslatePipe],
+    imports: [Bind, FormsModule, SelectModule, TableModule, DateTranslatePipe, TranslatePipe, PaginatorComponent],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OperationLogsComponent {
+export class OperationLogsComponent implements OnInit {
 
   private dynamicDialogRef: DynamicDialogRef = inject(DynamicDialogRef);
   private dynamicDialogConfig: DynamicDialogConfig = inject(DynamicDialogConfig);
   private operationLogsApiService: OperationLogsApiService = inject(OperationLogsApiService);
   private appStore: InstanceType<typeof AppStore> = inject(AppStore);
-  private translateService: NgCoreTranslateService = inject(NgCoreTranslateService);
+  private injector: Injector = inject(Injector);
 
   // COMPONENT ATTRIBUTES =====================================================
   private readonly resourceType: string = this.dynamicDialogConfig?.data?.resourceType;
   private readonly resourcePid: string = this.dynamicDialogConfig?.data?.resourcePid;
   private readonly resourceKey: string = this.appStore.getResourceKeyByResourceName(this.resourceType);
 
-  /** items per pages */
-  private readonly itemsPerPage = 5;
-  /** Current page */
-  private readonly page = signal(1);
-  /** Total of records */
-  readonly recordTotals = signal(0);
-  /** Array of records */
-  readonly records = signal<RecordData[]>([]);
-  /** first loaded record */
-  readonly loadedRecord = signal(false);
-
-  // COMPUTED =================================================================
-  /** Show more link is visible ? */
-  readonly isLinkShowMore = computed(() =>
-    this.recordTotals() > 0 && (this.page() * this.itemsPerPage) < this.recordTotals()
-  );
-
-  /** Hidden operation logs counter */
-  readonly hiddenOperationLogs = computed(() => {
-    let count = this.recordTotals() - (this.page() * this.itemsPerPage);
-    count = Math.max(count, 0);
-    const linkText = (count > 1)
-      ? _('{{ counter }} hidden operation logs')
-      : _('{{ counter }} hidden operation log');
-    return this.translateService.instant(linkText, { counter: count });
+  /** Paginator configuration */
+  readonly pager = signal<Pager>({
+    page: 1,
+    first: 1,
+    rows: 10,
+    rowsPerPageOptions: [10, 20, 50]
   });
+  /** Sort criteria */
+  readonly sortCriteria = signal('mostrecent');
+  /** Sort options */
+  readonly sortOptions = signal([
+    { value: 'mostrecent', label: _('Date (newest)'), icon: 'fa fa-sort-amount-desc' },
+    { value: 'created', label: _('Date (oldest)'), icon: 'fa fa-sort-amount-asc' }
+  ]);
 
-  constructor() {
-    forkJoin([this.operationLogsQuery(1, 'create'), this.operationLogsQuery(1, 'update')])
-      .pipe(
-        finalize(() => this.loadedRecord.set(true))
-      )
-      .subscribe(([createOpLogs, updateOpLogs]) => {
-        this.recordTotals.set(updateOpLogs.hits.total.value);
-        this.records.update(r => [...r, ...createOpLogs.hits.hits, ...updateOpLogs.hits.hits]);
-      });
+  readonly operationLogsResult = signal<EsResult | undefined>(undefined);
+
+  /** Total of records */
+  readonly recordTotals = computed(() => this.operationLogsResult()?.hits.total.value ?? 0);
+  /** Array of records */
+  readonly records = computed<RecordData[]>(() => this.operationLogsResult()?.hits.hits ?? []);
+
+  /** onInit hook */
+  ngOnInit(): void {
+    if (this.dynamicDialogConfig?.data?.sortCriteria) {
+      this.sortCriteria.set(this.dynamicDialogConfig?.data?.sortCriteria);
+    }
+    if (this.dynamicDialogConfig?.data?.sortOptions) {
+      this.sortOptions.set(this.dynamicDialogConfig?.data?.sortOptions);
+    }
+    effect(
+      (onCleanup) => {
+        const pager = this.pager();
+        const sort = this.sortCriteria();
+
+        const subscription = this.operationLogsApiService.getLogs(
+          this.resourceKey,
+          this.resourcePid,
+          pager.page,
+          pager.rows,
+          sort
+        )
+          .subscribe(response => this.operationLogsResult.set(response as EsResult));
+
+        onCleanup(() => subscription.unsubscribe());
+      },
+      { injector: this.injector }
+    );
   }
 
   /** Close operation log dialog */
@@ -76,21 +96,21 @@ export class OperationLogsComponent {
     this.dynamicDialogRef.close();
   }
 
-  /** show more */
-  showMore(): void {
-    this.page.update(p => p + 1);
-    this.operationLogsQuery(this.page(), 'update')
-      .subscribe((response: EsResult) => this.records.update(r => [...r, ...response.hits.hits]));
+  /** Change page */
+  pageChange(event: PaginatorState): void {
+    const rows = event.rows || this.pager().rows;
+    const hasRowsChanged = rows !== this.pager().rows;
+    this.pager.update(pager => ({
+      page: hasRowsChanged ? 1 : (event.page || 0) + 1,
+      first: hasRowsChanged ? 1 : (event.first || 0) + 1,
+      rows,
+      rowsPerPageOptions: pager.rowsPerPageOptions
+    }));
   }
 
-  /**
-   * Operation logs query
-   * @param page - number
-   * @param action - string
-   * @return Observable
-   */
-  private operationLogsQuery(page: number, action: 'create' | 'update'): Observable<EsResult> {
-    return this.operationLogsApiService
-      .getLogs(this.resourceKey, this.resourcePid, action, page, this.itemsPerPage) as Observable<EsResult>;
+  /** Change sort */
+  sortChange(event: SelectChangeEvent): void {
+    this.sortCriteria.set(event.value);
+    this.pager.update(pager => ({ ...pager, page: 1, first: 1 }));
   }
 }

--- a/projects/shared/src/lib/component/paginator/paginator.component.ts
+++ b/projects/shared/src/lib/component/paginator/paginator.component.ts
@@ -9,8 +9,8 @@ import { Pager } from './model/paginator-model';
   imports: [Paginator],
   template: `
     <p-paginator
-      dropdownAppendTo="body"
-      alwaysShow="false"
+      appendTo="body"
+      [alwaysShow]="alwaysShow()"
       [first]="pager().first"
       [rows]="pager().rows"
       [totalRecords]="total()"
@@ -24,6 +24,8 @@ export class PaginatorComponent {
   pager = input.required<Pager>();
 
   total = input.required<number>();
+
+  alwaysShow = input<boolean>(false);
 
   pageChange = output<PaginatorState>();
 }


### PR DESCRIPTION
* Sorts values by most recent first by default.
* Can also be sorted by oldest first.
* Adds a prime paginator to replace the "show more" button.
* Allows 10 rows per page by default.
* Closes rero/rero-ils#4154.