### PR TITLE
build(ci): use pnpm ci instead of install --frozen-lockfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
     - name: install package
-      run: pnpm install --frozen-lockfile
+      run: pnpm ci
 
     - name: Checkout ng-core
       if: steps.ng_core.outputs.local == 'true'
@@ -50,7 +50,7 @@ jobs:
     - name: Build and install local ng-core
       if: steps.ng_core.outputs.local == 'true'
       run: |
-        pnpm install --frozen-lockfile --dir ng-core
+        pnpm ci --dir ng-core
         pnpm --dir ng-core run pack
         pnpm add ng-core/dist/rero/ng-core
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Build library
         run: pnpm run pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Run semantic-release
         id: release


### PR DESCRIPTION
* Applies to main, publish and release workflows