### PR TITLE
refactor(ill-request): use signal for pickupName

### DIFF
--- a/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.html
@@ -73,13 +73,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       }
       <dt translate>Requester</dt>
       <dd>
-        @if (requester() && requester().patron && requester().patron.barcode[0]) {
-          <a [routerLink]="['/circulation', 'patron', requester().patron.barcode[0]]">
-            <span id="patron-last-name">{{ requester().last_name }}</span>
-            @if (requester().first_name; as firstName) {
-              <span id="patron-first-name">, {{ firstName }}</span>
-            }
-          </a>
+        @if (requester(); as req) {
+          @if (req.patron?.barcode?.[0]; as barcode) {
+            <a [routerLink]="['/circulation', 'patron', barcode]">
+              <span id="patron-last-name">{{ req.last_name }}</span>
+              @if (req.first_name; as firstName) {
+                <span id="patron-first-name">, {{ firstName }}</span>
+              }
+            </a>
+          }
         }
       </dd>
       <dt translate>Request date</dt>
@@ -100,9 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       }
       <dt translate>Pickup location</dt>
       <dd>
-        @if (rec.metadata.pickup_location.pid | getRecord:'locations':'field':'ill_pickup_name' | async; as location_name) {
-          {{ location_name }}
-        }
+        {{ pickupName() || 'Unknown' | translate }}
       </dd>
       <dt translate>Scope</dt>
       <dd>

--- a/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/ill-request-detail-view/ill-request-detail-view.component.ts
@@ -1,21 +1,20 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Component, computed, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
 import { getTagSeverityFromStatus } from '@app/admin/utils/utils';
-import { RecordService, TruncateTextPipe, DateTranslatePipe, GetRecordPipe, Nl2brPipe } from '@rero/ng-core';
-import { map, of, switchMap } from 'rxjs';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+import { DateTranslatePipe, Nl2brPipe, RecordService, TruncateTextPipe } from '@rero/ng-core';
 import { Bind } from 'primeng/bind';
 import { Panel } from 'primeng/panel';
-import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { RouterLink } from '@angular/router';
 import { Tag } from 'primeng/tag';
-import { AsyncPipe } from '@angular/common';
+import { catchError, map, of, switchMap } from 'rxjs';
 
 @Component({
     selector: 'admin-ill-request-detail-view',
     templateUrl: './ill-request-detail-view.component.html',
-    imports: [Bind, Panel, TranslateDirective, RouterLink, Tag, AsyncPipe, TruncateTextPipe, TranslatePipe, DateTranslatePipe, GetRecordPipe, Nl2brPipe],
+    imports: [Bind, Panel, TranslateDirective, RouterLink, Tag, TruncateTextPipe, TranslatePipe, DateTranslatePipe, Nl2brPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class IllRequestDetailViewComponent {
@@ -34,6 +33,20 @@ export class IllRequestDetailViewComponent {
         const pid = r?.metadata?.patron?.pid;
         if (!pid) return of(null);
         return this.recordService.getRecord('patrons', pid).pipe(map((p: any) => p.metadata));
+      })
+    ),
+    { initialValue: null }
+  );
+
+  readonly pickupName = toSignal(
+    toObservable(this.record).pipe(
+      switchMap(r => {
+        const pid = r?.metadata?.pickup_location?.pid;
+        if (!pid) return of(null);
+        return this.recordService.getRecord('locations', pid).pipe(
+          map((l: any) => l.metadata.ill_pickup_name),
+          catchError(() => of(null))
+        );
       })
     ),
     { initialValue: null }


### PR DESCRIPTION
* Convert pickup location lookup from GetRecordPipe/AsyncPipe to a toSignal/switchMap pattern consistent with requester, with a catchError fallback so failures reset to null instead of hanging.
* Harden the requester template block against a missing/empty patron barcode and avoid repeated requester() calls.

use with: https://github.com/rero/rero-ils/pull/4125