### PR TITLE
feat(exports): add Excel downloads

### DIFF
--- a/projects/admin/src/app/acquisition/routes/accounts-route.ts
+++ b/projects/admin/src/app/acquisition/routes/accounts-route.ts
@@ -28,6 +28,11 @@ export const exportFormats = [
     format: 'csv',
     disableMaxRestResultsSize: true,
   },
+  {
+    label: 'Excel',
+    format: 'xml',
+    disableMaxRestResultsSize: true,
+  },
 ];
 
 export const accountsRouteResolver: ResolveFn<Partial<RecordType>[]> = () =>

--- a/projects/admin/src/app/acquisition/routes/orders-route.ts
+++ b/projects/admin/src/app/acquisition/routes/orders-route.ts
@@ -147,6 +147,12 @@ class OrdersRoute extends BaseRoute implements RouteDataTypesInterface {
           endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
           disableMaxRestResultsSize: true,
         },
+        {
+          label: 'Excel',
+          format: 'xml',
+          endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
+          disableMaxRestResultsSize: true,
+        },
       ],
     };
     return [orderType];

--- a/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/reports-list/reports-list.component.html
+++ b/projects/admin/src/app/record/detail-view/statistics-cfg-detail-view/reports-list/reports-list.component.html
@@ -16,6 +16,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           <a pButton text [href]="getReportUrl(report.metadata.pid)+'?format=csv'">
             <i class="fa-solid fa-file-csv"></i>
           </a>
+          <a pButton text [href]="getReportUrl(report.metadata.pid)+'?format=xml'">
+            <i class="fa-regular fa-file-excel"></i>
+          </a>
         </td>
       </tr>
     </ng-template>

--- a/projects/admin/src/app/routes/issues-route.ts
+++ b/projects/admin/src/app/routes/issues-route.ts
@@ -63,6 +63,12 @@ class IssuesRoute extends BaseRoute implements RouteDataTypesInterface {
             endpoint: this.routeToolService.apiService.getEndpointByType('item/inventory'),
             disableMaxRestResultsSize: true,
           },
+          {
+            label: 'Excel',
+            format: 'xml',
+            endpoint: this.routeToolService.apiService.getEndpointByType('item/inventory'),
+            disableMaxRestResultsSize: true,
+          },
         ],
         showFacetsIfNoResults: true,
       },

--- a/projects/admin/src/app/routes/items-route.ts
+++ b/projects/admin/src/app/routes/items-route.ts
@@ -192,6 +192,12 @@ class ItemsRoute extends BaseRoute implements RouteDataTypesInterface {
             endpoint: this.routeToolService.apiService.getEndpointByType('item/inventory'),
             disableMaxRestResultsSize: true,
           },
+          {
+            label: 'Excel',
+            format: 'xml',
+            endpoint: this.routeToolService.apiService.getEndpointByType('item/inventory'),
+            disableMaxRestResultsSize: true,
+          },
         ],
         sortOptions: [
           {

--- a/projects/admin/src/app/routes/loans-route.ts
+++ b/projects/admin/src/app/routes/loans-route.ts
@@ -67,6 +67,12 @@ class LoansRoute extends BaseRoute implements RouteDataTypesInterface {
             endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
             disableMaxRestResultsSize: true,
           },
+          {
+            label: 'Excel',
+            format: 'xml',
+            endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
+            disableMaxRestResultsSize: true,
+          },
         ],
         showFacetsIfNoResults: true,
       },

--- a/projects/admin/src/app/routes/patron-transaction-events-route.ts
+++ b/projects/admin/src/app/routes/patron-transaction-events-route.ts
@@ -96,6 +96,12 @@ class PatronTransactionEventsRoute extends BaseRoute implements RouteDataTypesIn
             endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
             disableMaxRestResultsSize: true,
           },
+          {
+            label: 'Excel',
+            format: 'xml',
+            endpoint: this.routeToolService.apiService.getExportEndpointByType(this.recordType),
+            disableMaxRestResultsSize: true,
+          },
         ],
         showFacetsIfNoResults: true,
       },


### PR DESCRIPTION
* Adds Excel XML options beside every existing CSV export.
* Reuses the current endpoints and queries with the XML format.
* Covers inventory, issues, loans, fees, acquisitions, and reports.
* Adds Excel icons to statistics report downloads.
* Relies on https://github.com/rero/rero-ils/pull/4190.
* Closes rero/rero-ils#4168.