### PR TITLE
docs(ai): sync AI instructions with actual project state

### DIFF
--- a/.ai/angular-rules.md
+++ b/.ai/angular-rules.md
@@ -7,17 +7,10 @@ Framework version: Angular 21
 - Always use dot notation (`obj.prop`) over bracket notation (`obj['prop']`).
 - Avoid `Record<string, any>` — use a proper typed interface or type alias instead.
 
-## Migration rules
-
-This project is migrating incrementally to Angular 21 patterns:
-
-- New components are standalone by default (Angular 19+) — do not add `standalone: true` explicitly.
-- Existing NgModules are not removed unless explicitly refactored.
-- New code must not introduce new NgModules.
-
 ## Core rules
 
 - Components, directives and pipes are standalone by default since Angular 19 — omit `standalone: true`.
+- Do not introduce NgModules.
 - Prefer Angular Signals for local state in new components.
 - Avoid RxJS when Signals are sufficient for new code.
 - Use strict TypeScript typing.

--- a/.ai/dev-commands.md
+++ b/.ai/dev-commands.md
@@ -37,11 +37,11 @@ pnpm run build-shared
 
 Build a specific app:
 
-ng build admin --configuration production
-ng build public-search --configuration production
-ng build public-patron-profile --configuration production
-ng build public-holdings-items --configuration production
-ng build search-bar --configuration production
+pnpm exec ng build admin --configuration production
+pnpm exec ng build public-search --configuration production
+pnpm exec ng build public-patron-profile --configuration production
+pnpm exec ng build public-holdings-items --configuration production
+pnpm exec ng build search-bar --configuration production
 
 ## Tests
 
@@ -51,9 +51,9 @@ pnpm test
 
 Run tests for a specific project:
 
-ng test shared
-ng test admin
-ng test public-search
+pnpm exec ng test shared
+pnpm exec ng test admin
+pnpm exec ng test public-search
 
 ## Lint
 

--- a/.ai/project-context.md
+++ b/.ai/project-context.md
@@ -4,20 +4,12 @@
 
 - Angular 21
 - TypeScript strict mode
-- Zone.js (zoneless migration planned but not yet done)
+- Zoneless (`provideZonelessChangeDetection()`) — no Zone.js
 - NgRx Signal Store for application state
 - Signals preferred over RxJS for new code
-- Karma + Jasmine for testing (Vitest migration planned)
+- Vitest for testing (all projects, via `@angular/build:unit-test`)
+- pnpm for package management
 - Node 20+
-
-## Migration status
-
-This project is in active migration from Angular 19 to Angular 21 patterns:
-
-- NgModules still present — migration to standalone components in progress
-- Zone.js still active — zoneless migration not yet started
-- Karma/Jasmine still used — Vitest migration planned for a later phase
-- New code should follow Angular 21 patterns (standalone, signals, inject())
 
 ## Architecture
 
@@ -73,9 +65,8 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 
 ## Testing philosophy
 
-- Use Karma + Jasmine for tests (current standard).
+- Use Vitest for tests — see `.ai/testing-rules.md` for details.
 - Use TestBed when Angular integration is required.
-- Vitest migration will happen in a later phase — do not introduce it now.
 
 ## State management
 

--- a/.ai/prompts.md
+++ b/.ai/prompts.md
@@ -4,49 +4,19 @@ These prompt templates help guide the LLM when performing common tasks in this r
 
 ---
 
