### PR TITLE
feat(acquisition): add sortable order lines list

### DIFF
--- a/.ng-core-ref
+++ b/.ng-core-ref
@@ -2,4 +2,4 @@
 #   published                    — use published npm version (default, staging)
 #   feat/my-branch               — branch on rero/ng-core
 #   owner/ng-core@branch-or-sha  — fork + branch or SHA
-staging
+Garfield-fr/ng-core@feat/export-overlay-scroll-fix

--- a/projects/admin/src/app/acquisition/api/acq-order-api.service.spec.ts
+++ b/projects/admin/src/app/acquisition/api/acq-order-api.service.spec.ts
@@ -72,6 +72,8 @@ describe('AcqOrderApiService', () => {
 
   const orderLines = [
     {
+      created: '2025-04-01T00:00:00+00:00',
+      updated: '2025-04-17T00:00:00+00:00',
       metadata: {
         pid: '1',
         status: AcqOrderLineStatus.APPROVED,
@@ -97,6 +99,16 @@ describe('AcqOrderApiService', () => {
       }
     }
   ];
+
+  const orderWithDenormalizedLines = {
+    metadata: {
+      pid: '1',
+      order_lines: [
+        { pid: '1', document: { pid: '1', title: 'Title 1' } },
+        { pid: '2', document: { pid: '2' } },
+      ]
+    }
+  };
 
   const recordServiceSpy = { getRecord: vi.fn(), getRecords: vi.fn(), totalHits: vi.fn() };
   recordServiceSpy.totalHits.mockReturnValue(1);
@@ -157,11 +169,34 @@ describe('AcqOrderApiService', () => {
   it('should return a list of lines in an order', () => {
     apiResponse.hits.hits = orderLines;
     recordServiceSpy.getRecords.mockReturnValue(of(apiResponse));
-    const data = [{...orderLineDefaultData, ...orderLines[0].metadata}];
+    const data = [{
+      ...orderLineDefaultData,
+      ...orderLines[0].metadata,
+      created: orderLines[0].created,
+      updated: orderLines[0].updated
+    }];
     service.getOrderLines('1').subscribe((result: any) => {
         expect(result).toEqual(data);
         expect(result[0].quantity).toEqual(2);
       });
+  });
+
+  it('should return an empty document titles map when the order has no hits', () => {
+    recordServiceSpy.totalHits.mockReturnValueOnce(0);
+    apiResponse.hits.hits = [];
+    recordServiceSpy.getRecords.mockReturnValue(of(apiResponse));
+    service.getOrderLinesDocumentTitles('1').subscribe((result: Map<string, string>) => {
+      expect(result.size).toBe(0);
+    });
+  });
+
+  it('should return a map of document titles keyed by order line pid', () => {
+    apiResponse.hits.hits = [orderWithDenormalizedLines];
+    recordServiceSpy.getRecords.mockReturnValue(of(apiResponse));
+    service.getOrderLinesDocumentTitles('1').subscribe((result: Map<string, string>) => {
+      expect(result.get('1')).toBe('Title 1');
+      expect(result.get('2')).toBe('');
+    });
   });
 
   it('should update lastDeletedOrderLine signal on deleteOrderLine', () => {

--- a/projects/admin/src/app/acquisition/api/acq-order-api.service.ts
+++ b/projects/admin/src/app/acquisition/api/acq-order-api.service.ts
@@ -46,6 +46,29 @@ export class AcqOrderApiService extends BaseApi {
   }
 
   /**
+   * Get the denormalized order lines (pid + document title) as indexed on
+   * the order search index. This data is only available on the ES index
+   * (populated at indexing time), not on the plain record REST endpoint.
+   * @param orderPid: the order pid
+   */
+  getOrderLinesDocumentTitles(orderPid: string): Observable<Map<string, string>> {
+    return this.recordService
+      .getRecords('acq_orders', {
+        query: `pid:${orderPid}`,
+        page: 1,
+        itemsPerPage: 1
+      })
+      .pipe(
+        map((result: EsResult): { pid: string, document?: { title?: string } }[] =>
+          +this.recordService.totalHits(result.hits.total) === 0 ? [] : (result.hits.hits[0] as any).metadata.order_lines ?? []
+        ),
+        map(orderLines =>
+          new Map(orderLines.map(orderLine => [orderLine.pid, orderLine.document?.title ?? '']))
+        )
+      );
+  }
+
+  /**
    * Get an order preview.
    * @param orderPid: the order pid
    */
@@ -92,7 +115,12 @@ export class AcqOrderApiService extends BaseApi {
       })
       .pipe(
         map((result: EsResult) => +this.recordService.totalHits(result.hits.total) === 0 ? [] : result.hits.hits),
-        map((hits: any[]) => hits.map(hit => ({...orderLineDefaultData, ...hit.metadata})))
+        map((hits: any[]) => hits.map(hit => ({
+          ...orderLineDefaultData,
+          ...hit.metadata,
+          created: hit.created,
+          updated: hit.updated
+        })))
       );
   }
 

--- a/projects/admin/src/app/acquisition/classes/common.ts
+++ b/projects/admin/src/app/acquisition/classes/common.ts
@@ -8,6 +8,8 @@
 export type IAcqBaseResource = {
   $schema?: string;
   pid?: string;
+  created?: string;
+  updated?: string;
   organisation: IObjectReference;
   library?: IObjectReference;
 }

--- a/projects/admin/src/app/acquisition/classes/order.ts
+++ b/projects/admin/src/app/acquisition/classes/order.ts
@@ -77,6 +77,7 @@ export type IAcqOrderLine = {
     title: string,
     identifiers: string[],
   };
+  documentTitle?: string;
 } & IAcqBaseResource & IAcqResourceWithNotes
 
 /** Default values */

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.html
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.html
@@ -77,6 +77,29 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                   </ng-template>
                 </p-accordion-header>
                 <p-accordion-content>
+                  <div class="ui:flex ui:justify-end ui:mb-2">
+                    <p-select
+                      appendTo="body"
+                      [options]="sortingCriteria()"
+                      optionValue="value"
+                      [ngModel]="store.linesSortCriteria()"
+                      (onChange)="store.setSortCriteria($event.value)"
+                      (onShow)="onSortSelectShow()"
+                    >
+                      <ng-template #selectedItem let-item>
+                        <div class="ui:flex ui:items-center ui:gap-2">
+                          <i [class]="item.icon"></i>
+                          <div>{{ item.label }}</div>
+                        </div>
+                      </ng-template>
+                      <ng-template #item let-item>
+                        <div class="ui:flex ui:items-center ui:gap-2">
+                          <i [class]="item.icon"></i>
+                          <div>{{ item.label }}</div>
+                        </div>
+                      </ng-template>
+                    </p-select>
+                  </div>
                   <admin-order-lines />
                 </p-accordion-content>
               </p-accordion-panel>

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-detail-view.component.ts
@@ -2,11 +2,12 @@
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { I18nPluralPipe, NgClass, ViewportScroller } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, input } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { extractIdOnRef, Nl2brPipe } from '@rero/ng-core';
+import { extractIdOnRef, fixOverlayTouchScroll, Nl2brPipe } from '@rero/ng-core';
 
 import { AcqOrderStatus, IAcqOrder } from '@app/admin/acquisition/classes/order';
 import { NotesComponent } from '@app/admin/acquisition/components/notes/notes.component';
@@ -22,18 +23,25 @@ import { Button } from 'primeng/button';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { Message } from 'primeng/message';
 import { Ripple } from 'primeng/ripple';
+import { SelectModule } from 'primeng/select';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from 'primeng/tabs';
 import { Tag } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
-import { map } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { OrderHistoryComponent } from './order-history/order-history.component';
 import { OrderLinesComponent } from './order-lines/order-lines.component';
 import { OrderDetailStore } from './store/order-detail.store';
 
+type SortOption = {
+  value: string;
+  label: string;
+  icon: string;
+};
+
 @Component({
     selector: 'admin-acquisition-order-detail-view',
     templateUrl: './order-detail-view.component.html',
-    imports: [NgClass, Bind, Button, OrderSummaryComponent, TranslateDirective, Tag, Tabs, TabList, Ripple, Tab, TabPanels, TabPanel, Accordion, AccordionPanel, AccordionHeader, RouterLink, AccordionContent, OrderLinesComponent, OrderHistoryComponent, NotesComponent, ReceiptListComponent, I18nPluralPipe, Nl2brPipe, TranslatePipe, NoteBadgeColorPipe, TooltipModule, Message, Badge, SharedModule],
+    imports: [NgClass, Bind, Button, OrderSummaryComponent, TranslateDirective, Tag, Tabs, TabList, Ripple, Tab, TabPanels, TabPanel, Accordion, AccordionPanel, AccordionHeader, RouterLink, AccordionContent, OrderLinesComponent, OrderHistoryComponent, NotesComponent, ReceiptListComponent, I18nPluralPipe, Nl2brPipe, TranslatePipe, NoteBadgeColorPipe, TooltipModule, Message, Badge, SharedModule, SelectModule, FormsModule],
     providers: [OrderDetailStore],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -60,6 +68,30 @@ export class OrderDetailViewComponent {
     { initialValue: 'order' }
   );
 
+  private readonly currentLanguage = toSignal(
+    this.translateService.onLangChange.pipe(
+      map(() => this.translateService.getCurrentLang()),
+      startWith(this.translateService.getCurrentLang())
+    ),
+    { initialValue: this.translateService.getCurrentLang() }
+  );
+
+  readonly sortingCriteria = computed<SortOption[]>(() => {
+    this.currentLanguage();
+    return [
+      { value: 'documenttitle', label: this.translateService.instant('Title'), icon: 'fa-solid fa-arrow-down-a-z' },
+      { value: '-documenttitle', label: this.translateService.instant('Title (desc)'), icon: 'fa-solid fa-arrow-down-z-a' },
+      { value: 'priority', label: this.translateService.instant('Priority'), icon: 'fa-solid fa-arrow-down-1-9' },
+      { value: '-priority', label: this.translateService.instant('Priority (desc)'), icon: 'fa-solid fa-arrow-down-9-1' },
+      { value: 'status', label: this.translateService.instant('Status'), icon: 'fa-solid fa-arrow-down-a-z' },
+      { value: '-status', label: this.translateService.instant('Status (desc)'), icon: 'fa-solid fa-arrow-down-z-a' },
+      { value: 'created', label: this.translateService.instant('Created'), icon: 'fa-solid fa-arrow-down-1-9' },
+      { value: '-created', label: this.translateService.instant('Created (desc)'), icon: 'fa-solid fa-arrow-down-9-1' },
+      { value: 'updated', label: this.translateService.instant('Updated'), icon: 'fa-solid fa-arrow-down-1-9' },
+      { value: '-updated', label: this.translateService.instant('Updated (desc)'), icon: 'fa-solid fa-arrow-down-9-1' },
+    ];
+  });
+
   constructor() {
     effect(() => this.store.setFromRecord(this.record()));
   }
@@ -78,6 +110,10 @@ export class OrderDetailViewComponent {
   scrollTo(e: Event, anchorId: string): void {
     e.preventDefault();
     this.scroller.scrollToAnchor(anchorId);
+  }
+
+  onSortSelectShow(): void {
+    fixOverlayTouchScroll('.p-select-overlay');
   }
 
   placeOrderDialog(): void {

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/order-lines/order-lines.component.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/order-lines/order-lines.component.ts
@@ -16,5 +16,5 @@ export class OrderLinesComponent {
 
   protected readonly store = inject(OrderDetailStore);
   protected readonly order = this.store.order;
-  protected readonly orderLines = this.store.orderLines;
+  protected readonly orderLines = this.store.sortedOrderLines;
 }

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
@@ -52,6 +52,24 @@ describe('OrderDetailStore', () => {
     notes: [],
   };
 
+  const mockOrderLineA: IAcqOrderLine = {
+    ...mockOrderLine,
+    pid: 'lineA',
+    status: AcqOrderLineStatus.ORDERED,
+    priority: 3,
+    created: '2025-01-02T00:00:00+00:00',
+    updated: '2025-02-02T00:00:00+00:00',
+  };
+
+  const mockOrderLineB: IAcqOrderLine = {
+    ...mockOrderLine,
+    pid: 'lineB',
+    status: AcqOrderLineStatus.APPROVED,
+    priority: 1,
+    created: '2025-01-01T00:00:00+00:00',
+    updated: '2025-02-03T00:00:00+00:00',
+  };
+
   const mockReceipt: IAcqReceipt = {
     pid: 'receipt1',
     acq_order: { pid: '1' },
@@ -74,6 +92,7 @@ describe('OrderDetailStore', () => {
   const acqOrderServiceSpy = {
     getOrder: vi.fn(),
     getOrderLines: vi.fn(),
+    getOrderLinesDocumentTitles: vi.fn(),
     getOrderHistory: vi.fn(),
     lastDeletedOrderLine,
   };
@@ -98,6 +117,7 @@ describe('OrderDetailStore', () => {
     lastDeletedReceipt.set(null);
     acqOrderServiceSpy.getOrder.mockReturnValue(of(mockOrder));
     acqOrderServiceSpy.getOrderLines.mockReturnValue(of([mockOrderLine]));
+    acqOrderServiceSpy.getOrderLinesDocumentTitles.mockReturnValue(of(new Map()));
     acqOrderServiceSpy.getOrderHistory.mockReturnValue(of([]));
     acqReceiptServiceSpy.getReceiptsForOrder.mockReturnValue(of([mockReceipt]));
     recordPermissionServiceSpy.getPermission.mockReturnValue(of({ ...mockPermissions }));
@@ -322,6 +342,118 @@ describe('OrderDetailStore', () => {
       acqOrderServiceSpy.getOrderLines.mockReturnValue(throwError(() => new Error('fail')));
       store['loadOrderLines']('1');
       expect(store.orderLines()).toEqual([]);
+    });
+
+    it('should still populate orderLines when getOrderLinesDocumentTitles fails', () => {
+      const store = setupStore();
+      acqOrderServiceSpy.getOrderLinesDocumentTitles.mockReturnValue(throwError(() => new Error('fail')));
+      store['loadOrderLines']('1');
+      expect(store.orderLines()).toEqual([{ ...mockOrderLine, documentTitle: undefined }]);
+    });
+
+    it('should merge document titles returned by getOrderLinesDocumentTitles', () => {
+      const store = setupStore();
+      acqOrderServiceSpy.getOrderLines.mockReturnValue(of([mockOrderLineA, mockOrderLineB]));
+      acqOrderServiceSpy.getOrderLinesDocumentTitles.mockReturnValue(
+        of(new Map([['lineA', 'Title A']]))
+      );
+      store['loadOrderLines']('1');
+      expect(store.orderLines().find(l => l.pid === 'lineA')?.documentTitle).toBe('Title A');
+      expect(store.orderLines().find(l => l.pid === 'lineB')?.documentTitle).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setSortCriteria
+  // ---------------------------------------------------------------------------
+  describe('setSortCriteria', () => {
+    it('should update the linesSortCriteria state', () => {
+      const store = setupStore();
+      expect(store.linesSortCriteria()).toBe('priority');
+      store.setSortCriteria('-priority');
+      expect(store.linesSortCriteria()).toBe('-priority');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Computed: sortedOrderLines
+  // ---------------------------------------------------------------------------
+  describe('sortedOrderLines', () => {
+    const setupSortedStore = () => {
+      const store = setupStore();
+      acqOrderServiceSpy.getOrderLines.mockReturnValue(of([mockOrderLineA, mockOrderLineB]));
+      acqOrderServiceSpy.getOrderLinesDocumentTitles.mockReturnValue(
+        of(new Map([['lineA', 'Zebra'], ['lineB', 'Alpha']]))
+      );
+      store['loadOrderLines']('1');
+      return store;
+    };
+
+    it('should sort by priority ascending by default', () => {
+      const store = setupSortedStore();
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+    });
+
+    it('should sort by priority descending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('-priority');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+    });
+
+    it('should sort by document title ascending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('documenttitle');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+    });
+
+    it('should sort by document title descending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('-documenttitle');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+    });
+
+    it('should sort by status ascending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('status');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+    });
+
+    it('should sort by status descending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('-status');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+    });
+
+    it('should sort by created ascending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('created');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+    });
+
+    it('should sort by created descending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('-created');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+    });
+
+    it('should sort by updated ascending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('updated');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+    });
+
+    it('should sort by updated descending', () => {
+      const store = setupSortedStore();
+      store.setSortCriteria('-updated');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+    });
+
+    it('should not mutate the original orderLines array', () => {
+      const store = setupSortedStore();
+      const before = store.orderLines().map(line => line.pid);
+      store.setSortCriteria('-priority');
+      store.sortedOrderLines();
+      expect(store.orderLines().map(line => line.pid)).toEqual(before);
     });
   });
 

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
@@ -5,7 +5,7 @@ import { computed, effect, inject, untracked } from '@angular/core';
 import { patchState, signalStore, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { AppStore, RecordPermissions } from '@rero/shared';
-import { EMPTY, pipe } from 'rxjs';
+import { EMPTY, forkJoin, of, pipe } from 'rxjs';
 import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { AcqOrderApiService } from '../../../../api/acq-order-api.service';
 import { AcqReceiptApiService } from '../../../../api/acq-receipt-api.service';
@@ -23,6 +23,7 @@ export type OrderDetailState = {
   order: IAcqOrder | undefined;
   orderPermissions: RecordPermissions | undefined;
   orderLines: IAcqOrderLine[];
+  linesSortCriteria: string;
   receipts: IAcqReceipt[];
   receiptPermissions: RecordPermissions | undefined;
   historyVersions: AcqOrderHistoryVersion[];
@@ -33,6 +34,7 @@ export const OrderDetailStore = signalStore(
     order: undefined,
     orderPermissions: undefined,
     orderLines: [],
+    linesSortCriteria: 'priority',
     receipts: [],
     receiptPermissions: undefined,
     historyVersions: [],
@@ -48,6 +50,26 @@ export const OrderDetailStore = signalStore(
       [AcqOrderStatus.PENDING, AcqOrderStatus.CANCELLED].some(s => s === store.order()?.status),
     canAddReceipt: () =>
       [AcqOrderStatus.ORDERED, AcqOrderStatus.PARTIALLY_RECEIVED].some(s => s === store.order()?.status),
+    sortedOrderLines: (): IAcqOrderLine[] => {
+      const linesSortCriteria = store.linesSortCriteria();
+      const desc = linesSortCriteria.startsWith('-');
+      const field = desc ? linesSortCriteria.slice(1) : linesSortCriteria;
+      const direction = desc ? -1 : 1;
+      return [...store.orderLines()].sort((a, b) => {
+        switch (field) {
+          case 'documenttitle':
+            return direction * (a.documentTitle ?? '').localeCompare(b.documentTitle ?? '');
+          case 'status':
+            return direction * a.status.localeCompare(b.status);
+          case 'created':
+            return direction * (a.created ?? '').localeCompare(b.created ?? '');
+          case 'updated':
+            return direction * (a.updated ?? '').localeCompare(b.updated ?? '');
+          default:
+            return direction * (a.priority - b.priority);
+        }
+      });
+    },
   })),
   withMethods((store,
     acqOrderService = inject(AcqOrderApiService),
@@ -63,6 +85,10 @@ export const OrderDetailStore = signalStore(
 
     updateOrder(order: IAcqOrder): void {
       patchState(store, { order });
+    },
+
+    setSortCriteria(linesSortCriteria: string): void {
+      patchState(store, { linesSortCriteria });
     },
 
     orderCreateInfoMessage(): string {
@@ -90,7 +116,16 @@ export const OrderDetailStore = signalStore(
       pipe(
         filter(Boolean),
         switchMap(pid =>
-          acqOrderService.getOrderLines(pid).pipe(
+          forkJoin([
+            acqOrderService.getOrderLines(pid),
+            acqOrderService.getOrderLinesDocumentTitles(pid).pipe(catchError(() => of(new Map<string, string>()))),
+          ]).pipe(
+            map(([orderLines, documentTitles]) =>
+              orderLines.map(orderLine => ({
+                ...orderLine,
+                documentTitle: documentTitles.get(orderLine.pid ?? ''),
+              }))
+            ),
             tap(orderLines => patchState(store, { orderLines })),
             catchError(() => EMPTY)
           )


### PR DESCRIPTION
Add a sort select above the order lines list (title, priority, status, created, updated - asc/desc), computed entirely client-side since all order lines are already loaded in the store.

* Closes rero/rero-ils#4191.

Test with [feat(formly): export overlay touch-scroll iOS fix- #855](https://github.com/rero/ng-core/pull/855)