### PR TITLE
fix(icons): harmonize acquisition and serial icons

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.html
@@ -13,6 +13,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       }
       <span class="ui:font-bold ui:text-muted-color ui:text-sm">
         [
+        <i class="fa-solid" [title]="order.status | translate" [ngClass]="{
+          'fa-inbox': order.status === orderStatus.PENDING,
+          'fa-paper-plane': order.status === orderStatus.ORDERED,
+          'fa-box-open text-warning': order.status === orderStatus.PARTIALLY_RECEIVED,
+          'fa-circle-check text-success': order.status === orderStatus.RECEIVED,
+          'fa-ban text-error': order.status === orderStatus.CANCELLED
+        }"></i>
         {{ order.status | translate }}
         @switch (order.status) {
           @case (orderStatus.ORDERED) {
@@ -49,7 +56,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             {{ order.account_statement.expenditure.total_amount | currency : order.currency }}
           </span>
           <span class="ui:w-4/12 ui:text-center ui:border-surface ui:border ui:p-2 ui:bg-surface-100 ui:rounded-r ui:text-muted-color ui:text-right">
-            <i class="fa-solid fa-right-to-bracket"></i>&nbsp;{{ order.account_statement.expenditure.quantity }}
+            <i class="fa-solid fa-circle-check"></i>&nbsp;{{ order.account_statement.expenditure.quantity }}
           </span>
         </div>
       }

--- a/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-brief-view/order-brief-view.component.ts
@@ -6,7 +6,7 @@ import { Component, input, OnInit, ChangeDetectionStrategy} from '@angular/core'
 import { AcqNoteType } from '../../../classes/common';
 import { AcqOrderStatus, IAcqOrder, orderDefaultData } from '../../../classes/order';
 import { RouterLink } from '@angular/router';
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe, CurrencyPipe, NgClass } from '@angular/common';
 import { DateTranslatePipe, GetRecordPipe, Nl2brPipe, TruncateTextPipe } from '@rero/ng-core';
 import { NotesFilterPipe } from '@rero/shared';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -14,7 +14,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 @Component({
     selector: 'admin-acquisition-order-brief-view',
     templateUrl: './order-brief-view.component.html',
-    imports: [RouterLink, AsyncPipe, CurrencyPipe, DateTranslatePipe, GetRecordPipe, Nl2brPipe, NotesFilterPipe, TruncateTextPipe, TranslatePipe],
+    imports: [RouterLink, AsyncPipe, CurrencyPipe, NgClass, DateTranslatePipe, GetRecordPipe, Nl2brPipe, NotesFilterPipe, TruncateTextPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrderBriefViewComponent implements OnInit {

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.html
@@ -22,7 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             (onClick)="placeOrderDialog()"
             severity="primary"
             [disabled]="!store.canPlaceOrder()"
-            icon="fa-solid fa-cart-shopping"
+            icon="fa-solid fa-paper-plane"
             [label]="'Place order' | translate"
           />
         </section>

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.html
@@ -10,14 +10,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <i class="ui:mt-1"
             title="{{ orderLine().status | translate }}"
             [ngClass]="{
-          'fa-regular': orderLine().status === orderLineStatus.APPROVED || orderLine().status === orderLineStatus.ORDERED || orderLine().status === orderLineStatus.CANCELLED,
-          'fa-envelope-open': orderLine().status === orderLineStatus.APPROVED,
-          'fa-envelope': orderLine().status === orderLineStatus.ORDERED,
+          'fa-solid': true,
+          'fa-inbox': orderLine().status === orderLineStatus.APPROVED,
+          'fa-paper-plane': orderLine().status === orderLineStatus.ORDERED,
           'ui:text-muted-color': orderLine().status === orderLineStatus.APPROVED || orderLine().status === orderLineStatus.ORDERED,
-          'fa-solid fa-right-to-bracket': orderLine().status === orderLineStatus.RECEIVED || orderLine().status === orderLineStatus.PARTIALLY_RECEIVED,
-          'text-success': orderLine().status === orderLineStatus.RECEIVED,
-          'text-warning': orderLine().status === orderLineStatus.PARTIALLY_RECEIVED,
-          'fa-rectangle-xmark text-error': orderLine().status === orderLineStatus.CANCELLED
+          'fa-box-open text-warning': orderLine().status === orderLineStatus.PARTIALLY_RECEIVED,
+          'fa-circle-check text-success': orderLine().status === orderLineStatus.RECEIVED,
+          'fa-ban text-error': orderLine().status === orderLineStatus.CANCELLED
         }"></i>
         <div class="ui:flex ui:items-start ui:flex-col ui:w-full">
           <div class="ui:flex ui:w-full ui:justify-between">
@@ -28,20 +27,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 <span class="ui:text-muted-color"><i class="fa-solid fa-triangle-exclamation"></i>&nbsp;{{ "Unknown document" | translate }} (pid {{ orderLine().document.pid }})</span>
               }
             </div>
-            <div class="ui:flex ui:pt-2 ui:gap-2">
+            <div class="ui:flex ui:items-start ui:pt-2 ui:gap-2">
               @if (orderLine().notes.length > 0) {
                 <div class="ui:flex ui:gap-1">
                   @for (note of orderLine().notes; track $index) {
-                    <i class="fa-solid fa-circle fa-bullet text-{{ note | noteBadgeColor }}" [title]="note.type | translate"></i>
+                    <i class="fa-regular fa-note-sticky text-{{ note | noteBadgeColor }}" [title]="note.type | translate"></i>
                   }
                 </div>
               }
               @if (orderLine().priority > 0) {
-                <div class="ui:flex">
-                  <p-overlaybadge [value]="orderLine().priority" [severity]="$any(severity())">
-                    <i class="fa-solid fa-gauge-high" style="font-size: 1.2rem"></i>
-                  </p-overlaybadge>
-                </div>
+                <p-tag [severity]="severity()" [title]="'Priority' | translate">
+                  <i class="fa-solid fa-flag"></i>&nbsp;{{ orderLine().priority }}
+                </p-tag>
               }
             </div>
           </div>

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-line/order-line.component.ts
@@ -13,7 +13,7 @@ import { AcqOrderLineStatus, IAcqOrderLine } from '../../../../classes/order';
 import { AppStore, OpenCloseButtonComponent, DocumentBriefViewComponent, ActionButtonComponent } from '@rero/shared';
 import { NgClass, CurrencyPipe } from '@angular/common';
 import { Bind } from 'primeng/bind';
-import { OverlayBadge } from 'primeng/overlaybadge';
+import { Tag } from 'primeng/tag';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NotesComponent } from '../../../notes/notes.component';
 import { RouterLink } from '@angular/router';
@@ -22,7 +22,7 @@ import { NoteBadgeColorPipe } from '../../../../pipes/note-badge-color.pipe';
 @Component({
     selector: 'admin-order-line',
     templateUrl: './order-line.component.html',
-    imports: [OpenCloseButtonComponent, NgClass, DocumentBriefViewComponent, Bind, OverlayBadge, TranslateDirective, NotesComponent, ActionButtonComponent, RouterLink, CurrencyPipe, TranslatePipe, NoteBadgeColorPipe],
+    imports: [OpenCloseButtonComponent, NgClass, DocumentBriefViewComponent, Bind, Tag, TranslateDirective, NotesComponent, ActionButtonComponent, RouterLink, CurrencyPipe, TranslatePipe, NoteBadgeColorPipe],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrderLineComponent {
@@ -63,13 +63,13 @@ export class OrderLineComponent {
     this.acqOrderApiService.deleteOrderLine(this.orderLine());
   }
 
-  severity(): string {
+  severity(): 'success' | 'secondary' | 'info' | 'warn' | 'danger' {
     switch (this.orderLine().priority) {
-      case 2: return 'primary';
+      case 2: return 'success';
       case 3: return 'info';
       case 4: return 'warn';
       case 5: return 'danger';
-      default: return 'success';
+      default: return 'secondary';
     }
   }
 }

--- a/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-summary/order-summary.component.html
@@ -43,7 +43,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       [ngTemplateOutletContext]="{
         quantity: order().account_statement.provisional.quantity,
         total: order().account_statement.provisional.total_amount,
-        label: 'Ordered' | translate
+        label: 'Ordered' | translate,
+        icon: 'fa-cart-shopping'
       }"
     />
     @if (order().account_statement.expenditure.quantity > 0) {
@@ -52,17 +53,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       [ngTemplateOutletContext]="{
         quantity: order().account_statement.expenditure.quantity,
         total: order().account_statement.expenditure.total_amount,
-        label: 'Received' | translate
+        label: 'Received' | translate,
+        icon: 'fa-circle-check'
       }"
     />
     }
   </div>
 </section>
 }
-<ng-template #totalAmount let-quantity="quantity" let-total="total" let-label="label">
+<ng-template #totalAmount let-quantity="quantity" let-total="total" let-label="label" let-icon="icon">
   <div class="ui:bg-surface-50 ui:py-4 ui:border ui:rounded-border ui:border-surface ui:relative">
     <div class="ui:absolute ui:bg-surface-200 ui:text-muted-color ui:rounded-l-md ui:rounded-r-md ui:border-l ui:border-b ui:border-surface ui:py-2 ui:px-6 ui:top-0 ui:right-0">
-      <i class="fa-solid fa-cart-shopping"></i>&nbsp;{{ quantity }}
+      <i class="fa-solid" [class]="icon"></i>&nbsp;{{ quantity }}
     </div>
     <div class="ui:flex ui:flex-wrap ui:text-center">
       <div class="ui:w-full ui:text-2xl ui:font-bold">

--- a/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
+++ b/projects/admin/src/app/acquisition/components/receipt/receipt-summary/receipt-summary.component.html
@@ -25,14 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           @if (receipt().notes.length > 0 && isCollapsed) {
             <span class="ui:flex ui:gap-1">
               @for (note of receipt().notes; track $index) {
-                <i class="fa-solid fa-circle text-{{ note | noteBadgeColor }}" aria-hidden="true" [title]="note.type | translate"></i>
+                <i class="fa-regular fa-note-sticky text-{{ note | noteBadgeColor }}" aria-hidden="true" [title]="note.type | translate"></i>
               }
             </span>
           }
         </div>
           @if (receipt().quantity) {
               <p-tag severity="info">
-                <i class="fa-solid fa-right-to-bracket"></i>&nbsp;
+                <i class="fa-solid fa-circle-check"></i>&nbsp;
                 {{ receipt().quantity }}
                 {{ receipt().quantity | i18nPlural: {'=1': 'item', 'other': 'items'} | translate }}
               </p-tag>

--- a/projects/admin/src/app/menu/menu-definition/menu-app.ts
+++ b/projects/admin/src/app/menu/menu-definition/menu-app.ts
@@ -245,7 +245,7 @@ export const MENU_APP: MenuItem[] = [
         label: 'Late issues',
         translateLabel: 'Late issues',
         id: MENU_IDS.APP.ACQUISITION.LATE_ISSUE,
-        icon: 'fa-solid fa-calendar-xmark',
+        icon: 'fa-solid fa-hourglass-half',
         routerLink: ['/', 'records', 'issues'],
         queryParams: {
           q: '',

--- a/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
+++ b/projects/admin/src/app/record/brief-view/issues-brief-view/issues-brief-view.component.html
@@ -67,9 +67,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     @if (record().metadata.issue.status; as status) {
       <dt translate>Issue status</dt>
       <dd>
-        <i class="text-warning" [ngClass]="{
-          'fa-solid fa-envelope': status === issueItemStatus.EXPECTED,
-          'fa-regular fa-envelope-open': status === issueItemStatus.LATE
+        <i [ngClass]="{
+          'fa-solid fa-envelope ui:text-muted-color': status === issueItemStatus.EXPECTED,
+          'fa-solid fa-hourglass-half text-warning': status === issueItemStatus.LATE
         }"
         ></i>
       {{ status | translate }} [{{ record().metadata.issue.status_date | dateTranslate }}]

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/received-issue/received-issue.component.html
@@ -87,7 +87,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       @if (recordPermissions()?.update?.can) {
         @if (isClaimAllowed) {
           <p-button
-            icon="fa-solid fa-gavel"
+            icon="fa-solid fa-bell-concierge"
             size="small"
             [title]="'Claim'|translate"
             outlined

--- a/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/holding-detail-view/serial-holding-detail-view/serial-holding-detail-view.component.html
@@ -66,7 +66,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                   <ng-container actions>
                     @if (store.isAllowIssueCreation()) {
                       <p-button
-                        icon="fa-solid fa-circle-check"
+                        icon="fa-regular fa-square-check"
                         size="small"
                         [title]="'Quick receive'|translate"
                         [outlined]="true"
@@ -74,7 +74,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                         [disabled]="store.quickReceiveDisableButton()"
                       />
                       <p-button
-                        icon="fa-regular fa-square-plus"
+                        icon="fa-solid fa-pen-to-square"
                         size="small"
                         [title]="'Receive and edit this issue'|translate"
                         [outlined]="true"

--- a/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/item-detail-view/item-detail-view.component.html
@@ -206,7 +206,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         }
         @if (record()?.metadata?.issue?.claims) {
           <p-tab value="claim" class="ui:flex ui:items-center ui:!gap-2">
-            <i class="fa-solid fa-gavel"></i>
+            <i class="fa-solid fa-bell-concierge"></i>
             <span [ngPlural]="record()?.metadata.issue.claims.counter">
               <ng-template ngPluralCase="=0">{{ 'Claim' | translate }}</ng-template>
               <ng-template ngPluralCase="=1">{{ 'Claim' | translate }}</ng-template>

--- a/projects/admin/src/app/service/holdings.service.spec.ts
+++ b/projects/admin/src/app/service/holdings.service.spec.ts
@@ -49,7 +49,7 @@ describe('HoldingsService', () => {
   it('should return the icon classes', () => {
     expect(service.getIcon(IssueItemStatus.DELETED)).toEqual('fa-solid fa-circle text-error');
     expect(service.getIcon(IssueItemStatus.RECEIVED)).toEqual('fa-solid fa-circle text-success');
-    expect(service.getIcon(IssueItemStatus.LATE)).toEqual('fa-regular fa-envelope-open text-warning');
+    expect(service.getIcon(IssueItemStatus.LATE)).toEqual('fa-solid fa-hourglass-half text-warning');
     expect(service.getIcon(IssueItemStatus.EXPECTED)).toEqual('fa-solid fa-circle text-secondary');
   });
 

--- a/projects/admin/src/app/service/holdings.service.ts
+++ b/projects/admin/src/app/service/holdings.service.ts
@@ -68,7 +68,7 @@ export class HoldingsService {
     switch (status) {
       case IssueItemStatus.DELETED: return 'fa-solid fa-circle text-error';
       case IssueItemStatus.RECEIVED: return 'fa-solid fa-circle text-success';
-      case IssueItemStatus.LATE: return 'fa-regular fa-envelope-open text-warning';
+      case IssueItemStatus.LATE: return 'fa-solid fa-hourglass-half text-warning';
       case IssueItemStatus.EXPECTED: return 'fa-solid fa-circle text-secondary';
       default: return 'fa-solid fa-circle text-dark';
     }


### PR DESCRIPTION
- rework order status into a coherent family (inbox → paper-plane → box-open → circle-check, ban for cancelled)
- use circle-check for received quantities (was right-to-bracket)
- use paper-plane for the "Place order" button
- use the app-wide note-sticky icon for notes
- show order line priority as a flag tag instead of an overlay badge
- replace the serial claim gavel with bell-concierge
- clarify quick-receive / receive-and-edit buttons

<img width="1462" height="443" alt="image" src="https://github.com/user-attachments/assets/9f219977-4eab-44fe-9ee1-60ca94c9d182" />

<img width="1474" height="689" alt="image" src="https://github.com/user-attachments/assets/2b30a635-2826-4bb1-b2fc-1d9854c98465" />

<img width="1491" height="813" alt="image" src="https://github.com/user-attachments/assets/e875a33c-4bf9-4d30-801c-260e1a3a4dba" />

