### PR TITLE
feat(documents): display missing metadata

### DIFF
--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.html
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.html
@@ -59,6 +59,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <ng-container content>
         @for (lang of $any(record().metadata.language); track $index; let isLast = $last) {
           {{ lang.value | translateLanguage: currentLanguage }}
+          @if (lang.note) {
+            ({{ lang.note }})
+          }
           @if (!isLast) {, }
         }
       </ng-container>
@@ -181,7 +184,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <ng-container content>
         <ul class="ui:list-none">
           @for (scale of $any(record().metadata.scale); track $index) {
-            <li>{{ scale.label }}</li>
+            <li>
+              {{ scale.label }}
+              @if (scaleRatios(scale); as ratios) {
+                <span class="ui:text-muted-color">({{ ratios }})</span>
+              }
+              @if (scale.type) {
+                <p-tag class="ui:ml-1 ui:text-sm" [value]="scale.type | translate" severity="secondary" />
+              }
+            </li>
           }
         </ul>
       </ng-container>
@@ -205,7 +216,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               @if (cartographic.coordinates && cartographic.coordinates.label) {
                 {{ cartographic.coordinates.label }}
               }
+              @if (cartographic.equinox) {
+                @if (cartographic.projection || cartographic.coordinates?.label) {
+                  ;
+                }
+                {{ 'Equinox' | translate }}: {{ cartographic.equinox }}
+              }
             </li>
+          }
+        </ul>
+      </ng-container>
+    </shared-description-zone>
+  }
+
+  <!-- TEMPORAL COVERAGE -->
+  @if (temporalCoverages.length > 0) {
+    <shared-description-zone>
+      <ng-container label>{{ 'Temporal coverage' | translate }}</ng-container>
+      <ng-container content>
+        <ul class="ui:list-none">
+          @for (coverage of temporalCoverages; track $index) {
+            <li>{{ coverage }}</li>
           }
         </ul>
       </ng-container>
@@ -224,7 +255,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               @if (classification.subdivision) {
                 - {{ classification.subdivision.join(' - ') }}
               }
-              ({{ classification.type | translate }})
+              ({{ classificationQualifiers(classification) }})
             </li>
           }
         </ul>
@@ -329,6 +360,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         }
       </ng-container>
     </shared-description-zone>
+  }
+
+  <!-- PROVISION ACTIVITY NOTE (ALL TYPES, INCLUDING PUBLICATION) -->
+  @if (provisionActivityNotes) {
+    @for (provisionNote of provisionActivityNotes | keyvalue; track $index) {
+      <shared-description-zone>
+        <ng-container label>{{ provisionNote.key | translate }} ({{ 'Note' | translate }})</ng-container>
+        <ng-container content>
+          <ul class="ui:list-none">
+            @for (note of provisionNote.value; track $index) {
+              <li>{{ note }}</li>
+            }
+          </ul>
+        </ng-container>
+      </shared-description-zone>
+    }
   }
 
   <!-- COPYRIGHT DATE -->
@@ -479,5 +526,57 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         {{ $any(record().metadata.issuance).main_type | translate }} / {{ $any(record().metadata.issuance).subtype | translate }}
       </ng-container>
     </shared-description-zone>