-## Migrate Angular component to standalone
-
-Goal: migrate this component to standalone.
-
-Constraints:
-
-- Angular 21
-- standalone: true
-- do not introduce NgModules
-- replace constructor injection with inject()
-- replace *ngIf/*ngFor with @if/@for
-- keep change detection strategy OnPush
-- do not change business logic
-
----
-
 ## Refactor Angular component
 
 Goal: simplify this component.
 
 Constraints:
 
-- Angular 21
-- standalone components only
+- Angular 21, standalone components only
 - do not introduce NgModules
 - replace constructor injection with inject()
 - move business logic outside components when possible
 - prefer Angular Signals over RxJS for local state
 - use new input()/output() API
 - keep change detection strategy OnPush
-
----
-
-## Fix Angular test
-
-Goal: update this test to match the current component.
-
-Constraints:
-
-- keep Karma + Jasmine
-- do not introduce Vitest
-- keep TestBed when Angular integration is required
-- use jasmine.createSpy() for mocks
 
 ---
 
@@ -68,7 +38,7 @@ Goal: write a unit test for the provided code.
 
 Constraints:
 
-- use Karma + Jasmine
+- use Vitest (`vi.fn()`, `vi.spyOn()`) — see `.ai/testing-rules.md`
 - prefer pure function testing
 - avoid TestBed unless Angular integration is required
 - keep the test minimal and readable

--- a/.ai/testing-rules.md
+++ b/.ai/testing-rules.md
@@ -89,19 +89,6 @@ Prefer:
 - Synchronous assertions (synchronous `of(...)` observables complete synchronously — no tick needed)
 - `async/await` with `await vi.advanceTimersByTimeAsync(0)` for effects (see NgRx section below)
 
-## Migration patterns (Jasmine → Vitest)
-
-| Before | After |
-|---|---|
-| `waitForAsync(() => {` | `async () => {` |
-| `fakeAsync(() => {` | `async () => {` |
-| `tick(N)` | `await new Promise(r => setTimeout(r, N))` |
-| `tick()` | `await Promise.resolve()` |
-| `.compileComponents()` | remove (no-op in Angular 14+) |
-| `fail('msg')` | `throw new Error('msg')` |
-| `jasmine.createSpy` | `vi.fn()` |
-| `spyOn(obj, 'method')` | `vi.spyOn(obj, 'method')` |
-
 - Spy types: use `any` instead of `MockedObject<T>` for partial mocks
 - Remove `.mockName('...')` from `vi.fn()` chains (causes TS errors)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Claude Code Instructions
 
-This repository uses Angular 21 and is in active migration from Angular 19 patterns.
+This repository uses Angular 21, zoneless change detection, and pnpm.
 
 Follow the rules defined in:
 
@@ -15,30 +15,23 @@ Follow the rules defined in:
 - .ai/testing-rules.md
 - .ai/dev-commands.md
 
-## Migration status
-
-This project is migrating incrementally — do not assume it is fully on Angular 21 patterns yet:
-
-- NgModules are still present — do not remove them unless explicitly asked
-- Zone.js is still active — do not apply zoneless patterns
-- `shared` uses Vitest (`@angular/build:unit-test`) — use Vitest API (`vi.fn()`, `vi.spyOn()`) for new specs in shared
-- Other projects (`admin`, `public-search`, etc.) still use Karma + Jasmine — do not introduce Vitest there yet
-
 ## Important constraints for new code
 
-- New components must be standalone (`standalone: true`)
+- Components are standalone by default (Angular 19+) — do not add `standalone: true` explicitly
+- Do not introduce NgModules
 - Use `inject()` instead of constructor injection
 - Use `@if` / `@for` in templates instead of `*ngIf` / `*ngFor`
 - Use `input()` / `output()` APIs for new components
 - Prefer Angular Signals over RxJS for local state
 - Use `OnPush` change detection
+- The app runs zoneless (`provideZonelessChangeDetection()`) — do not rely on Zone.js or `fakeAsync`/`tick`
 - Avoid `any` — prefer explicit TypeScript types
 
 ## Testing
 
-- `shared`: Vitest via `@angular/build:unit-test` — run with `ng test shared`
-- Other projects: Karma + Jasmine (not yet migrated)
+All projects use Vitest (`@angular/build:unit-test`) — run with `pnpm exec ng test <project>`.
+Use the Vitest API (`vi.fn()`, `vi.spyOn()`) — see `.ai/testing-rules.md` for details.
 
 ## Development commands
 
-See `.ai/dev-commands.md` for all available commands.
+See `.ai/dev-commands.md` for all available commands (uses pnpm).


### PR DESCRIPTION
The Angular 19→21, Karma→Vitest, and Zone.js→zoneless migrations are complete, and package management moved to pnpm, but CLAUDE.md and .ai/*.md still described them as in progress or not yet done.

* Remove obsolete "migration in progress" sections from CLAUDE.md, project-context.md and angular-rules.md
* Correct testing docs: all projects use Vitest, not just shared; drop the Jasmine→Vitest conversion table now that no Jasmine code remains
* Remove prompts.md templates that told the LLM to keep Karma+Jasmine or migrate components to standalone (already done everywhere)
* Prefix bare `ng ...` commands with `pnpm exec` in dev-commands.md and CLAUDE.md so they resolve correctly under pnpm's isolated node_modules