### PR TITLE
fix(pwd-edit): refresh password validation error

### DIFF
--- a/projects/public-search/src/app/patron-profile/patron-profile-password/patron-profile-password.component.spec.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-password/patron-profile-password.component.spec.ts
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Location } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { HttpPendingService } from '@rero/ng-core';
+import { MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+import { afterEach } from 'vitest';
+import { UserApiService } from '../../api/user-api.service';
+import {
+  fieldPasswordMatchValidator,
+  PatronProfilePasswordComponent
+} from './patron-profile-password.component';
+
+describe('PatronProfilePasswordComponent', () => {
+  let component: PatronProfilePasswordComponent;
+  let fixture: ComponentFixture<PatronProfilePasswordComponent>;
+
+  const locationSpy = { back: vi.fn() };
+  const messageServiceSpy = { add: vi.fn() };
+  const translateServiceSpy = { instant: vi.fn() };
+  const httpPendingServiceSpy = { isPending: vi.fn() };
+  const userApiServiceSpy = {
+    updatePassword: vi.fn(),
+    validatePassword: vi.fn()
+  };
+
+  beforeEach(async () => {
+    translateServiceSpy.instant.mockImplementation((message: string) => message);
+    httpPendingServiceSpy.isPending.mockReturnValue(false);
+    userApiServiceSpy.validatePassword.mockReturnValue(of({}));
+
+    await TestBed.configureTestingModule({
+      imports: [PatronProfilePasswordComponent],
+      providers: [
+        { provide: Location, useValue: locationSpy },
+        { provide: MessageService, useValue: messageServiceSpy },
+        { provide: TranslateService, useValue: translateServiceSpy },
+        { provide: HttpPendingService, useValue: httpPendingServiceSpy },
+        { provide: UserApiService, useValue: userApiServiceSpy }
+      ]
+    })
+      .overrideComponent(PatronProfilePasswordComponent, {
+        set: {
+          imports: [ReactiveFormsModule],
+          template: `
+            <form [formGroup]="form">
+              <input id="password" formControlName="password">
+              <input id="newPassword" formControlName="newPassword">
+              <input id="confirmPassword" formControlName="confirmPassword">
+              <button id="save" [disabled]="!form.valid || httpPending.isPending()">Save</button>
+            </form>
+          `
+        }
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(PatronProfilePasswordComponent);
+    component = fixture.componentInstance;
+    component.form = new UntypedFormGroup({
+      password: new UntypedFormControl('', Validators.required),
+      newPassword: new UntypedFormControl('', [Validators.required, Validators.minLength(8)]),
+      confirmPassword: new UntypedFormControl('', [Validators.required, Validators.minLength(8)])
+    }, fieldPasswordMatchValidator);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => vi.resetAllMocks());
+
+  function setPasswords(password: string, newPassword: string, confirmPassword: string): void {
+    component.model = { password, newPassword, confirmPassword };
+    component.form.setValue({ password, newPassword, confirmPassword });
+    fixture.detectChanges();
+  }
+
+  function returnPasswordError(message: string): void {
+    userApiServiceSpy.updatePassword.mockReturnValue(throwError(() => ({
+      message: 'Validation error.',
+      error: { errors: [{ field: 'password', message }] }
+    })));
+  }
+
+  function editPasswordField(field: string, value: string): void {
+    const input = fixture.nativeElement.querySelector(`#${field}`) as HTMLInputElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+  }
+
+  it('should attach a same-password error to the new password field', () => {
+    setPasswords('Current123', 'Current123', 'Current123');
+    returnPasswordError('Password is the same.');
+    const focusSpy = vi.spyOn(
+      fixture.nativeElement.querySelector('#newPassword') as HTMLInputElement,
+      'focus'
+    );
+
+    component.submit();
+
+    expect(component.form.get('password').errors).toBeNull();
+    expect(component.form.get('newPassword').errors?.invalid).toEqual({
+      message: 'Password is the same.'
+    });
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['newPassword', 'confirmPassword'],
+    ['confirmPassword', 'newPassword']
+  ])('should clear the same-password error when %s changes', (field, matchingField) => {
+    setPasswords('Current123', 'Current123', 'Current123');
+    returnPasswordError('Password is the same.');
+    component.submit();
+
+    editPasswordField(field, 'Different123');
+    editPasswordField(matchingField, 'Different123');
+    fixture.detectChanges();
+
+    expect(component.form.get('newPassword').errors?.invalid).toBeUndefined();
+    expect(component.form.get('password').value).toBe('Current123');
+    expect(component.form.valid).toBe(true);
+    expect((fixture.nativeElement.querySelector('#save') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('should preserve other errors when clearing the same-password error', () => {
+    setPasswords('Current123', 'Current123', 'Current123');
+    returnPasswordError('Password is the same.');
+    component.submit();
+    const newPasswordControl = component.form.get('newPassword');
+    newPasswordControl.setErrors({
+      ...newPasswordControl.errors,
+      required: true,
+      minlength: { requiredLength: 8, actualLength: 0 },
+      validatePassword: true
+    });
+
+    component.form.get('confirmPassword').setValue('Different123');
+
+    expect(newPasswordControl.errors?.invalid).toBeUndefined();
+    expect(newPasswordControl.errors?.required).toBe(true);
+    expect(newPasswordControl.errors?.minlength).toEqual({ requiredLength: 8, actualLength: 0 });
+    expect(newPasswordControl.errors?.validatePassword).toBe(true);
+    expect(component.form.errors?.fieldMatch).toBeDefined();
+  });
+
+  it('should keep an incorrect-current-password error on the current password field', () => {
+    setPasswords('Current123', 'Different123', 'Different123');
+    returnPasswordError('Invalid password.');
+
+    component.submit();
+    component.form.get('confirmPassword').setValue('Another123');
+
+    expect(component.form.get('password').errors?.invalid).toEqual({
+      message: 'Invalid password.'
+    });
+    expect(component.form.get('newPassword').errors).toBeNull();
+  });
+
+  it.each([
+    ['missing error details', { message: 'Validation error.', error: {} }],
+    ['an unmapped field', {
+      message: 'Validation error.',
+      error: { errors: [{ field: 'unknown', message: 'Unexpected error.' }] }
+    }]
+  ])('should show a generic form error for %s', (_scenario, errorResponse) => {
+    setPasswords('Current123', 'Different123', 'Different123');
+    userApiServiceSpy.updatePassword.mockReturnValue(throwError(() => errorResponse));
+
+    component.submit();
+
+    expect(messageServiceSpy.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'The form contains errors.',
+      closable: true
+    });
+  });
+});

--- a/projects/public-search/src/app/patron-profile/patron-profile-password/patron-profile-password.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-password/patron-profile-password.component.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { Location } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AbstractControl, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { LoadingBarModule } from '@ngx-loading-bar/core';
@@ -9,8 +10,8 @@ import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { CONFIG, HttpPendingService } from '@rero/ng-core';
 import { MessageService } from 'primeng/api';
 import { Button } from 'primeng/button';
-import { of } from 'rxjs';
-import { catchError, debounceTime, map } from 'rxjs/operators';
+import { merge, of } from 'rxjs';
+import { catchError, debounceTime, map, take } from 'rxjs/operators';
 import { UserApiService } from '../../api/user-api.service';
 
 export function fieldPasswordMatchValidator(control: AbstractControl) {
@@ -41,6 +42,7 @@ export class PatronProfilePasswordComponent {
   private userApiService: UserApiService = inject(UserApiService);
   private el: ElementRef = inject(ElementRef);
   private messageService: MessageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
   readonly httpPending = inject(HttpPendingService);
 
   /** Request referer */
@@ -102,7 +104,7 @@ export class PatronProfilePasswordComponent {
   }];
 
   /** Matching fields between invenio and Angular */
-  private fieldsMatching = {
+  private fieldsMatching: Record<PasswordApiField, PasswordFormField> = {
     password: 'password',
     new_password: 'newPassword',
     new_password_confirm: 'confirmPassword'
@@ -116,12 +118,7 @@ export class PatronProfilePasswordComponent {
     if (this.httpPending.isPending()) { return; }
     this.form.updateValueAndValidity();
     if (this.form.valid === false) {
-      this.messageService.add({
-        severity: 'error',
-        summary: this.translateService.instant('Error'),
-        detail: this.translateService.instant('The form contains errors.'),
-        closable: true
-      });
+      this.showFormError();
       return;
     }
 
@@ -132,7 +129,7 @@ export class PatronProfilePasswordComponent {
     };
 
     this.userApiService.updatePassword(data).pipe(
-      catchError((err: any) =>  of({ success: false, message: err.message, error: err.error?.errors[0] }))
+      catchError((err: any) =>  of({ success: false, message: err.message, error: err.error?.errors?.at(0) }))
     ).subscribe((response: IPasswordResponse) => {
       if (!('success' in response)) {
         this.messageService.add({
@@ -144,9 +141,30 @@ export class PatronProfilePasswordComponent {
         // Close password form and show personal data
         this._redirect();
       } else {
-        // Set error on field
-        const formField = this.fieldsMatching[response.error.field];
-        this.form.get(formField).setErrors({ invalid: { message: response.error.message } });
+        if (!response.error) {
+          this.showFormError();
+          return;
+        }
+
+        // Same-password errors are reported on `password` by the API, but belong to the new password field.
+        const isSamePasswordError = response.error.field === 'password'
+          && data.password === data.new_password;
+        const formField = isSamePasswordError
+          ? 'newPassword'
+          : this.fieldsMatching[response.error.field];
+        const formControl = this.form.get(formField);
+        if (!formControl) {
+          this.showFormError();
+          return;
+        }
+
+        formControl.setErrors({
+          ...formControl.errors,
+          invalid: { message: response.error.message }
+        });
+        if (isSamePasswordError) {
+          this.clearSamePasswordErrorOnChange();
+        }
         // Make focus on error field
         this.el.nativeElement.querySelector(`#${formField}`).focus();
       }
@@ -179,14 +197,44 @@ export class PatronProfilePasswordComponent {
     this._redirect();
   }
 
+  /** Display a generic form-level error. */
+  private showFormError(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: this.translateService.instant('Error'),
+      detail: this.translateService.instant('The form contains errors.'),
+      closable: true
+    });
+  }
+
+  /** Remove only the same-password server error when either new password field changes. */
+  private clearSamePasswordErrorOnChange(): void {
+    const newPasswordControl = this.form.get('newPassword');
+    const confirmPasswordControl = this.form.get('confirmPassword');
+    if (!newPasswordControl || !confirmPasswordControl) {
+      return;
+    }
+
+    merge(newPasswordControl.valueChanges, confirmPasswordControl.valueChanges)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        const errors = { ...newPasswordControl.errors };
+        delete errors.invalid;
+        newPasswordControl.setErrors(Object.keys(errors).length > 0 ? errors : null);
+      });
+  }
+
   /** Redirect to external project */
   private _redirect(): void {
     this.location.back();
   }
 }
 
+type PasswordApiField = 'password' | 'new_password' | 'new_password_confirm';
+type PasswordFormField = 'password' | 'newPassword' | 'confirmPassword';
+
 type IPasswordResponse = {
   success?: boolean;
   message: string;
-  error?: { field: string, message: string };
+  error?: { field: PasswordApiField, message: string };
 }


### PR DESCRIPTION
* Displays same-password rejections on the new password field instead of current password.
* Clears the stale error when either new-password field is edited.
* Preserves all other form validation errors.
* Closes rero/rero-ils#2773