+  }
+
+  <!-- -------------- ADMIN METADATA (PROFESSIONAL INTERFACE ONLY) -------------- -->
+  <!-- `encodingLevel` and `note` are already reported by the detail view header banner. -->
+  @if (!isPublicView()) {
+    @let adminMetadata = $any(record().metadata.adminMetadata);
+
+    <!-- CATALOGUING SOURCE -->
+    @if (adminMetadata?.source) {
+      <shared-description-zone>
+        <ng-container label>{{ 'Cataloguing source' | translate }}</ng-container>
+        <ng-container content>{{ adminMetadata.source }}</ng-container>
+      </shared-description-zone>
+    }
+
+    <!-- DESCRIPTION MODIFIER -->
+    @if (adminMetadata?.descriptionModifier) {
+      <shared-description-zone>
+        <ng-container label>{{ 'Description modifier' | translate }}</ng-container>
+        <ng-container content>
+          <ul class="ui:list-none">
+            @for (modifier of adminMetadata.descriptionModifier; track $index) {
+              <li>{{ modifier }}</li>
+            }
+          </ul>
+        </ng-container>
+      </shared-description-zone>
+    }
+
+    <!-- LANGUAGE OF CATALOGUING -->
+    @if (adminMetadata?.descriptionLanguage) {
+      <shared-description-zone>
+        <ng-container label>{{ 'Language of cataloguing' | translate }}</ng-container>
+        <ng-container content>
+          {{ adminMetadata.descriptionLanguage | translateLanguage: currentLanguage }}
+        </ng-container>
+      </shared-description-zone>
+    }
+
+    <!-- DESCRIPTION CONVENTIONS -->
+    @if (adminMetadata?.descriptionConventions) {
+      <shared-description-zone>
+        <ng-container label>{{ 'Description conventions' | translate }}</ng-container>
+        <ng-container content>
+          <ul class="ui:list-none">
+            @for (convention of adminMetadata.descriptionConventions; track $index) {
+              <li>{{ convention }}</li>
+            }
+          </ul>
+        </ng-container>
+      </shared-description-zone>
+    }
   }
 </div>

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { DocumentDescriptionComponent } from './document-description.component';
+
+describe('DocumentDescriptionComponent', () => {
+  let component: DocumentDescriptionComponent;
+  let fixture: ComponentFixture<DocumentDescriptionComponent>;
+
+  /**
+   * Create the component for the given document metadata and run its init hook.
+   * The template is deliberately not rendered: these tests target the metadata processing only.
+   * @param metadata - the document metadata exposed through the `record` input
+   */
+  function withMetadata(metadata: object): void {
+    fixture = TestBed.createComponent(DocumentDescriptionComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('record', { metadata });
+    component.ngOnInit();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot({}), DocumentDescriptionComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    withMetadata({});
+    expect(component).toBeTruthy();
+  });
+
+  describe('provision activity notes', () => {
+    it('should group notes by provision activity type', () => {
+      withMetadata({
+        provisionActivity: [
+          { type: 'bf:Production', note: 'assumed place' },
+          { type: 'bf:Production', note: 'assumed agent' },
+          { type: 'bf:Distribution', note: 'distributor unknown' }
+        ]
+      });
+      expect(component.provisionActivityNotes).toEqual({
+        'bf:Production': ['assumed place', 'assumed agent'],
+        'bf:Distribution': ['distributor unknown']
+      });
+    });
+
+    it('should keep the note of a bf:Publication, whose statement is rendered in the header', () => {
+      withMetadata({
+        provisionActivity: [{ type: 'bf:Publication', note: 'uncertain publication date' }]
+      });
+      expect(component.provisionActivityNotes).toEqual({
+        'bf:Publication': ['uncertain publication date']
+      });
+    });
+
+    it('should ignore provision activities without a note', () => {
+      withMetadata({
+        provisionActivity: [
+          { type: 'bf:Publication', startDate: 1999 },
+          { type: 'bf:Production', note: 'assumed place' }
+        ]
+      });
+      expect(component.provisionActivityNotes).toEqual({ 'bf:Production': ['assumed place'] });
+    });
+
+    it('should stay undefined when no provision activity holds a note', () => {
+      withMetadata({ provisionActivity: [{ type: 'bf:Publication', startDate: 1999 }] });
+      expect(component.provisionActivityNotes).toBeUndefined();
+    });
+
+    it('should stay undefined without any provision activity', () => {
+      withMetadata({});
+      expect(component.provisionActivityNotes).toBeUndefined();
+    });
+  });
+
+  describe('temporal coverage', () => {
+    it('should strip the leading plus sign of a single date', () => {
+      withMetadata({ temporalCoverage: [{ type: 'time', date: '+1945-05-08' }] });
+      expect(component.temporalCoverages).toEqual(['1945-05-08']);
+    });
+
+    it('should keep the minus sign of a BCE date', () => {
+      withMetadata({ temporalCoverage: [{ type: 'time', date: '-0500' }] });
+      expect(component.temporalCoverages).toEqual(['-0500']);
+    });
+
+    it('should format a period', () => {
+      withMetadata({
+        temporalCoverage: [{ type: 'period', start_date: '+1914', end_date: '+1918' }]
+      });
+      expect(component.temporalCoverages).toEqual(['1914 - 1918']);
+    });
+
+    it('should format a period with only a start date', () => {
+      withMetadata({ temporalCoverage: [{ type: 'period', start_date: '+1914' }] });
+      expect(component.temporalCoverages).toEqual(['1914']);
+    });
+
+    it('should append the period codes', () => {
+      withMetadata({
+        temporalCoverage: [{ type: 'time', date: '+1945', period_code: ['x1x4', 'y2y5'] }]
+      });
+      expect(component.temporalCoverages).toEqual(['1945 (x1x4, y2y5)']);
+    });
+
+    it('should display a period code alone', () => {
+      withMetadata({ temporalCoverage: [{ type: 'time', period_code: ['x1x4'] }] });
+      expect(component.temporalCoverages).toEqual(['(x1x4)']);
+    });
+
+    it('should ignore an entry holding no displayable value', () => {
+      withMetadata({ temporalCoverage: [{ type: 'time' }] });
+      expect(component.temporalCoverages).toEqual([]);
+    });
+
+    it('should stay empty without any temporal coverage', () => {
+      withMetadata({});
+      expect(component.temporalCoverages).toEqual([]);
+    });
+  });
+
+  describe('cartographic attributes', () => {
+    it('should keep an attribute holding only an equinox', () => {
+      withMetadata({ cartographicAttributes: [{ equinox: 'J2000' }] });
+      expect(component.cartographicAttributes).toEqual([{ equinox: 'J2000' }]);
+    });
+
+    it('should keep an attribute holding a projection', () => {
+      withMetadata({ cartographicAttributes: [{ projection: 'Mercator' }] });
+      expect(component.cartographicAttributes).toEqual([{ projection: 'Mercator' }]);
+    });
+
+    it('should keep an attribute holding labelled coordinates', () => {
+      const attribute = { coordinates: { label: 'E 6°--E 10°' } };
+      withMetadata({ cartographicAttributes: [attribute] });
+      expect(component.cartographicAttributes).toEqual([attribute]);
+    });
+
+    it('should discard an attribute holding no displayable value', () => {
+      withMetadata({
+        cartographicAttributes: [{ coordinates: { longitude: 'E0060000' } }]
+      });
+      expect(component.cartographicAttributes).toEqual([]);
+    });
+  });
+
+  describe('work access point', () => {
+    it('should include the form subdivisions', () => {
+      withMetadata({
+        work_access_point: [{ title: 'Die Zauberflöte', form_subdivision: ['Libretti', 'Excerpts'] }]
+      });
+      expect(component.workAccessPoint).toEqual(['Die Zauberflöte. Libretti. Excerpts.']);
+    });
+
+    it('should not add a separator without form subdivisions', () => {
+      withMetadata({ work_access_point: [{ title: 'Die Zauberflöte' }] });
+      expect(component.workAccessPoint).toEqual(['Die Zauberflöte.']);
+    });
+  });
+
+  describe('scaleRatios', () => {
+    it('should join the horizontal and vertical ratios', () => {
+      withMetadata({});
+      expect(component.scaleRatios({ ratio_linear_horizontal: '25000', ratio_linear_vertical: '50000' }))
+        .toBe('25000 / 50000');
+    });
+
+    it('should return the only available ratio', () => {
+      withMetadata({});
+      expect(component.scaleRatios({ ratio_linear_horizontal: '25000' })).toBe('25000');
+    });
+
+    it('should return null without any ratio', () => {
+      withMetadata({});
+      expect(component.scaleRatios({})).toBeNull();
+    });
+  });
+
+  describe('classificationQualifiers', () => {
+    it('should join the type, the edition and the assigner', () => {
+      withMetadata({});
+      expect(component.classificationQualifiers({
+        type: 'bf:ClassificationDdc',
+        edition: '23',
+        assigner: 'DLC'
+      })).toBe('bf:ClassificationDdc, 23, DLC');
+    });
+
+    it('should keep the type alone when no other qualifier is set', () => {
+      withMetadata({});
+      expect(component.classificationQualifiers({ type: 'bf:ClassificationLcc' }))
+        .toBe('bf:ClassificationLcc');
+    });
+
+    it('should skip the missing edition', () => {
+      withMetadata({});
+      expect(component.classificationQualifiers({ type: 'bf:ClassificationUdc', assigner: 'DLC' }))
+        .toBe('bf:ClassificationUdc, DLC');
+    });
+  });
+});

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
@@ -13,6 +13,21 @@ import { DocumentProvisionActivityPipe } from '../../../pipe/document-provision-
 import { IdAttributePipe } from '../../../pipe/id-attribute.pipe';
 import { SafeUrlPipe } from '../../../pipe/safe-url.pipe';
 
