### PR TITLE
refactor(guards): use createUrlTree over navigate

### DIFF
--- a/projects/admin/src/app/guard/acq-order-line.guard.spec.ts
+++ b/projects/admin/src/app/guard/acq-order-line.guard.spec.ts
@@ -1,15 +1,31 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from "@angular/core/testing";
 import { acqOrderLineGuard } from "./acq-order-line.guard";
-import { of } from "rxjs";
+import { cloneDeep } from 'lodash-es';
+import { firstValueFrom, of, throwError } from "rxjs";
 import { RecordService } from "@rero/ng-core";
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from "@angular/router";
+import { ActivatedRouteSnapshot, Router, RouterModule, RouterStateSnapshot, UrlTree } from "@angular/router";
 import { AppStore } from "@rero/shared";
+import { ErrorPageComponent } from '../error/error-page/error-page.component';
 
 describe('acqOrderLineGuard', () => {
   let route: ActivatedRouteSnapshot;
+  let router: Router;
+
+  const routes = [
+    {
+      path: 'errors/403',
+      component: ErrorPageComponent
+    },
+    {
+      path: 'errors/500',
+      component: ErrorPageComponent
+    }
+  ];
 
   const acqOrder = {
     metadata: {
@@ -37,22 +53,40 @@ describe('acqOrderLineGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [RouterModule.forRoot(routes)],
       providers: [
         { provide: RecordService, useValue: recordServiceSpy },
         { provide: ActivatedRouteSnapshot, useValue: activatedRouteSnapshotSpy },
-        { provide: AppStore, useValue: appStoreSpy }
+        { provide: AppStore, useValue: appStoreSpy },
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     });
 
     route = TestBed.inject(ActivatedRouteSnapshot);
+    router = TestBed.inject(Router);
   });
 
   it('should be created', () => {
     expect(acqOrderLineGuard).toBeTruthy();
   });
 
-  it('should return true when the library matches', () => {
-    runGuard(route)
-      .subscribe((result: boolean) => expect(result).toBe(true));
+  it('should return true when the library matches', async () => {
+    const result = await firstValueFrom(runGuard(route));
+    expect(result).toBe(true);
+  });
+
+  it('should return a 403 UrlTree if the library does not match', async () => {
+    appStoreSpy.currentLibraryPid.mockReturnValueOnce('99');
+    const result = await firstValueFrom(runGuard(cloneDeep(route)));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
+  });
+
+  it('should return a 500 UrlTree if the record service fails', async () => {
+    recordServiceSpy.getRecord.mockReturnValueOnce(throwError(() => new Error('boom')));
+    const result = await firstValueFrom(runGuard(cloneDeep(route)));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/500');
   });
 });

--- a/projects/admin/src/app/guard/acq-order-line.guard.ts
+++ b/projects/admin/src/app/guard/acq-order-line.guard.ts
@@ -4,7 +4,6 @@ import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { extractIdOnRef, RecordService } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
-import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { checkLibraryAccess } from './library.guard';
 
@@ -12,7 +11,7 @@ import { checkLibraryAccess } from './library.guard';
  * Guard that checks if the current user's library matches the library of the
  * acquisition order referenced by the `order` query param (or `pid` route param).
  */
-export const acqOrderLineGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const acqOrderLineGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const recordService = inject(RecordService);
   const appStore = inject(AppStore);
   const router = inject(Router);

--- a/projects/admin/src/app/guard/can-access.guard.spec.ts
+++ b/projects/admin/src/app/guard/can-access.guard.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, Router, RouterModule, RouterStateSnapshot } from '@angular/router';
+import { Router, RouterModule, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { cloneDeep } from 'lodash-es';
-import { firstValueFrom, filter } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { of } from 'rxjs';
 import { ErrorPageComponent } from '../error/error-page/error-page.component';
 import { RecordPermissionService } from '../service/record-permission.service';
@@ -74,77 +74,64 @@ describe('canAccessGuard', () => {
     recordPermissionService = TestBed.inject(RecordPermissionService);
   });
 
-  /** Helper to wait until router finishes navigating */
-  async function waitForNavigation(): Promise<void> {
-    await firstValueFrom(
-      router.events.pipe(filter(e => e instanceof NavigationEnd))
-    );
-  }
-
   it('should be created', () => {
     expect(canAccessGuard).toBeTruthy();
   });
 
-  it('should return a 400 error if any parameters are missing', async () => {
+  it('should return a 400 UrlTree if any parameters are missing', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = {};
     activatedRoute.params = {};
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
-  it('should return a 400 error if route parameters are missing', async () => {
+  it('should return a 400 UrlTree if route parameters are missing', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = { action: CAN_ACCESS_ACTIONS.READ };
     activatedRoute.params = {};
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
-  it('should return a 400 error if data parameters are missing', async () => {
+  it('should return a 400 UrlTree if data parameters are missing', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = {};
     activatedRoute.params = { type: 'patrons', pid: 1 };
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
-  it('should return a 400 error if the action parameter is not in the action list', async () => {
+  it('should return a 400 UrlTree if the action parameter is not in the action list', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = { action: 'foo' };
     activatedRoute.params = { type: 'patrons', pid: 1 };
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
-  it('should return a 400 error if any parameter of the route is not in the mandatory parameters.', async () => {
+  it('should return a 400 UrlTree if any parameter of the route is not in the mandatory parameters.', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = { action: CAN_ACCESS_ACTIONS.READ };
     activatedRoute.params = { foo: 'bar' };
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
-  it('should return a 403 error, if the permission is not allowed', async () => {
+  it('should return a 403 UrlTree, if the permission is not allowed', async () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = { action: CAN_ACCESS_ACTIONS.READ };
     activatedRoute.params = { type: 'patrons', pid: 1 };
     const perms = cloneDeep(permissions);
     vi.spyOn(recordPermissionService, 'getPermission').mockReturnValue(of(perms));
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+    const result = await firstValueFrom(runGuard(activatedRoute));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 
   it('should return true, if permission is granted', async () => {
@@ -158,14 +145,13 @@ describe('canAccessGuard', () => {
     expect(access).toBe(true);
   });
 
-  it('should return a 403 error, if the permission on the update action is not allowed', async () => {
+  it('should return a 403 UrlTree, if the permission on the update action is not allowed', async () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.data = { action: CAN_ACCESS_ACTIONS.UPDATE };
     activatedRoute.params = { type: 'patrons', pid: 1 };
     vi.spyOn(recordPermissionService, 'getPermission').mockReturnValue(of(permissions));
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+    const result = await firstValueFrom(runGuard(activatedRoute));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 });

--- a/projects/admin/src/app/guard/can-access.guard.ts
+++ b/projects/admin/src/app/guard/can-access.guard.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
-import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { RecordPermissions } from '../classes/permissions';
 import { RecordPermissionService } from '../service/record-permission.service';
@@ -22,7 +21,7 @@ const mandatoryParams = ['type', 'pid'];
  * Requires `data.action` (one of CAN_ACCESS_ACTIONS) and route params `type` + `pid`.
  * Redirects to /errors/400 on bad route config, /errors/403 on insufficient permissions.
  */
-export const canAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const canAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const permissionService = inject(RecordPermissionService);
   const router = inject(Router);
 
@@ -31,16 +30,14 @@ export const canAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Ob
     || !(Object.values(CAN_ACCESS_ACTIONS).includes(route.data.action))
     || !(mandatoryParams.every((param: string) => param in route.params))
   ) {
-    router.navigate(['/errors/400'], { skipLocationChange: true });
-    return of(false);
+    return router.createUrlTree(['/errors/400']);
   }
 
   return permissionService.getPermission(route.params.type, route.params.pid).pipe(
     map((permission: RecordPermissions) => {
       const action = route.data.action as keyof RecordPermissions;
       if (!permission[action]?.can) {
-        router.navigate(['/errors/403'], { skipLocationChange: true });
-        return false;
+        return router.createUrlTree(['/errors/403']);
       }
       return true;
     })

--- a/projects/admin/src/app/guard/can-add-local-fields.guard.spec.ts
+++ b/projects/admin/src/app/guard/can-add-local-fields.guard.spec.ts
@@ -3,12 +3,12 @@
 
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, Router, RouterModule, RouterStateSnapshot } from '@angular/router';
+import { Router, RouterModule, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { RecordUiService } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
 import { cloneDeep } from 'lodash-es';
-import { filter, firstValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { of } from 'rxjs';
 import { LocalFieldApiService } from '../api/local-field-api.service';
 import { ErrorPageComponent } from '../error/error-page/error-page.component';
@@ -54,24 +54,17 @@ describe('canAddLocalFieldsGuard', () => {
     router = TestBed.inject(Router);
   });
 
-  async function waitForNavigation(): Promise<void> {
-    await firstValueFrom(
-      router.events.pipe(filter(e => e instanceof NavigationEnd))
-    );
-  }
-
   it('should create a service', () => {
     expect(canAddLocalFieldsGuard).toBeTruthy();
   });
 
-  it('should return a 400 error if any parameters are missing', async () => {
+  it('should return a 400 UrlTree if any parameters are missing', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.queryParams = {};
     vi.spyOn(localFieldApiService, 'getByResourceTypeAndResourcePidAndOrganisationId').mockReturnValue(of(record));
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 
   it('should return false if the current document has a local fields', async () => {
@@ -81,13 +74,12 @@ describe('canAddLocalFieldsGuard', () => {
     expect(access).toBeFalsy();
   });
 
-  it('should return a 400 error if the type is not correct', async () => {
+  it('should return a 400 UrlTree if the type is not correct', () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.queryParams = { type: 'foo', ref: '240' };
     vi.spyOn(localFieldApiService, 'getByResourceTypeAndResourcePidAndOrganisationId').mockReturnValue(of(record));
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/400');
+    const result = runGuard(activatedRoute);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/400');
   });
 });

--- a/projects/admin/src/app/guard/can-add-local-fields.guard.ts
+++ b/projects/admin/src/app/guard/can-add-local-fields.guard.ts
@@ -3,7 +3,6 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { AppStore } from '@rero/shared';
-import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LocalFieldApiService } from '../api/local-field-api.service';
 
@@ -17,21 +16,19 @@ const typeMap: Record<string, string> = {
  * Guard that prevents adding a local field record when one already exists for
  * the current organisation. Redirects to /errors/400 on missing params or unknown type.
  */
-export const canAddLocalFieldsGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const canAddLocalFieldsGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const appStore = inject(AppStore);
   const localFieldsApiService = inject(LocalFieldApiService);
   const router = inject(Router);
 
   const { type, ref } = route.queryParams;
   if (!type || !ref) {
-    router.navigate(['/errors/400'], { skipLocationChange: true });
-    return of(false);
+    return router.createUrlTree(['/errors/400']);
   }
 
   const mappedType = typeMap[type];
   if (!mappedType) {
-    router.navigate(['/errors/400'], { skipLocationChange: true });
-    return of(false);
+    return router.createUrlTree(['/errors/400']);
   }
 
   return localFieldsApiService

--- a/projects/admin/src/app/guard/item-access.guard.spec.ts
+++ b/projects/admin/src/app/guard/item-access.guard.spec.ts
@@ -4,17 +4,23 @@
 import { TestBed } from "@angular/core/testing";
 import { itemAccessGuard } from "./item-access.guard";
 import { AppStore } from "@rero/shared";
-import { of } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 import { apiResponse } from "@rero/shared";
 import { RecordService } from "@rero/ng-core";
 import { TranslateModule } from "@ngx-translate/core";
 import { MessageService, ToastMessageOptions } from "primeng/api";
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from "@angular/router";
+import { ActivatedRouteSnapshot, Router, RouterModule, RouterStateSnapshot, UrlTree } from "@angular/router";
+import { ErrorPageComponent } from "../error/error-page/error-page.component";
 
 describe('itemAccessGuard', () => {
   let route: ActivatedRouteSnapshot;
   let routerState: RouterStateSnapshot;
   let messageService: MessageService;
+  let router: Router;
+
+  const routes = [
+    { path: '', component: ErrorPageComponent }
+  ];
 
   const item = {
     metadata: {
@@ -48,6 +54,7 @@ describe('itemAccessGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        RouterModule.forRoot(routes),
         TranslateModule.forRoot()
       ],
       providers: [
@@ -62,6 +69,7 @@ describe('itemAccessGuard', () => {
     route = TestBed.inject(ActivatedRouteSnapshot);
     routerState = TestBed.inject(RouterStateSnapshot);
     messageService = TestBed.inject(MessageService);
+    router = TestBed.inject(Router);
 
     apiResponse.hits.hits = [holdings];
     recordServiceSpy.getRecords.mockReturnValue(of(apiResponse));
@@ -71,12 +79,16 @@ describe('itemAccessGuard', () => {
     expect(itemAccessGuard).toBeTruthy();
   });
 
-  it('should display a message if access is denied', () => {
+  it('should display a message and return a UrlTree if access is denied', async () => {
     messageService.messageObserver
       .subscribe((message: ToastMessageOptions) => {
         expect(message.severity).toEqual('warn');
         expect(message.detail).toEqual('Access denied');
       });
-    TestBed.runInInjectionContext(() => itemAccessGuard(route, routerState));
+    const result = await firstValueFrom(
+      TestBed.runInInjectionContext(() => itemAccessGuard(route, routerState)) as any
+    );
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/');
   });
 });

--- a/projects/admin/src/app/guard/item-access.guard.ts
+++ b/projects/admin/src/app/guard/item-access.guard.ts
@@ -7,29 +7,27 @@ import { CONFIG, extractIdOnRef, RecordService } from '@rero/ng-core';
 import type { EsResult } from '@rero/ng-core';
 import { AppStore } from '@rero/shared';
 import { MessageService } from 'primeng/api';
-import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
 /**
  * Guard that checks whether the current user's library owns the holding
  * linked to the given item. Redirects to `/` with a warning toast if denied.
  */
-export const itemAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const itemAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const router = inject(Router);
   const appStore = inject(AppStore);
   const recordService = inject(RecordService);
   const translateService = inject(TranslateService);
   const messageService = inject(MessageService);
 
-  const deny = (detailKey: string): boolean => {
+  const deny = (detailKey: string) => {
     messageService.add({
       severity: 'warn',
       summary: translateService.instant('item'),
       detail: translateService.instant(detailKey),
       life: CONFIG.MESSAGE_LIFE,
     });
-    router.navigate(['/']);
-    return false;
+    return router.createUrlTree(['/']);
   };
 
   return recordService.getRecord('items', route.params.pid).pipe(
@@ -41,7 +39,7 @@ export const itemAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): O
         ),
         map((data: any) => {
           if (data === null) {
-            return deny('Access denied');
+            return deny('Item not found');
           }
           if (appStore.currentLibraryPid() !== data.metadata.library.pid) {
             return deny('Access denied');
@@ -49,12 +47,6 @@ export const itemAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): O
           return true;
         })
       )
-    ),
-    map((result): boolean => {
-      if (result === false || result === null) {
-        return deny('Item not found');
-      }
-      return result as boolean;
-    })
+    )
   );
 };

--- a/projects/admin/src/app/guard/library.guard.spec.ts
+++ b/projects/admin/src/app/guard/library.guard.spec.ts
@@ -3,11 +3,11 @@
 
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, Router, RouterModule, RouterStateSnapshot } from '@angular/router';
+import { Router, RouterModule, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppStore } from '@rero/shared';
 import { cloneDeep } from 'lodash-es';
-import { filter, firstValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { ErrorPageComponent } from '../error/error-page/error-page.component';
 import { libraryGuard } from './library.guard';
 import { provideHttpClient } from '@angular/common/http';
@@ -46,12 +46,6 @@ describe('libraryGuard', () => {
     router = TestBed.inject(Router);
   });
 
-  async function waitForNavigation(): Promise<void> {
-    await firstValueFrom(
-      router.events.pipe(filter(e => e instanceof NavigationEnd))
-    );
-  }
-
   it('should be created', () => {
     expect(libraryGuard).toBeTruthy();
   });
@@ -61,12 +55,11 @@ describe('libraryGuard', () => {
     expect(access).toBeTruthy();
   });
 
-  it('should return a 403 error if the type is not correct', async () => {
+  it('should return a 403 UrlTree if the library does not match', async () => {
     const activatedRoute = cloneDeep(activatedRouteSnapshotSpy);
     activatedRoute.queryParams = { library: '2' };
-    const navPromise = waitForNavigation();
-    await firstValueFrom(runGuard(activatedRoute));
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+    const result = await firstValueFrom(runGuard(activatedRoute));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 });

--- a/projects/admin/src/app/guard/library.guard.ts
+++ b/projects/admin/src/app/guard/library.guard.ts
@@ -14,19 +14,15 @@ export function checkLibraryAccess(
   owningLibrary$: Observable<string>,
   appStore: InstanceType<typeof AppStore>,
   router: Router
-): Observable<boolean> {
+) {
   return owningLibrary$.pipe(
     map((owningLibrary: string) => {
       if (owningLibrary !== appStore.currentLibraryPid()) {
-        router.navigate(['/errors/403'], { skipLocationChange: true });
-        return false;
+        return router.createUrlTree(['/errors/403']);
       }
       return true;
     }),
-    catchError(() => {
-      router.navigate(['/errors/500'], { skipLocationChange: true });
-      return of(false);
-    })
+    catchError(() => of(router.createUrlTree(['/errors/500'])))
   );
 }
 
@@ -34,7 +30,7 @@ export function checkLibraryAccess(
  * Guard that checks if the current user belongs to the library passed via the
  * `library` query parameter. Redirects to /errors/403 if denied, /errors/500 on error.
  */
-export const libraryGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const libraryGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const appStore = inject(AppStore);
   const router = inject(Router);
   return checkLibraryAccess(of(route.queryParams.library), appStore, router);

--- a/projects/admin/src/app/guard/permission.guard.spec.ts
+++ b/projects/admin/src/app/guard/permission.guard.spec.ts
@@ -3,11 +3,10 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, NavigationEnd, Router, RouterStateSnapshot, RouterModule } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, RouterModule, UrlTree } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { AppStore, PERMISSION_OPERATOR, PERMISSIONS } from '@rero/shared';
-import { patchState } from '@ngrx/signals';
-import { filter, firstValueFrom } from 'rxjs';
+import { AppState, AppStore, PERMISSION_OPERATOR, PERMISSIONS } from '@rero/shared';
+import { patchState, WritableStateSource } from '@ngrx/signals';
 import { ErrorPageComponent } from '@app/admin/error/error-page/error-page.component';
 import { permissionGuard } from './permission.guard';
 
@@ -23,9 +22,9 @@ describe('permissionGuard', () => {
     data: { permissions: [PERMISSIONS.DOC_SEARCH, PERMISSIONS.DOC_CREATE, PERMISSIONS.ILL_SEARCH] }
   } as any as ActivatedRouteSnapshot;
 
-  const runGuard = (route: ActivatedRouteSnapshot): boolean =>
+  const runGuard = (route: ActivatedRouteSnapshot) =>
     TestBed.runInInjectionContext(() =>
-      permissionGuard(route, {} as RouterStateSnapshot) as boolean
+      permissionGuard(route, {} as RouterStateSnapshot)
     );
 
   beforeEach(() => {
@@ -37,47 +36,38 @@ describe('permissionGuard', () => {
     router = TestBed.inject(Router);
   });
 
-  async function waitForNavigation(): Promise<void> {
-    await firstValueFrom(
-      router.events.pipe(filter(e => e instanceof NavigationEnd))
-    );
-  }
-
   it('should allow access when one matching permission is present (OR)', () => {
-    patchState(appStore as any, { permissions: [PERMISSIONS.DOC_SEARCH] });
+    patchState(appStore as unknown as WritableStateSource<AppState>, { permissions: [PERMISSIONS.DOC_SEARCH] });
     expect(runGuard(routeSnapshot)).toBe(true);
   });
 
-  it('should deny access and redirect to 403 when no matching permission', async () => {
-    patchState(appStore as any, { permissions: [PERMISSIONS.ITTY_SEARCH] });
-    const navPromise = waitForNavigation();
-    expect(runGuard(routeSnapshot)).toBe(false);
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+  it('should deny access and redirect to 403 when no matching permission', () => {
+    patchState(appStore as unknown as WritableStateSource<AppState>, { permissions: [PERMISSIONS.ITTY_SEARCH] });
+    const result = runGuard(routeSnapshot);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 
-  it('should deny access when route data has no permissions', async () => {
-    patchState(appStore as any, { permissions: [PERMISSIONS.ILL_SEARCH] });
+  it('should deny access when route data has no permissions', () => {
+    patchState(appStore as unknown as WritableStateSource<AppState>, { permissions: [PERMISSIONS.ILL_SEARCH] });
     const snapshot = structuredClone(routeSnapshot);
     snapshot.data = {};
-    const navPromise = waitForNavigation();
-    expect(runGuard(snapshot)).toBe(false);
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+    const result = runGuard(snapshot);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 
-  it('should deny access when not all permissions are present (AND)', async () => {
-    patchState(appStore as any, { permissions: [PERMISSIONS.DOC_CREATE, PERMISSIONS.HOLD_CREATE] });
+  it('should deny access when not all permissions are present (AND)', () => {
+    patchState(appStore as unknown as WritableStateSource<AppState>, { permissions: [PERMISSIONS.DOC_CREATE, PERMISSIONS.HOLD_CREATE] });
     const snapshot = structuredClone(routeSnapshot);
     snapshot.data = { ...snapshot.data, operator: PERMISSION_OPERATOR.AND };
-    const navPromise = waitForNavigation();
-    expect(runGuard(snapshot)).toBe(false);
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+    const result = runGuard(snapshot);
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 
   it('should allow access when all permissions are present (AND)', () => {
-    patchState(appStore as any, { permissions: [PERMISSIONS.DOC_SEARCH, PERMISSIONS.DOC_CREATE, PERMISSIONS.ILL_SEARCH] });
+    patchState(appStore as unknown as WritableStateSource<AppState>, { permissions: [PERMISSIONS.DOC_SEARCH, PERMISSIONS.DOC_CREATE, PERMISSIONS.ILL_SEARCH] });
     const snapshot = structuredClone(routeSnapshot);
     snapshot.data = { ...snapshot.data, operator: PERMISSION_OPERATOR.AND };
     expect(runGuard(snapshot)).toBe(true);

--- a/projects/admin/src/app/guard/permission.guard.ts
+++ b/projects/admin/src/app/guard/permission.guard.ts
@@ -20,7 +20,7 @@ import { AppStore, PERMISSION_OPERATOR } from '@rero/shared';
  *   }
  * }
  */
-export const permissionGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean => {
+export const permissionGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const appStore = inject(AppStore);
   const router = inject(Router);
 
@@ -29,8 +29,7 @@ export const permissionGuard: CanActivateFn = (route: ActivatedRouteSnapshot): b
 
   const result = appStore.canAccess(permissions, operator);
   if (!result) {
-    router.navigate(['/errors/403'], { skipLocationChange: true });
-    return false;
+    return router.createUrlTree(['/errors/403']);
   }
 
   return true;

--- a/projects/public-search/src/app/guard/collection-access.guard.spec.ts
+++ b/projects/public-search/src/app/guard/collection-access.guard.spec.ts
@@ -1,14 +1,10 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, NavigationEnd, Router, RouterModule, RouterStateSnapshot } from '@angular/router';
-import { filter, firstValueFrom } from 'rxjs';
+import { ActivatedRouteSnapshot, Router, RouterModule, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { AppConfigService } from '../app-config.service';
 import { ErrorPageComponent } from '../error/error-page.component';
 import { collectionAccessGuard } from './collection-access.guard';
-
-const waitForNavigation = (router: Router): Promise<void> =>
-  firstValueFrom(router.events.pipe(filter(e => e instanceof NavigationEnd))).then(() => undefined);
 
 const makeRoute = (viewcode: string | undefined, parentViewcode?: string): ActivatedRouteSnapshot =>
   ({
@@ -24,9 +20,9 @@ describe('collectionAccessGuard', () => {
     { path: 'errors/403', component: ErrorPageComponent }
   ];
 
-  const runGuard = (route: ActivatedRouteSnapshot): boolean =>
+  const runGuard = (route: ActivatedRouteSnapshot) =>
     TestBed.runInInjectionContext(() =>
-      collectionAccessGuard(route, {} as RouterStateSnapshot) as boolean
+      collectionAccessGuard(route, {} as RouterStateSnapshot)
     );
 
   beforeEach(() => {
@@ -38,11 +34,10 @@ describe('collectionAccessGuard', () => {
     appConfigService = TestBed.inject(AppConfigService);
   });
 
-  it('should deny access and redirect to 403 when viewcode matches globalViewName', async () => {
-    const navPromise = waitForNavigation(router);
-    expect(runGuard(makeRoute(appConfigService.globalViewName))).toBe(false);
-    await navPromise;
-    expect(router.url).toBe('/errors/403');
+  it('should deny access and redirect to 403 when viewcode matches globalViewName', () => {
+    const result = runGuard(makeRoute(appConfigService.globalViewName));
+    expect(result instanceof UrlTree).toBeTruthy();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/errors/403');
   });
 
   it('should allow access when viewcode does not match globalViewName', () => {

--- a/projects/public-search/src/app/guard/collection-access.guard.ts
+++ b/projects/public-search/src/app/guard/collection-access.guard.ts
@@ -4,14 +4,13 @@ import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { AppConfigService } from '../app-config.service';
 
-export const collectionAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot): boolean => {
+export const collectionAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const appConfigService = inject(AppConfigService);
   const router = inject(Router);
 
   const viewcode = route.params['viewcode'] ?? route.parent?.params['viewcode'];
   if (appConfigService.globalViewName === viewcode) {
-    router.navigate(['/errors/403'], { skipLocationChange: true });
-    return false;
+    return router.createUrlTree(['/errors/403']);
   }
   return true;
 };


### PR DESCRIPTION
* Return UrlTree from guards instead of calling router.navigate with skipLocationChange
* Widen CanActivateFn bodies to Angular's own return type instead of a redundant annotation
* Remove dead branch in item-access.guard reached only via the old imperative navigate() call
* Update specs to assert on the returned UrlTree instead of waiting for a real navigation event