### PR TITLE
fix(editor): use phrase match for title autocomplete

### DIFF
--- a/projects/admin/src/app/record/editor/formly/primeng/remote-autocomplete/remote/documents-remote.service.ts
+++ b/projects/admin/src/app/record/editor/formly/primeng/remote-autocomplete/remote/documents-remote.service.ts
@@ -29,7 +29,7 @@ export class DocumentsRemoteService implements IRemoteAutocomplete {
       return of([]);
     }
 
-    let queryString = `((autocomplete_title:${query})^2 OR ${query})`;
+    let queryString = `((autocomplete_title:"${query}")^2 OR "${query}")`;
     const additionalQuery = [];
     if (queryOptions.filter) {
       additionalQuery.push(queryOptions.filter);


### PR DESCRIPTION
* Wrap query in quotes so autocomplete_title uses match_phrase instead of a loose term match
* Improves relevance by prioritizing exact phrase matches, boosted via the existing ^2 factor
* Safe against user-supplied quotes, since ng-core's removeChars() already strips them upstream
* Closes rero/rero-ils#3016