+/** A provision activity of a document, as described by the `provisionActivity` field. */
+type ProvisionActivity = {
+  type: string;
+  note?: string;
+};
+
+/** A temporal content coverage of a document, as described by MARC 045. */
+type TemporalCoverage = {
+  type: string;
+  date?: string;
+  start_date?: string;
+  end_date?: string;
+  period_code?: string[];
+};
+
 @Component({
     selector: 'shared-document-description',
     templateUrl: './document-description.component.html',
@@ -41,8 +56,12 @@ export class DocumentDescriptionComponent implements OnInit {
   notesExceptGeneral: Record<string, string[]>;
   /** General notes only */
   notesGeneral: Record<string, string[]>;
+  /** Provision activity notes, grouped by provision activity type */
+  provisionActivityNotes: Record<string, string[]>;
   /** Provision activity original date */
   provisionActivityOriginalDate: any[] = [];
+  /** Temporal coverages, formatted for display */
+  temporalCoverages: string[] = [];
   /** Title variants */
   titleVariants: any = {};
   /** Work access point */
@@ -63,7 +82,9 @@ export class DocumentDescriptionComponent implements OnInit {
     this.processIdentifiedBy();
     this.processNotesExceptGeneral();
     this.processNotesGeneral();
+    this.processProvisionActivityNote();
     this.processProvisionActivityOriginalDate();
+    this.processTemporalCoverage();
     this.processTitleVariants();
     this.processWorkAccessPoint();
   }
@@ -77,12 +98,40 @@ export class DocumentDescriptionComponent implements OnInit {
     return ('key' in element && element.key !== 'bf:Publication');
   }
 
+  /**
+   * Format the qualifiers of a classification: type, edition and assigning agency.
+   * @param classification - the classification to format
+   * @returns the available qualifiers, joined by a comma
+   */
+  classificationQualifiers(classification: { type: string, edition?: string, assigner?: string }): string {
+    return [
+      this.translateService.instant(classification.type),
+      classification.edition,
+      classification.assigner
+    ].filter((qualifier: string) => qualifier).join(', ');
+  }
+
+  /**
+   * Format the linear ratios of a scale.
+   * @param scale - the scale to format
+   * @returns the horizontal and vertical ratios, or null when neither is set
+   */
+  scaleRatios(scale: { ratio_linear_horizontal?: string, ratio_linear_vertical?: string }): string | null {
+    const ratios = [scale.ratio_linear_horizontal, scale.ratio_linear_vertical]
+      .filter((ratio: string) => ratio);
+    return ratios.length > 0 ? ratios.join(' / ') : null;
+  }
+
   /** Process cartographic attributes */
   private processCartographicAttributes(): void {
     const metadata = this.record()?.metadata;
     if ('cartographicAttributes' in metadata) {
       metadata.cartographicAttributes.forEach((attribute: any) => {
-        if ('projection' in attribute || ('coordinates' in attribute && 'label' in attribute.coordinates)) {
+        if (
+          'projection' in attribute
+          || 'equinox' in attribute
+          || ('coordinates' in attribute && 'label' in attribute.coordinates)
+        ) {
           this.cartographicAttributes.push(attribute);
         }
       });
@@ -158,6 +207,23 @@ export class DocumentDescriptionComponent implements OnInit {
     }
   }
 
+  /** Process provision activity notes.*/
+  private processProvisionActivityNote(): void {
+    const metadata = this.record()?.metadata;
+    if ('provisionActivity' in metadata) {
+      const notesByType: Record<string, string[]> = {};
+      metadata.provisionActivity
+        .filter((provision: ProvisionActivity) => provision.note)
+        .forEach((provision: ProvisionActivity) => {
+          notesByType[provision.type] ??= [];
+          notesByType[provision.type].push(provision.note);
+        });
+      if (Object.keys(notesByType).length > 0) {
+        this.provisionActivityNotes = notesByType;
+      }
+    }
+  }
+
   /** Process provision activity original date */
   private processProvisionActivityOriginalDate(): void {
     const metadata = this.record()?.metadata;
@@ -165,6 +231,32 @@ export class DocumentDescriptionComponent implements OnInit {
       this.provisionActivityOriginalDate = metadata.provisionActivity
       .filter((element: any) => element.key !== 'bf:Publication')
       .filter((provision: any) => 'original_date' in provision)
+    }
+  }
+
+  /** Process temporal coverage.*/
+  private processTemporalCoverage(): void {
+    const metadata = this.record()?.metadata;
+    if ('temporalCoverage' in metadata) {
+      metadata.temporalCoverage.forEach((coverage: TemporalCoverage) => {
+        const parts: string[] = [];
+        if (coverage.date) {
+          parts.push(this._formatTemporalDate(coverage.date));
+        } else if (coverage.start_date || coverage.end_date) {
+          parts.push(
+            [coverage.start_date, coverage.end_date]
+              .filter((date: string) => date)
+              .map((date: string) => this._formatTemporalDate(date))
+              .join(' - ')
+          );
+        }
+        if (coverage.period_code?.length) {
+          parts.push(`(${coverage.period_code.join(', ')})`);
+        }
+        if (parts.length > 0) {
+          this.temporalCoverages.push(parts.join(' '));
+        }
+      });
     }
   }
 
@@ -276,6 +368,9 @@ export class DocumentDescriptionComponent implements OnInit {
             });
           });
         }
+        if (workAccess.form_subdivision) {
+          agentFormatted += workAccess.form_subdivision.join('. ') + '. ';
+        }
         if (workAccess.miscellaneous_information) {
           agentFormatted += workAccess.miscellaneous_information + '. ';
         }
@@ -297,6 +392,16 @@ export class DocumentDescriptionComponent implements OnInit {
         this.workAccessPoint.push(agentFormatted.trim());
       });
     }
+  }
+
+  /**
+   * Strip the leading '+' of a temporal coverage date.
+   * The '-' sign of BCE dates is kept.
+   * @param date - the raw date, i.e. '+1945-05-08'
+   * @returns the date without its leading '+'
+   */
+  private _formatTemporalDate(date: string): string {
+    return date.startsWith('+') ? date.slice(1) : date;
   }
 
   /**


### PR DESCRIPTION
Several catalogued fields were indexed and searchable but rendered nowhere, forcing librarians into the editor or the MARC tab to read them.

* Add publication notes (in the description tab), temporal coverage and cataloguing metadata.
* Complete the classification, scale, language and cartographic zones, whose subfields were silently dropped.
* Restrict cataloguing metadata to the professional interface.
* Closes rero/rero-ils#4189.