### PR TITLE
fix: refresh values derived from a rebound input

### DIFF
--- a/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/document-detail-view.component.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Component, computed, inject, input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, input, linkedSignal, ChangeDetectionStrategy } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
@@ -18,6 +18,7 @@ import { Tabs, TabList, Tab, TabPanels, TabPanel } from 'primeng/tabs';
 import { Ripple } from 'primeng/ripple';
 import { HoldingsComponent } from './holdings/holdings.component';
 import { EntitiesRelatedComponent } from './entities-related/entities-related.component';
+import { RawRelatedEntity } from './entities-related/entities-related.interface';
 import { LocalFieldComponent } from '../local-field/local-field.component';
 import { UploadFilesComponent } from './files-collections/upload-files/upload-files.component';
 import { TableModule } from 'primeng/table';
@@ -70,12 +71,22 @@ export class DocumentDetailViewComponent {
     if (!metadata) return false;
     return Entity.FIELDS_WITH_REF.some((field: string) =>
       field in metadata &&
-      (metadata[field] as any[]).some((e: any) => e.entity?.resource_type)
+      (metadata[field] as RawRelatedEntity[]).some((related: RawRelatedEntity) => related.entity.resource_type)
     );
   });
 
-  /** Whether the current (harvested) document has local fields; fed by the local-field component output. */
-  readonly hasLocalFields = signal(false);
+  /**
+   * Whether the current (harvested) document has local fields; fed by the local-field
+   * component output. As this view is reused, and not recreated, when navigating to a
+   * linked document, it is reset on each document pid: the local-field component refetches
+   * on its own — its `resourcePid` input changed — and the tab of the previous document
+   * must not stay visible until it emits again.
+   */
+  readonly hasLocalFields = linkedSignal({
+    source: () => this.record()?.metadata?.pid,
+    // Back to false on each new pid, until the local-field component sets it again
+    computation: (): boolean => false
+  });
 
   readonly activateLink = computed(() =>
     !this.activatedRouter.snapshot.params.type?.startsWith('import_')

--- a/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.html
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Fondation RERO+
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <div class="ui:py-2">
-  @for (field of entities | keyvalue; track $index) {
+  @for (field of entities() | keyvalue; track $index) {
     <dl class="metadata ui:odd:bg-surface-50">
       <dt>{{ field.key | translate |ucfirst }}</dt>
       <dd>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.spec.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { EntitiesRelatedComponent } from './entities-related.component';
+
+describe('EntitiesRelatedComponent', () => {
+  let component: EntitiesRelatedComponent;
+  let fixture: ComponentFixture<EntitiesRelatedComponent>;
+
+  /**
+   * Create the component for the given document metadata.
+   * The template is deliberately not rendered: these tests target the metadata processing only.
+   * @param metadata - the document metadata exposed through the `record` input
+   */
+  function withMetadata(metadata: object): void {
+    fixture.componentRef.setInput('record', { metadata });
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), EntitiesRelatedComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
+    TestBed.inject(TranslateService).use('fr');
+    fixture = TestBed.createComponent(EntitiesRelatedComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should stay empty without any record', () => {
+    expect(component.entities()).toEqual({});
+  });
+
+  it('should group the entities by field', () => {
+    withMetadata({
+      contribution: [
+        { entity: { pid: '1', resource_type: 'remote', type: 'bf:Person', authorized_access_point_fr: 'Rousseau' } }
+      ],
+      genreForm: [
+        { entity: { pid: '2', resource_type: 'local', type: 'bf:Topic', authorized_access_point_fr: 'Photographies' } }
+      ]
+    });
+    expect(component.entities()).toEqual({
+      contribution: [{
+        authorized_access_point: 'Rousseau',
+        pid: '1',
+        resource_type: 'remote',
+        type: 'bf:Person',
+        icon: 'fa-regular fa-user'
+      }],
+      genreForm: [{
+        authorized_access_point: 'Photographies',
+        pid: '2',
+        resource_type: 'local',
+        type: 'bf:Topic',
+        icon: 'fa-solid fa-tag'
+      }]
+    });
+  });
+
+  it('should discard the entities without resource type', () => {
+    withMetadata({
+      contribution: [
+        { entity: { authorized_access_point_fr: 'Local contributor' } },
+        { entity: { pid: '1', resource_type: 'remote', type: 'bf:Person', authorized_access_point_fr: 'Rousseau' } }
+      ]
+    });
+    expect(component.entities().contribution).toHaveLength(1);
+  });
+
+  it('should ignore the fields holding no entity', () => {
+    withMetadata({ contribution: [], subjects: [{ entity: { pid: '1', resource_type: 'remote', type: 'bf:Work' } }] });
+    expect(Object.keys(component.entities())).toEqual(['subjects']);
+  });
+
+  /**
+   * The detail view rebinds the `record` input instead of recreating this component
+   * when navigating to a linked document: the list must be rebuilt from scratch,
+   * without accumulating the entities of the previous document.
+   */
+  it('should replace the entities of the previous document', () => {
+    withMetadata({
+      contribution: [
+        { entity: { pid: '1', resource_type: 'remote', type: 'bf:Person', authorized_access_point_fr: 'Rousseau' } }
+      ]
+    });
+    expect(component.entities().contribution).toHaveLength(1);
+
+    withMetadata({
+      subjects: [
+        { entity: { pid: '2', resource_type: 'remote', type: 'bf:Place', authorized_access_point_fr: 'Genève' } }
+      ]
+    });
+    expect(component.entities().contribution).toBeUndefined();
+    expect(component.entities().subjects).toHaveLength(1);
+  });
+});

--- a/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.component.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Component, inject, input, OnInit, ChangeDetectionStrategy} from '@angular/core';
+import { Component, computed, inject, input, Signal, ChangeDetectionStrategy} from '@angular/core';
 import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { Entity } from '@rero/shared';
-import { IEntityRelated } from './entities-related.interface';
+import { IEntityRelated, RawRelatedEntity } from './entities-related.interface';
 import { RouterLink } from '@angular/router';
 import { KeyValuePipe } from '@angular/common';
 import { UpperCaseFirstPipe } from '@rero/ng-core';
@@ -14,37 +14,38 @@ import { UpperCaseFirstPipe } from '@rero/ng-core';
     imports: [RouterLink, TranslateDirective, KeyValuePipe, UpperCaseFirstPipe, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntitiesRelatedComponent implements OnInit {
+export class EntitiesRelatedComponent {
 
   private translateService: TranslateService = inject(TranslateService);
 
   /** Record metadata */
   record = input<any>();
 
-  /** Entities processed */
-  entities: Record<string, IEntityRelated[]> = {};
-
-  /** OnInit hook */
-  ngOnInit(): void {
+  /**
+   * Entities processed.
+   * Derived from the `record` input, so that navigating to a linked document —
+   * which only rebinds the input, without recreating this component — refreshes the list.
+   */
+  readonly entities: Signal<Record<string, IEntityRelated[]>> = computed(() => {
     const language = this.translateService.getCurrentLang();
-    const { metadata } = this.record();
+    const metadata = this.record()?.metadata ?? {};
+    const entities: Record<string, IEntityRelated[]> = {};
     Entity.FIELDS_WITH_REF.forEach((field: string) => {
       if (field in metadata && metadata[field].length > 0) {
-        metadata[field].forEach((entity: any) => {
-          if (entity.entity.resource_type) {
-            if (!Object.keys(this.entities).includes(field)) {
-              this.entities[field] = [];
-            }
-            this.entities[field].push({
-              authorized_access_point: entity.entity[`authorized_access_point_${language}`],
-              pid: entity.entity.pid,
-              resource_type: entity.entity.resource_type,
-              type: entity.entity.type,
-              icon: Entity.getIcon(entity.entity.type)
+        metadata[field].forEach(({ entity }: RawRelatedEntity) => {
+          if (entity.resource_type) {
+            entities[field] ??= [];
+            entities[field].push({
+              authorized_access_point: entity[`authorized_access_point_${language}`],
+              pid: entity.pid,
+              resource_type: entity.resource_type,
+              type: entity.type,
+              icon: Entity.getIcon(entity.type)
             });
           }
         });
       }
     });
-  }
+    return entities;
+  });
 }

--- a/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.interface.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/entities-related/entities-related.interface.ts
@@ -7,3 +7,19 @@ export type IEntityRelated = {
   type: string;
   icon: string;
 }
+
+/**
+ * An entity of a document field, as described by the fields holding a `$ref`.
+ * Every entry of these fields carries an entity, be it linked or textual, and every
+ * entity carries a type. Only a linked one is resolved into a pid and a resource type.
+ */
+export type RawRelatedEntity = {
+  entity: {
+    type: string;
+    pid?: string;
+    resource_type?: string;
+  } & Partial<
+    /** Access point of a given language, i.e. `authorized_access_point_fre` */
+    Record<`authorized_access_point_${string}`, string>
+  >;
+};

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.html
@@ -15,6 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       [fluid]="true"
       [maxSelectedLabels]="2"
       [placeholder]="'Filter by library'|translate"
+      [ngModel]="store.filteredLibrary()"
       (onChange)="store.setLibraryFilter($event)"
     />
   </div>

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/holdings.component.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { Component, effect, inject, input, ChangeDetectionStrategy} from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { EsRecord } from '@rero/shared';
 import { HoldingsStore } from './store/holdings-store';
 import { MenuActionsComponent } from './menu-actions/menu-actions.component';
@@ -17,7 +18,7 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
     templateUrl: './holdings.component.html',
     styles: `.p-accordionheader { user-select: text !important; }`,
     providers: [HoldingsStore],
-    imports: [MenuActionsComponent, Bind, MultiSelect, Accordion, AccordionPanel, Ripple, AccordionHeader, HoldingHeaderComponent, AccordionContent, HoldingContentComponent, TranslateDirective, TranslatePipe],
+    imports: [MenuActionsComponent, Bind, FormsModule, MultiSelect, Accordion, AccordionPanel, Ripple, AccordionHeader, HoldingHeaderComponent, AccordionContent, HoldingContentComponent, TranslateDirective, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class HoldingsComponent {

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.spec.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.spec.ts
@@ -55,18 +55,49 @@ describe('Holdings Store', () => {
     const store = TestBed.inject(HoldingsStore);
     store.setDocument(document);
     await vi.advanceTimersByTimeAsync(500);
-    store.setLibraryFilter({ originalEvent: new Event(''), value: ["1"] });
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: ["1"] });
     expect(store.holdingsCurrentOrganisation()).toHaveLength(9);
     expect(store.holdingsOtherOrganisation()).toHaveLength(0);
-    store.setLibraryFilter({ originalEvent: new Event(''), value: ["2"] });
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: ["2"] });
     expect(store.holdingsCurrentOrganisation()).toHaveLength(0);
     expect(store.holdingsOtherOrganisation()).toHaveLength(3);
-    store.setLibraryFilter({ originalEvent: new Event(''), value: ["1", "2"] });
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: ["1", "2"] });
     expect(store.holdingsCurrentOrganisation()).toHaveLength(9);
     expect(store.holdingsOtherOrganisation()).toHaveLength(3);
-    store.setLibraryFilter({ originalEvent: new Event(''), value: [] });
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: [] });
     expect(store.holdingsCurrentOrganisation()).toHaveLength(9);
     expect(store.holdingsOtherOrganisation()).toHaveLength(3);
+  });
+
+  it('should drop the state of the previous document', async () => {
+    const store = TestBed.inject(HoldingsStore);
+    const holdingsApiService = TestBed.inject(HoldingsApiServiceMock);
+    store.setDocument(document);
+    await vi.advanceTimersByTimeAsync(500);
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: ["2"] });
+    expect(store.holdingsCurrentOrganisation()).toHaveLength(0);
+    // Navigating to a linked document only rebinds the inputs of the detail view:
+    // this store is reused, so the previous holdings and filter have to be dropped.
+    store.setDocument({ ...document, metadata: { ...document.metadata, pid: '263' } });
+    expect(store.filteredLibrary()).toEqual([]);
+    expect(store.holdings()).toEqual([]);
+    expect(store.total()).toEqual(0);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(store.holdingsCurrentOrganisation()).toHaveLength(9);
+    expect(holdingsApiService.requestedPids).toEqual(['262', '263']);
+  });
+
+  it('should keep the library filter when the same document is refreshed', async () => {
+    const store = TestBed.inject(HoldingsStore);
+    const holdingsApiService = TestBed.inject(HoldingsApiServiceMock);
+    store.setDocument(document);
+    await vi.advanceTimersByTimeAsync(500);
+    store.setLibraryFilter({ originalEvent: new Event('change'), value: ["1"] });
+    store.setDocument({ ...document });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(store.filteredLibrary()).toEqual(["1"]);
+    expect(store.holdings()).toHaveLength(12);
+    expect(holdingsApiService.requestedPids).toEqual(['262', '262']);
   });
 
   it('should remove a holding record', async () => {
@@ -231,7 +262,12 @@ const document = {
 }
 
 class HoldingsApiServiceMock {
-  getHoldingsByDocumentPid(_documentPid: string): Observable<EsResult | Error> {
+
+  /** Document pid of every request, in call order */
+  readonly requestedPids: string[] = [];
+
+  getHoldingsByDocumentPid(documentPid: string): Observable<EsResult | Error> {
+    this.requestedPids.push(documentPid);
     const holdings = [];
 
     for (let i = 0; i < 12; i++) {

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.ts
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/store/holdings-store.ts
@@ -15,7 +15,7 @@ type HoldingsState = {
   record: EsRecord | undefined;
   holdings: EsRecord[];
   total: number;
-  filteredLibrary: number[];
+  filteredLibrary: string[];
 }
 
 export const initialHoldingsState: HoldingsState = {
@@ -71,8 +71,19 @@ export const HoldingsStore = signalStore(
     })
   })),
   withMethods((store) => ({
+    /**
+     * Set the document whose holdings are displayed.
+     * The store outlives the navigation to another document, as the detail view only
+     * rebinds its inputs: every document related state has to be dropped explicitly,
+     * otherwise the holdings and the library filter of the previous document remain.
+     * @param document - the document to display the holdings of
+     */
     setDocument(document: EsRecord) {
-      patchState(store, { document });
+      const isAnotherDocument = store.document()?.metadata?.pid !== document?.metadata?.pid;
+      patchState(store, isAnotherDocument
+        ? { ...initialHoldingsState, document }
+        : { document }
+      );
     },
     setLibraryFilter(filter: MultiSelectChangeEvent) {
       patchState(store, { filteredLibrary: filter.value });

--- a/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/model/remote-topic-model.ts
+++ b/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/model/remote-topic-model.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-FileCopyrightText: UCLouvain
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** An identifier of a match, as described by the `identifiedBy` field. */
+export type RawIdentifier = {
+  type: string;
+  value: string;
+};
+
+/** An exact or close match of a remote entity, as described by the record. */
+export type RawMatch = {
+  authorized_access_point: string;
+  source: string;
+  identifiedBy?: RawIdentifier[];
+};
+
+/** An exact or close match of a remote entity, formatted for display. */
+export type Match = {
+  authorized_access_point: string;
+  source: string;
+  uri?: string;
+};

--- a/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.html
+++ b/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.html
@@ -81,17 +81,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   </dd>
 }
 <!-- EXACT MATCH -->
-@if (record().exactMatch) {
+@if (exactMatch().length > 0) {
   <ng-container
     [ngTemplateOutlet]="match"
-    [ngTemplateOutletContext]="{ item: {match: exactMatch, title: 'Exact match' | translate } }"
+    [ngTemplateOutletContext]="{ item: {match: exactMatch(), title: 'Exact match' | translate } }"
   ></ng-container>
 }
 <!-- CLOSE MATCH -->
-@if (record().closeMatch) {
+@if (closeMatch().length > 0) {
   <ng-container
     [ngTemplateOutlet]="match"
-    [ngTemplateOutletContext]="{ item: {match: closeMatch, title: 'Close match' | translate } }"
+    [ngTemplateOutletContext]="{ item: {match: closeMatch(), title: 'Close match' | translate } }"
   ></ng-container>
 }
 </dl>
@@ -100,19 +100,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <dt translate>{{ item.title }}</dt>
   <dd>
     <ul  class="ui:list-none">
-      @if (item.match) {
-        @for(match of item.match; track $index) {
-          <li>
-            {{ match.source }}:
-            @if (match.uri) {
-              <a class="rero-ils-external-link" href="{{ match.uri }}" title="{{ match.uri }}" target="_blank">
-                {{ match.authorized_access_point }}
-              </a>
-            } @else {
+      @for(match of item.match; track $index) {
+        <li>
+          {{ match.source }}:
+          @if (match.uri) {
+            <a class="rero-ils-external-link" href="{{ match.uri }}" title="{{ match.uri }}" target="_blank">
               {{ match.authorized_access_point }}
-            }
-          </li>
-        }
+            </a>
+          } @else {
+            {{ match.authorized_access_point }}
+          }
+        </li>
       }
     </ul>
   </dd>

--- a/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.spec.ts
+++ b/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.spec.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RemoteTopicDetailViewComponent } from './remote-topic-detail-view.component';
+
+describe('RemoteTopicDetailViewComponent', () => {
+  let component: RemoteTopicDetailViewComponent;
+  let fixture: ComponentFixture<RemoteTopicDetailViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), RemoteTopicDetailViewComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RemoteTopicDetailViewComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should stay empty without any record', () => {
+    expect(component.exactMatch()).toEqual([]);
+    expect(component.closeMatch()).toEqual([]);
+  });
+
+  it('should keep the first uri of a match', () => {
+    fixture.componentRef.setInput('record', {
+      exactMatch: [{
+        authorized_access_point: 'Photographie',
+        source: 'idref',
+        identifiedBy: [
+          { type: 'bf:Local', value: 'ignored' },
+          { type: 'uri', value: 'https://www.idref.fr/027224651' },
+          { type: 'uri', value: 'https://www.idref.fr/second' }
+        ]
+      }]
+    });
+    expect(component.exactMatch()).toEqual([{
+      authorized_access_point: 'Photographie',
+      source: 'idref',
+      uri: 'https://www.idref.fr/027224651'
+    }]);
+  });
+
+  it('should omit the uri when the match has no identifier of that type', () => {
+    fixture.componentRef.setInput('record', {
+      closeMatch: [{ authorized_access_point: 'Photographie', source: 'gnd', identifiedBy: [] }]
+    });
+    expect(component.closeMatch()).toEqual([{
+      authorized_access_point: 'Photographie',
+      source: 'gnd'
+    }]);
+  });
+
+  /**
+   * The detail view rebinds the `record` input instead of recreating this component
+   * when navigating to another remote entity: the matches must be recomputed.
+   */
+  it('should replace the matches of the previous entity', () => {
+    fixture.componentRef.setInput('record', {
+      exactMatch: [{ authorized_access_point: 'Photographie', source: 'idref' }]
+    });
+    expect(component.exactMatch()).toHaveLength(1);
+
+    fixture.componentRef.setInput('record', { closeMatch: [{ authorized_access_point: 'Image', source: 'gnd' }] });
+    expect(component.exactMatch()).toEqual([]);
+    expect(component.closeMatch()).toHaveLength(1);
+  });
+});

--- a/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.ts
+++ b/projects/admin/src/app/record/detail-view/entities-detail-view/remote/remote-topic-detail-view/remote-topic-detail-view.component.ts
@@ -2,11 +2,12 @@
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { Component, input, OnInit, ChangeDetectionStrategy} from '@angular/core';
+import { Component, computed, input, Signal, ChangeDetectionStrategy} from '@angular/core';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { Bind } from 'primeng/bind';
 import { Tag } from 'primeng/tag';
 import { NgTemplateOutlet } from '@angular/common';
+import { Match, RawIdentifier, RawMatch } from './model/remote-topic-model';
 
 @Component({
     selector: 'admin-remote-topic-detail-view',
@@ -14,7 +15,7 @@ import { NgTemplateOutlet } from '@angular/common';
     imports: [TranslateDirective, Bind, Tag, NgTemplateOutlet, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class RemoteTopicDetailViewComponent implements OnInit{
+export class RemoteTopicDetailViewComponent {
 
   /** Record metadata */
   record = input<any>();
@@ -22,22 +23,28 @@ export class RemoteTopicDetailViewComponent implements OnInit{
   /** Record source */
   source = input<string>();
 
-  exactMatch = [];
-  closeMatch = [];
+  /**
+   * Matches derived from the `record` input, so that navigating to another remote
+   * entity — which only rebinds the input, without recreating this component —
+   * refreshes them.
+   */
+  readonly exactMatch: Signal<Match[]> = computed(() => this.identifiedByUriFilter(this.record()?.exactMatch));
+  readonly closeMatch: Signal<Match[]> = computed(() => this.identifiedByUriFilter(this.record()?.closeMatch));
 
-  ngOnInit(): void {
-    this.exactMatch = this.identifiedByUriFilter(this.record().exactMatch);
-    this.closeMatch = this.identifiedByUriFilter(this.record().closeMatch);
-  }
-  identifiedByUriFilter(match: any[]): any[] {
-    return match?.map((m: any) => {
-      const element = {
+  /**
+   * Keep the access point, the source and the first URI of each match.
+   * @param match - the raw matches of the record, may be undefined
+   * @returns the matches formatted for display, empty when there is none
+   */
+  private identifiedByUriFilter(match: RawMatch[]): Match[] {
+    return (match ?? []).map((m: RawMatch) => {
+      const element: Match = {
         authorized_access_point: m.authorized_access_point,
         source: m.source
       };
-      const uris = m.identifiedBy?.filter((id: any) => id.type === 'uri') || [];
+      const uris = m.identifiedBy?.filter((id: RawIdentifier) => id.type === 'uri') || [];
       if (uris.length > 0) {
-        element['uri'] = uris.shift().value;
+        element.uri = uris.shift().value;
       }
 
       return element;

--- a/projects/public-search/src/app/document-detail/store/holdings-store.ts
+++ b/projects/public-search/src/app/document-detail/store/holdings-store.ts
@@ -13,7 +13,7 @@ type HoldingsState = {
   holdings: EsRecord[],
   total: number;
   documentPid: string;
-  filteredLibrary: number[];
+  filteredLibrary: string[];
 };
 
 

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.html
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.html
@@ -326,7 +326,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <ng-container label>{{ 'Series statement' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (serie of editionStatement; track $index) {
+          @for (serie of seriesStatement; track $index) {
             <li>{{ serie.value }}</li>
           }
         </ul>

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.html
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.html
@@ -4,30 +4,30 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <div class="ui:*:odd:bg-surface-50 ui:*:block">
   <!-- FICTION STATEMENT -->
-  @if (record().metadata.fiction_statement) {
+  @if (metadata().fiction_statement) {
     <shared-description-zone>
       <ng-container label>{{ 'Fiction statement' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata).fiction_statement | translate }}
+        {{ metadata().fiction_statement | translate }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- -------------- WORK / EXPRESSION -------------- -->
   <!-- SUPPLEMENT, RELATED TO -->
-  @if (record().metadata.supplement) {
-    <shared-other-edition [fieldLabel]="'Supplement' | translate" [field]="record().metadata.supplement" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
+  @if (metadata().supplement) {
+    <shared-other-edition [fieldLabel]="'Supplement' | translate" [field]="metadata().supplement" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
   }
-  @if (record().metadata.relatedTo) {
-    <shared-other-edition [fieldLabel]="'Related to' | translate" [field]="record().metadata.relatedTo" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
+  @if (metadata().relatedTo) {
+    <shared-other-edition [fieldLabel]="'Related to' | translate" [field]="metadata().relatedTo" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
   }
 
   <!-- NOTE (TYPE GENERAL) -->
-  @if (notesGeneral) {
+  @if (notesGeneral()) {
     <shared-description-zone>
       <ng-container label>{{ 'General note' | translate }}</ng-container>
       <ng-container content>
-        @for (noteType of notesGeneral | keyvalue; track $index) {
+        @for (noteType of notesGeneral() | keyvalue; track $index) {
           <ul class="ui:list-none">
             @for (note of noteType.value; track $index) {
               <li>{{ note }}</li>
@@ -39,12 +39,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!--CREDITS -->
-  @if (record().metadata.credits) {
+  @if (metadata().credits) {
     <shared-description-zone>
       <ng-container label>{{ 'Other responsibilities' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (credit of $any(record().metadata).credits; track $index) {
+          @for (credit of metadata().credits; track $index) {
             <li>{{ credit }}</li>
           }
         </ul>
@@ -53,11 +53,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- LANGUAGE -->
-  @if (record().metadata.language && $any(record().metadata.language).length > 0) {
+  @if (metadata().language && metadata().language.length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Language' | translate }}</ng-container>
       <ng-container content>
-        @for (lang of $any(record().metadata.language); track $index; let isLast = $last) {
+        @for (lang of metadata().language; track $index; let isLast = $last) {
           {{ lang.value | translateLanguage: currentLanguage }}
           @if (lang.note) {
             ({{ lang.note }})
@@ -69,11 +69,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- ORIGINAL LANGUAGE -->
-  @if (record().metadata.originalLanguage) {
+  @if (metadata().originalLanguage) {
     <shared-description-zone>
       <ng-container label>{{ 'Original language' | translate }}</ng-container>
       <ng-container content>
-        @for (lang of $any(record().metadata.originalLanguage); track $index; let isLast = $last) {
+        @for (lang of metadata().originalLanguage; track $index; let isLast = $last) {
             {{ lang | translateLanguage: currentLanguage }}
             @if (!isLast) {, }
         }
@@ -82,12 +82,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- ORIGINAL TITLE -->
-  @if (record().metadata.originalTitle) {
+  @if (metadata().originalTitle) {
     <shared-description-zone>
       <ng-container label>{{ 'Original title' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (title of $any(record().metadata.originalTitle); track $index) {
+          @for (title of metadata().originalTitle; track $index) {
             <li>{{ title }}</li>
           }
         </ul>
@@ -96,28 +96,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- WORK ACCESS POINT -->
-  @if (workAccessPoint; as works) {
-    @if (works.length > 0) {
-      <shared-description-zone>
-        <ng-container label>{{ 'Work' | translate }}</ng-container>
-        <ng-container content>
-          <ul class="ui:list-none">
-            @for (work of works; track $index) {
-              <li>{{ work }}</li>
-            }
-          </ul>
-        </ng-container>
-      </shared-description-zone>
-    }
+  @if (workAccessPoint().length > 0) {
+    <shared-description-zone>
+      <ng-container label>{{ 'Work' | translate }}</ng-container>
+      <ng-container content>
+        <ul class="ui:list-none">
+          @for (work of workAccessPoint(); track $index) {
+            <li>{{ work }}</li>
+          }
+        </ul>
+      </ng-container>
+    </shared-description-zone>
   }
 
   <!-- TABLE OF CONTENTS -->
-  @if (record().metadata.tableOfContents) {
+  @if (metadata().tableOfContents) {
     <shared-description-zone>
       <ng-container label>{{ 'Contents' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (table of $any(record().metadata.tableOfContents); track $index) {
+          @for (table of metadata().tableOfContents; track $index) {
             <li>{{ table }}</li>
           }
         </ul>
@@ -126,12 +124,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- DISSERTATION -->
-  @if (record().metadata.dissertation) {
+  @if (metadata().dissertation) {
     <shared-description-zone>
       <ng-container label>{{ 'Thesis' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (dissertation of $any(record().metadata.dissertation); track $index) {
+          @for (dissertation of metadata().dissertation; track $index) {
             @for (label of dissertation.label; track $index) {
               <li>{{ label.value }}</li>
             }
@@ -142,11 +140,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- INTENDED AUDIENCE -->
-  @if (record().metadata.intendedAudience) {
+  @if (metadata().intendedAudience) {
     <shared-description-zone>
       <ng-container label>{{ 'Intended audience' | translate }}</ng-container>
       <ng-container content>
-        @for (audience of $any(record().metadata.intendedAudience); track $index; let isLast = $last) {
+        @for (audience of metadata().intendedAudience; track $index; let isLast = $last) {
           {{ audience.value | translate }}
           @if (!isLast) {, }
         }
@@ -155,21 +153,21 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- ILLUSTRATIVE CONTENT -->
-  @if (record().metadata.illustrativeContent) {
+  @if (metadata().illustrativeContent) {
     <shared-description-zone>
       <ng-container label>{{ 'Illustrations' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata.illustrativeContent).join(', ') }}
+        {{ metadata().illustrativeContent.join(', ') }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- COLOR CONTENT -->
-  @if (record().metadata.colorContent) {
+  @if (metadata().colorContent) {
     <shared-description-zone>
       <ng-container label>{{ 'Colors' | translate }}</ng-container>
       <ng-container content>
-        @for (color of $any(record().metadata.colorContent); track $index; let isLast = $last) {
+        @for (color of metadata().colorContent; track $index; let isLast = $last) {
           {{ color | translate }}
           @if (!isLast) {, }
         }
@@ -178,12 +176,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- SCALE -->
-  @if (record().metadata.scale) {
+  @if (metadata().scale) {
     <shared-description-zone>
       <ng-container label>{{ 'Scale' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (scale of $any(record().metadata.scale); track $index) {
+          @for (scale of metadata().scale; track $index) {
             <li>
               {{ scale.label }}
               @if (scaleRatios(scale); as ratios) {
@@ -200,12 +198,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- CARTOGRAPHIC ATTRIBUTES -->
-  @if (cartographicAttributes.length > 0) {
+  @if (cartographicAttributes().length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Cartographic data' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (cartographic of cartographicAttributes; track $index) {
+          @for (cartographic of cartographicAttributes(); track $index) {
             <li>
               @if (cartographic.projection) {
                 {{ cartographic.projection }}
@@ -230,12 +228,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- TEMPORAL COVERAGE -->
-  @if (temporalCoverages.length > 0) {
+  @if (temporalCoverages().length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Temporal coverage' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (coverage of temporalCoverages; track $index) {
+          @for (coverage of temporalCoverages(); track $index) {
             <li>{{ coverage }}</li>
           }
         </ul>
@@ -244,12 +242,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- CLASSIFICATION -->
-  @if (record().metadata.classification) {
+  @if (metadata().classification) {
     <shared-description-zone>
       <ng-container label>{{ 'Classification' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (classification of $any(record().metadata.classification); track $index) {
+          @for (classification of metadata().classification; track $index) {
             <li>
               {{ classification.classificationPortion }}
               @if (classification.subdivision) {
@@ -266,12 +264,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <!-- -------------- MANIFESTATION -------------- -->
 
   <!-- USAGE AND ACCESS POLICY -->
-  @if (record().metadata.usageAndAccessPolicy) {
+  @if (metadata().usageAndAccessPolicy) {
     <shared-description-zone>
       <ng-container label>{{ 'Use and access condition' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (usage of $any(record().metadata.usageAndAccessPolicy); track $index) {
+          @for (usage of metadata().usageAndAccessPolicy; track $index) {
             <li>{{ usage.label }}</li>
           }
         </ul>
@@ -280,39 +278,37 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- OTHER EDITION, OTHER PHYSICAL FORMAT, HAS REPRODUCTION -->
-  @if (record().metadata.otherEdition) {
-    <shared-other-edition [fieldLabel]="'Other edition' | translate" [field]="record().metadata.otherEdition" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
+  @if (metadata().otherEdition) {
+    <shared-other-edition [fieldLabel]="'Other edition' | translate" [field]="metadata().otherEdition" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
   }
-  @if (record().metadata.otherPhysicalFormat) {
-    <shared-other-edition [fieldLabel]="'Also issued as' | translate" [field]="record().metadata.otherPhysicalFormat" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
+  @if (metadata().otherPhysicalFormat) {
+    <shared-other-edition [fieldLabel]="'Also issued as' | translate" [field]="metadata().otherPhysicalFormat" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
   }
-  @if (record().metadata.hasReproduction) {
-    <shared-other-edition [fieldLabel]="'Reproduced as' | translate" [field]="record().metadata.hasReproduction" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
+  @if (metadata().hasReproduction) {
+    <shared-other-edition [fieldLabel]="'Reproduced as' | translate" [field]="metadata().hasReproduction" [viewcode]="viewcode()" [isPublicView]="isPublicView()" />
   }
 
   <!-- TITLE (KEY TITLE, ABBREVIATED TITLE, VARIANT TITLE)-->
-  @if (titleVariants !== {}) {
-    @for (title of titleVariants | keyvalue; track $index) {
-      <shared-description-zone>
-        <ng-container label>{{ $any(title).key | translate | ucfirst }}</ng-container>
-        <ng-container content>
-          <ul class="ui:list-none">
-            @for (value of $any(title).value; track $index) {
-              <li>{{ value }}</li>
-            }
-          </ul>
-        </ng-container>
-      </shared-description-zone>
-    }
+  @for (title of titleVariants() | keyvalue; track $index) {
+    <shared-description-zone>
+      <ng-container label>{{ title.key | translate | ucfirst }}</ng-container>
+      <ng-container content>
+        <ul class="ui:list-none">
+          @for (value of title.value; track $index) {
+            <li>{{ value }}</li>
+          }
+        </ul>
+      </ng-container>
+    </shared-description-zone>
   }
 
   <!-- RESPONSIBILITY STATEMENT -->
-  @if (record().metadata.ui_responsibilities) {
+  @if (metadata().ui_responsibilities) {
     <shared-description-zone>
       <ng-container label>{{ 'Statement of responsibility' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (responsibility of $any(record().metadata.ui_responsibilities); track $index) {
+          @for (responsibility of metadata().ui_responsibilities; track $index) {
             <li>{{ responsibility }}</li>
           }
         </ul>
@@ -321,12 +317,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- SERIES STATEMENT -->
-  @if (record().metadata.seriesStatement) {
+  @if (seriesStatement().length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Series statement' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (serie of seriesStatement; track $index) {
+          @for (serie of seriesStatement(); track $index) {
             <li>{{ serie.value }}</li>
           }
         </ul>
@@ -335,7 +331,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- PROVISION ACTIVITY STATEMENT (TYPES PRODUCTION, DIFFUSION/DISTRIBUTION, FABRICATION) -->
-  @if (record().metadata.provisionActivity | documentProvisionActivity | keyvalue | callbackArrayFilter: filterNotPublicationProvisionActivity;as provisionActivity) {
+  @if (metadata().provisionActivity | documentProvisionActivity | keyvalue | callbackArrayFilter: filterNotPublicationProvisionActivity;as provisionActivity) {
     @for (provision of provisionActivity; track $index) {
       <shared-description-zone>
         <ng-container label>{{ provision.key | translate }}</ng-container>
@@ -351,11 +347,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- PROVISION ACTIVITY ORIGINAL DATE (TYPES PRODUCTION, DIFFUSION/DISTRIBUTION, FABRICATION) -->
-  @if (provisionActivityOriginalDate.length > 0) {
+  @if (provisionActivityOriginalDate().length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Date of the original' | translate }}</ng-container>
       <ng-container content>
-        @for (provision of provisionActivityOriginalDate; track $index; let isLast = $last) {
+        @for (provision of provisionActivityOriginalDate(); track $index; let isLast = $last) {
           {{ provision.original_date }}@if (!isLast) {, }
         }
       </ng-container>
@@ -363,8 +359,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- PROVISION ACTIVITY NOTE (ALL TYPES, INCLUDING PUBLICATION) -->
-  @if (provisionActivityNotes) {
-    @for (provisionNote of provisionActivityNotes | keyvalue; track $index) {
+  @if (provisionActivityNotes()) {
+    @for (provisionNote of provisionActivityNotes() | keyvalue; track $index) {
       <shared-description-zone>
         <ng-container label>{{ provisionNote.key | translate }} ({{ 'Note' | translate }})</ng-container>
         <ng-container content>
@@ -379,51 +375,51 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- COPYRIGHT DATE -->
-  @if (record().metadata.copyrightDate) {
+  @if (metadata().copyrightDate) {
     <shared-description-zone>
       <ng-container label>{{ 'Copyright date' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata.copyrightDate).join(", ") }}
+        {{ metadata().copyrightDate.join(", ") }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- SEQUENCE NUMBERING -->
-  @if (record().metadata.sequence_numbering) {
+  @if (metadata().sequence_numbering) {
     <shared-description-zone>
       <ng-container label>{{ 'Numbering' | translate }}</ng-container>
       <ng-container content>
-        {{ record().metadata.sequence_numbering }}
+        {{ metadata().sequence_numbering }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- DIMENSIONS -->
-  @if (record().metadata.dimensions) {
+  @if (metadata().dimensions) {
     <shared-description-zone>
       <ng-container label>{{ 'Dimensions' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata.dimensions).join(", ") }}
+        {{ metadata().dimensions.join(", ") }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- BOOK FORMAT -->
-  @if (record().metadata.bookFormat) {
+  @if (metadata().bookFormat) {
     <shared-description-zone>
       <ng-container label>{{ 'Format' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata.bookFormat).join(", ") }}
+        {{ metadata().bookFormat.join(", ") }}
       </ng-container>
     </shared-description-zone>
   }
 
   <!-- PRODUCTION METHOD -->
-  @if (record().metadata.productionMethod) {
+  @if (metadata().productionMethod) {
     <shared-description-zone>
       <ng-container label>{{ 'Production method' | translate }}</ng-container>
       <ng-container content>
-        @for (method of $any(record().metadata.productionMethod); track $index; let isLast = $last) {
+        @for (method of metadata().productionMethod; track $index; let isLast = $last) {
           {{ method | translate }}@if (!isLast) {, }
         }
       </ng-container>
@@ -431,8 +427,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- NOTE (TYPE: CITED BY, OTHER PHYSICAL DETAILS, ACCOMPANYING MATERIAL) -->
-  @if (notesExceptGeneral) {
-    @for (noteType of notesExceptGeneral | keyvalue; track $index) {
+  @if (notesExceptGeneral()) {
+    @for (noteType of notesExceptGeneral() | keyvalue; track $index) {
       <shared-description-zone>
         <ng-container label>{{ noteType.key | translate | ucfirst }}</ng-container>
         <ng-container content>
@@ -447,12 +443,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- SUPPLEMENTARY CONTENT -->
-  @if (record().metadata.supplementaryContent) {
+  @if (metadata().supplementaryContent) {
     <shared-description-zone>
       <ng-container label>{{ 'Supplementary content' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (sup of $any(record().metadata.supplementaryContent); track $index) {
+          @for (sup of metadata().supplementaryContent; track $index) {
             <li>{{ sup }}</li>
           }
         </ul>
@@ -461,12 +457,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- ACQUISITION TERMS -->
-  @if (record().metadata.acquisitionTerms) {
+  @if (metadata().acquisitionTerms) {
     <shared-description-zone>
       <ng-container label>{{ 'Terms of availability' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (term of $any(record().metadata.acquisitionTerms); track $index) {
+          @for (term of metadata().acquisitionTerms; track $index) {
             <li>{{ term }}</li>
           }
         </ul>
@@ -475,12 +471,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- IDENTIFIED BY -->
-  @if (identifiedBy && identifiedBy.length > 0) {
+  @if (identifiedBy().length > 0) {
     <shared-description-zone>
       <ng-container label>{{ 'Identifier' | translate }}</ng-container>
       <ng-container content>
         <ul class="ui:list-none">
-          @for (identifier of identifiedBy; track $index; let i = $index) {
+          @for (identifier of identifiedBy(); track $index; let i = $index) {
             <li [attr.id]="i | idAttribute:{prefix: 'doc-identifier'}">
               @if (identifier.type === 'uri') {
                 <a class="rero-ils-external-link" [href]="identifier.value | safeUrl">{{ identifier.value }}</a>
@@ -501,11 +497,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <!-- -------------- TYPOLOGY -------------- -->
 
   <!-- CONTENT MEDIA CARRIER -->
-  @if (record().metadata.contentMediaCarrier) {
+  @if (metadata().contentMediaCarrier) {
     <shared-description-zone>
       <ng-container label>{{ 'Carrier and content type' | translate }}</ng-container>
       <ng-container content>
-        @for (content of $any(record().metadata.contentMediaCarrier); track $index; let isLastL1 = $last) {
+        @for (content of metadata().contentMediaCarrier; track $index; let isLastL1 = $last) {
             {{ content.carrierType | translate }}
             @if (content.contentType) {
               (@for (type of content.contentType; track $index; let isLast = $last) {
@@ -519,11 +515,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 
   <!-- ISSUANCE -->
-  @if (record().metadata.issuance) {
+  @if (metadata().issuance) {
     <shared-description-zone>
       <ng-container label>{{ 'Mode of issuance' | translate }}</ng-container>
       <ng-container content>
-        {{ $any(record().metadata.issuance).main_type | translate }} / {{ $any(record().metadata.issuance).subtype | translate }}
+        {{ metadata().issuance.main_type | translate }} / {{ metadata().issuance.subtype | translate }}
       </ng-container>
     </shared-description-zone>
   }
@@ -531,7 +527,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <!-- -------------- ADMIN METADATA (PROFESSIONAL INTERFACE ONLY) -------------- -->
   <!-- `encodingLevel` and `note` are already reported by the detail view header banner. -->
   @if (!isPublicView()) {
-    @let adminMetadata = $any(record().metadata.adminMetadata);
+    @let adminMetadata = metadata().adminMetadata;
 
     <!-- CATALOGUING SOURCE -->
     @if (adminMetadata?.source) {

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
@@ -10,7 +10,7 @@ describe('DocumentDescriptionComponent', () => {
   let fixture: ComponentFixture<DocumentDescriptionComponent>;
 
   /**
-   * Create the component for the given document metadata and run its init hook.
+   * Create the component for the given document metadata.
    * The template is deliberately not rendered: these tests target the metadata processing only.
    * @param metadata - the document metadata exposed through the `record` input
    */
@@ -18,7 +18,6 @@ describe('DocumentDescriptionComponent', () => {
     fixture = TestBed.createComponent(DocumentDescriptionComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('record', { metadata });
-    component.ngOnInit();
   }
 
   beforeEach(async () => {
@@ -32,6 +31,68 @@ describe('DocumentDescriptionComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should stay empty without any record', () => {
+    fixture = TestBed.createComponent(DocumentDescriptionComponent);
+    component = fixture.componentInstance;
+    expect(component.identifiedBy()).toEqual([]);
+    expect(component.notesGeneral()).toBeUndefined();
+  });
+
+  /**
+   * The detail view rebinds the `record` input instead of recreating this component
+   * when navigating to a linked document. Every derived field must then be recomputed,
+   * without keeping nor accumulating the values of the previous document.
+   */
+  it('should replace the derived fields of the previous document', () => {
+    withMetadata({
+      identifiedBy: [{ type: 'bf:Isbn', value: '9782070360024' }],
+      note: [{ noteType: 'general', label: 'first document note' }],
+      temporalCoverage: [{ type: 'time', date: '+1789' }]
+    });
+    expect(component.identifiedBy()).toHaveLength(1);
+
+    fixture.componentRef.setInput('record', {
+      metadata: {
+        identifiedBy: [{ type: 'bf:Issn', value: '1234-5678' }]
+      }
+    });
+
+    expect(component.identifiedBy()).toEqual([
+      { type: 'bf:Issn', value: '1234-5678', details: '' }
+    ]);
+    expect(component.notesGeneral()).toBeUndefined();
+    expect(component.temporalCoverages()).toEqual([]);
+  });
+
+  describe('identifiers', () => {
+    it('should replace the bf:Local type by the source', () => {
+      withMetadata({
+        identifiedBy: [{ type: 'bf:Local', source: 'RERO', value: 'R008745521' }]
+      });
+      expect(component.identifiedBy()).toEqual([
+        { type: 'RERO', value: 'R008745521', details: '' }
+      ]);
+    });
+
+    it('should join the qualifier, the status and the note as details', () => {
+      withMetadata({
+        identifiedBy: [{
+          type: 'bf:Isbn',
+          value: '9782070360024',
+          qualifier: 'broché',
+          status: 'invalid',
+          note: 'sur la couverture'
+        }]
+      });
+      expect(component.identifiedBy()[0].details).toEqual('broché, invalid, sur la couverture');
+    });
+
+    it('should stay empty without any identifier', () => {
+      withMetadata({});
+      expect(component.identifiedBy()).toEqual([]);
+    });
+  });
+
   describe('series statement', () => {
     it('should display the default language first', () => {
       withMetadata({
@@ -42,7 +103,7 @@ describe('DocumentDescriptionComponent', () => {
           ]
         }]
       });
-      expect(component.seriesStatement.map(statement => statement.value))
+      expect(component.seriesStatement().map(statement => statement.value))
         .toEqual(['Folio', 'Collection Folio']);
     });
 
@@ -53,17 +114,87 @@ describe('DocumentDescriptionComponent', () => {
           { _text: [{ language: 'default', value: 'Classiques' }] }
         ]
       });
-      expect(component.seriesStatement).toHaveLength(2);
+      expect(component.seriesStatement()).toHaveLength(2);
     });
 
     it('should ignore a statement without text', () => {
       withMetadata({ seriesStatement: [{ seriesTitle: [{ value: 'Folio' }] }] });
-      expect(component.seriesStatement).toEqual([]);
+      expect(component.seriesStatement()).toEqual([]);
     });
 
     it('should stay empty without any series statement', () => {
       withMetadata({});
-      expect(component.seriesStatement).toEqual([]);
+      expect(component.seriesStatement()).toEqual([]);
+    });
+  });
+
+  describe('title variants', () => {
+    it('should group the variants by title type', () => {
+      withMetadata({
+        title: [
+          { type: 'bf:Title', mainTitle: [{ value: 'Main title' }] },
+          { type: 'bf:VariantTitle', mainTitle: [{ value: 'First variant' }] },
+          { type: 'bf:VariantTitle', mainTitle: [{ value: 'Second variant' }] },
+          { type: 'bf:KeyTitle', mainTitle: [{ value: 'Key title' }] }
+        ]
+      });
+      expect(component.titleVariants()).toEqual({
+        'bf:VariantTitle': ['First variant', 'Second variant'],
+        'bf:KeyTitle': ['Key title']
+      });
+    });
+
+    it('should append the subtitle', () => {
+      withMetadata({
+        title: [{
+          type: 'bf:VariantTitle',
+          mainTitle: [{ value: 'Main title' }],
+          subtitle: [{ value: 'Subtitle' }]
+        }]
+      });
+      expect(component.titleVariants()['bf:VariantTitle']).toEqual(['Main title: Subtitle']);
+    });
+
+    it('should append the parts', () => {
+      withMetadata({
+        title: [{
+          type: 'bf:VariantTitle',
+          mainTitle: [{ value: 'Main title' }],
+          part: [
+            { partNumber: [{ value: '2' }], partName: [{ value: 'Le retour' }] },
+            { partName: [{ value: 'Suite' }] }
+          ]
+        }]
+      });
+      expect(component.titleVariants()['bf:VariantTitle'])
+        .toEqual(['Main title. 2, Le retour. Suite']);
+    });
+
+    it('should stay empty when the document only holds its main title', () => {
+      withMetadata({ title: [{ type: 'bf:Title', mainTitle: [{ value: 'Main title' }] }] });
+      expect(component.titleVariants()).toEqual({});
+    });
+  });
+
+  describe('notes except general', () => {
+    it('should group the notes by type, general excluded', () => {
+      withMetadata({
+        note: [
+          { noteType: 'general', label: 'general note' },
+          { noteType: 'citedBy', label: 'first citation' },
+          { noteType: 'citedBy', label: 'second citation' },
+          { noteType: 'accompanyingMaterial', label: 'with a CD' }
+        ]
+      });
+      expect(component.notesExceptGeneral()).toEqual({
+        citedBy: ['first citation', 'second citation'],
+        accompanyingMaterial: ['with a CD']
+      });
+    });
+
+    it('should stay undefined when every note is general', () => {
+      withMetadata({ note: [{ noteType: 'general', label: 'general note' }] });
+      expect(component.notesExceptGeneral()).toBeUndefined();
     });
   });
 
@@ -75,7 +206,7 @@ describe('DocumentDescriptionComponent', () => {
           { type: 'bf:Manufacture', original_date: '1791' }
         ]
       });
-      expect(component.provisionActivityOriginalDate.map(provision => provision.original_date))
+      expect(component.provisionActivityOriginalDate().map(provision => provision.original_date))
         .toEqual(['1789', '1791']);
     });
 
@@ -83,12 +214,12 @@ describe('DocumentDescriptionComponent', () => {
       withMetadata({
         provisionActivity: [{ type: 'bf:Publication', original_date: '1789' }]
       });
-      expect(component.provisionActivityOriginalDate).toEqual([]);
+      expect(component.provisionActivityOriginalDate()).toEqual([]);
     });
 
     it('should discard the activities without original date', () => {
       withMetadata({ provisionActivity: [{ type: 'bf:Production', startDate: 1789 }] });
-      expect(component.provisionActivityOriginalDate).toEqual([]);
+      expect(component.provisionActivityOriginalDate()).toEqual([]);
     });
   });
 
@@ -101,7 +232,7 @@ describe('DocumentDescriptionComponent', () => {
           { type: 'bf:Distribution', note: 'distributor unknown' }
         ]
       });
-      expect(component.provisionActivityNotes).toEqual({
+      expect(component.provisionActivityNotes()).toEqual({
         'bf:Production': ['assumed place', 'assumed agent'],
         'bf:Distribution': ['distributor unknown']
       });
@@ -111,7 +242,7 @@ describe('DocumentDescriptionComponent', () => {
       withMetadata({
         provisionActivity: [{ type: 'bf:Publication', note: 'uncertain publication date' }]
       });
-      expect(component.provisionActivityNotes).toEqual({
+      expect(component.provisionActivityNotes()).toEqual({
         'bf:Publication': ['uncertain publication date']
       });
     });
@@ -123,88 +254,88 @@ describe('DocumentDescriptionComponent', () => {
           { type: 'bf:Production', note: 'assumed place' }
         ]
       });
-      expect(component.provisionActivityNotes).toEqual({ 'bf:Production': ['assumed place'] });
+      expect(component.provisionActivityNotes()).toEqual({ 'bf:Production': ['assumed place'] });
     });
 
     it('should stay undefined when no provision activity holds a note', () => {
       withMetadata({ provisionActivity: [{ type: 'bf:Publication', startDate: 1999 }] });
-      expect(component.provisionActivityNotes).toBeUndefined();
+      expect(component.provisionActivityNotes()).toBeUndefined();
     });
 
     it('should stay undefined without any provision activity', () => {
       withMetadata({});
-      expect(component.provisionActivityNotes).toBeUndefined();
+      expect(component.provisionActivityNotes()).toBeUndefined();
     });
   });
 
   describe('temporal coverage', () => {
     it('should strip the leading plus sign of a single date', () => {
       withMetadata({ temporalCoverage: [{ type: 'time', date: '+1945-05-08' }] });
-      expect(component.temporalCoverages).toEqual(['1945-05-08']);
+      expect(component.temporalCoverages()).toEqual(['1945-05-08']);
     });
 
     it('should keep the minus sign of a BCE date', () => {
       withMetadata({ temporalCoverage: [{ type: 'time', date: '-0500' }] });
-      expect(component.temporalCoverages).toEqual(['-0500']);
+      expect(component.temporalCoverages()).toEqual(['-0500']);
     });
 
     it('should format a period', () => {
       withMetadata({
         temporalCoverage: [{ type: 'period', start_date: '+1914', end_date: '+1918' }]
       });
-      expect(component.temporalCoverages).toEqual(['1914 - 1918']);
+      expect(component.temporalCoverages()).toEqual(['1914 - 1918']);
     });
 
     it('should format a period with only a start date', () => {
       withMetadata({ temporalCoverage: [{ type: 'period', start_date: '+1914' }] });
-      expect(component.temporalCoverages).toEqual(['1914']);
+      expect(component.temporalCoverages()).toEqual(['1914']);
     });
 
     it('should append the period codes', () => {
       withMetadata({
         temporalCoverage: [{ type: 'time', date: '+1945', period_code: ['x1x4', 'y2y5'] }]
       });
-      expect(component.temporalCoverages).toEqual(['1945 (x1x4, y2y5)']);
+      expect(component.temporalCoverages()).toEqual(['1945 (x1x4, y2y5)']);
     });
 
     it('should display a period code alone', () => {
       withMetadata({ temporalCoverage: [{ type: 'time', period_code: ['x1x4'] }] });
-      expect(component.temporalCoverages).toEqual(['(x1x4)']);
+      expect(component.temporalCoverages()).toEqual(['(x1x4)']);
     });
 
     it('should ignore an entry holding no displayable value', () => {
       withMetadata({ temporalCoverage: [{ type: 'time' }] });
-      expect(component.temporalCoverages).toEqual([]);
+      expect(component.temporalCoverages()).toEqual([]);
     });
 
     it('should stay empty without any temporal coverage', () => {
       withMetadata({});
-      expect(component.temporalCoverages).toEqual([]);
+      expect(component.temporalCoverages()).toEqual([]);
     });
   });
 
   describe('cartographic attributes', () => {
     it('should keep an attribute holding only an equinox', () => {
       withMetadata({ cartographicAttributes: [{ equinox: 'J2000' }] });
-      expect(component.cartographicAttributes).toEqual([{ equinox: 'J2000' }]);
+      expect(component.cartographicAttributes()).toEqual([{ equinox: 'J2000' }]);
     });
 
     it('should keep an attribute holding a projection', () => {
       withMetadata({ cartographicAttributes: [{ projection: 'Mercator' }] });
-      expect(component.cartographicAttributes).toEqual([{ projection: 'Mercator' }]);
+      expect(component.cartographicAttributes()).toEqual([{ projection: 'Mercator' }]);
     });
 
     it('should keep an attribute holding labelled coordinates', () => {
       const attribute = { coordinates: { label: 'E 6°--E 10°' } };
       withMetadata({ cartographicAttributes: [attribute] });
-      expect(component.cartographicAttributes).toEqual([attribute]);
+      expect(component.cartographicAttributes()).toEqual([attribute]);
     });
 
     it('should discard an attribute holding no displayable value', () => {
       withMetadata({
         cartographicAttributes: [{ coordinates: { longitude: 'E0060000' } }]
       });
-      expect(component.cartographicAttributes).toEqual([]);
+      expect(component.cartographicAttributes()).toEqual([]);
     });
   });
 
@@ -213,12 +344,94 @@ describe('DocumentDescriptionComponent', () => {
       withMetadata({
         work_access_point: [{ title: 'Die Zauberflöte', form_subdivision: ['Libretti', 'Excerpts'] }]
       });
-      expect(component.workAccessPoint).toEqual(['Die Zauberflöte. Libretti. Excerpts.']);
+      expect(component.workAccessPoint()).toEqual(['Die Zauberflöte. Libretti. Excerpts.']);
     });
 
     it('should not add a separator without form subdivisions', () => {
       withMetadata({ work_access_point: [{ title: 'Die Zauberflöte' }] });
-      expect(component.workAccessPoint).toEqual(['Die Zauberflöte.']);
+      expect(component.workAccessPoint()).toEqual(['Die Zauberflöte.']);
+    });
+
+    it('should complete the name of a person creator by its fuller form', () => {
+      withMetadata({
+        work_access_point: [{
+          title: 'Die Zauberflöte',
+          creator: {
+            type: 'bf:Person',
+            preferred_name: 'Mozart, Wolfgang Amadeus',
+            fuller_form_of_name: 'Amadeus'
+          }
+        }]
+      });
+      expect(component.workAccessPoint())
+        .toEqual(['Mozart, Wolfgang Amadeus (Amadeus). Die Zauberflöte.']);
+    });
+
+    it('should discard the fuller form of name of a person creator holding a numeration', () => {
+      withMetadata({
+        work_access_point: [{
+          title: 'Die Zauberflöte',
+          creator: {
+            type: 'bf:Person',
+            preferred_name: 'Mozart',
+            numeration: 'II',
+            fuller_form_of_name: 'Amadeus'
+          }
+        }]
+      });
+      expect(component.workAccessPoint()).toEqual(['Mozart II. Die Zauberflöte.']);
+    });
+
+    it('should separate the name, the qualifier and the dates of a person creator by a comma', () => {
+      withMetadata({
+        work_access_point: [{
+          title: 'Die Zauberflöte',
+          creator: {
+            type: 'bf:Person',
+            preferred_name: 'Mozart',
+            numeration: 'II',
+            qualifier: 'compositeur',
+            date_of_birth: '1756',
+            date_of_death: '1791'
+          }
+        }]
+      });
+      expect(component.workAccessPoint())
+        .toEqual(['Mozart II, compositeur, 1756-1791. Die Zauberflöte.']);
+    });
+
+    it('should end the qualifier of an unnumbered person creator by a period', () => {
+      withMetadata({
+        work_access_point: [{
+          title: 'Die Zauberflöte',
+          creator: {
+            type: 'bf:Person',
+            preferred_name: 'Mozart',
+            qualifier: 'compositeur',
+            date_of_birth: '1756'
+          }
+        }]
+      });
+      expect(component.workAccessPoint()).toEqual(['Mozart, 1756. compositeur. Die Zauberflöte.']);
+    });
+
+    it('should append the conference of an organisation creator to its units', () => {
+      withMetadata({
+        work_access_point: [{
+          title: 'Proceedings',
+          creator: {
+            type: 'bf:Organisation',
+            preferred_name: 'Symposium on Glaucoma',
+            subordinate_unit: ['New Orleans Academy of Ophthalmology'],
+            numbering: '2nd',
+            conference_date: '1967',
+            place: 'New Orleans'
+          }
+        }]
+      });
+      expect(component.workAccessPoint()).toEqual([
+        'Symposium on Glaucoma. New Orleans Academy of Ophthalmology. (2nd : 1967 : New Orleans). Proceedings.'
+      ]);
     });
   });
 

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.spec.ts
@@ -32,6 +32,66 @@ describe('DocumentDescriptionComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('series statement', () => {
+    it('should display the default language first', () => {
+      withMetadata({
+        seriesStatement: [{
+          _text: [
+            { language: 'fre', value: 'Collection Folio' },
+            { language: 'default', value: 'Folio' }
+          ]
+        }]
+      });
+      expect(component.seriesStatement.map(statement => statement.value))
+        .toEqual(['Folio', 'Collection Folio']);
+    });
+
+    it('should keep every statement', () => {
+      withMetadata({
+        seriesStatement: [
+          { _text: [{ language: 'default', value: 'Folio' }] },
+          { _text: [{ language: 'default', value: 'Classiques' }] }
+        ]
+      });
+      expect(component.seriesStatement).toHaveLength(2);
+    });
+
+    it('should ignore a statement without text', () => {
+      withMetadata({ seriesStatement: [{ seriesTitle: [{ value: 'Folio' }] }] });
+      expect(component.seriesStatement).toEqual([]);
+    });
+
+    it('should stay empty without any series statement', () => {
+      withMetadata({});
+      expect(component.seriesStatement).toEqual([]);
+    });
+  });
+
+  describe('provision activity original date', () => {
+    it('should keep the original date of the activities that are not a publication', () => {
+      withMetadata({
+        provisionActivity: [
+          { type: 'bf:Production', original_date: '1789' },
+          { type: 'bf:Manufacture', original_date: '1791' }
+        ]
+      });
+      expect(component.provisionActivityOriginalDate.map(provision => provision.original_date))
+        .toEqual(['1789', '1791']);
+    });
+
+    it('should discard the publication activities', () => {
+      withMetadata({
+        provisionActivity: [{ type: 'bf:Publication', original_date: '1789' }]
+      });
+      expect(component.provisionActivityOriginalDate).toEqual([]);
+    });
+
+    it('should discard the activities without original date', () => {
+      withMetadata({ provisionActivity: [{ type: 'bf:Production', startDate: 1789 }] });
+      expect(component.provisionActivityOriginalDate).toEqual([]);
+    });
+  });
+
   describe('provision activity notes', () => {
     it('should group notes by provision activity type', () => {
       withMetadata({

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Component, inject, OnInit, input, ChangeDetectionStrategy} from '@angular/core';
-import { TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { LangChangeEvent, TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { map } from 'rxjs';
 import { DescriptionZoneComponent } from './description-zone/description-zone.component';
 import { OtherEditionComponent } from './other-edition/other-edition.component';
 import { Bind } from 'primeng/bind';
@@ -12,21 +14,20 @@ import { KeyValuePipe } from '@angular/common';
 import { DocumentProvisionActivityPipe } from '../../../pipe/document-provision-activity.pipe';
 import { IdAttributePipe } from '../../../pipe/id-attribute.pipe';
 import { SafeUrlPipe } from '../../../pipe/safe-url.pipe';
-
-/** A provision activity of a document, as described by the `provisionActivity` field. */
-type ProvisionActivity = {
-  type: string;
-  note?: string;
-};
-
-/** A temporal content coverage of a document, as described by MARC 045. */
-type TemporalCoverage = {
-  type: string;
-  date?: string;
-  start_date?: string;
-  end_date?: string;
-  period_code?: string[];
-};
+import {
+  CartographicAttribute,
+  DocumentMetadata,
+  Identifier,
+  LocalizedText,
+  Note,
+  ProvisionActivity,
+  RawIdentifier,
+  RawTitle,
+  SeriesStatement,
+  TemporalCoverage,
+  WorkAccessAgent,
+  WorkAccessPoint
+} from './model/document-description-model';
 
 @Component({
     selector: 'shared-document-description',
@@ -34,7 +35,7 @@ type TemporalCoverage = {
     imports: [DescriptionZoneComponent, OtherEditionComponent, Bind, Tag, CallbackArrayFilterPipe, KeyValuePipe, TranslateLanguagePipe, TranslatePipe, UpperCaseFirstPipe, DocumentProvisionActivityPipe, IdAttributePipe, SafeUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DocumentDescriptionComponent implements OnInit {
+export class DocumentDescriptionComponent {
 
   public translateService: TranslateService = inject(TranslateService);
 
@@ -46,26 +47,175 @@ export class DocumentDescriptionComponent implements OnInit {
 
   /** Is public view */
   readonly isPublicView = input(false);
+
+  /** Current interface language */
+  private readonly language = toSignal(
+    this.translateService.onLangChange.pipe(map((event: LangChangeEvent) => event.lang)),
+    { initialValue: this.translateService.getCurrentLang() }
+  );
+
+  /**
+   * Metadata of the current record.
+   * The template and all the derived fields below read this signal, so that navigating
+   * to another document — which only rebinds the `record` input, without
+   * recreating this component — refreshes the whole description.
+   */
+  protected readonly metadata: Signal<DocumentMetadata> = computed(() => this.record()?.metadata ?? {});
+
+  /** All notes of the document */
+  private readonly notes = computed<Note[]>(() => this.metadata().note ?? []);
+
   /** Cartographic attributes */
-  cartographicAttributes: any[] = [];
-  /** Series statement */
-  seriesStatement: any[] = [];
-  /** Identified bye */
-  identifiedBy: any[] = [];
-  /** All notes without general */
-  notesExceptGeneral: Record<string, string[]>;
+  readonly cartographicAttributes: Signal<CartographicAttribute[]> = computed(() =>
+    (this.metadata().cartographicAttributes ?? []).filter((attribute: CartographicAttribute) =>
+      'projection' in attribute
+      || 'equinox' in attribute
+      || ('coordinates' in attribute && 'label' in attribute.coordinates)
+    )
+  );
+
+  /**
+   * Series statements.
+   * The statement of the 'default' language comes first, the translations follow.
+   */
+  readonly seriesStatement: Signal<LocalizedText[]> = computed(() => {
+    const statements: LocalizedText[] = [];
+    (this.metadata().seriesStatement ?? []).forEach((statement: SeriesStatement) => {
+      const texts = statement._text ?? [];
+      statements.push(
+        ...texts.filter((text: LocalizedText) => text.language === 'default'),
+        ...texts.filter((text: LocalizedText) => text.language !== 'default')
+      );
+    });
+    return statements;
+  });
+
+  /** Identified by */
+  readonly identifiedBy: Signal<Identifier[]> = computed(() =>
+    (this.metadata().identifiedBy ?? []).map((id: RawIdentifier) => {
+      const details = [];
+      // Format qualifier, status and note
+      if (id.qualifier) {
+        details.push(id.qualifier);
+      }
+      if (id.status) {
+        details.push(id.status);
+      }
+      if (id.note) {
+        details.push(id.note);
+      }
+      return {
+        // Replace bf:Local by source, when the identifier provides one
+        type: (id.type === 'bf:Local') ? (id.source ?? id.type) : id.type,
+        value: id.value,
+        details: details.join(', ')
+      };
+    })
+  );
+
   /** General notes only */
-  notesGeneral: Record<string, string[]>;
+  readonly notesGeneral: Signal<Record<string, string[]> | undefined> = computed(() =>
+    this.sortedNotesByType(this.notes().filter((note: Note) => note.noteType === 'general'))
+  );
+
+  /** All notes without general */
+  readonly notesExceptGeneral: Signal<Record<string, string[]> | undefined> = computed(() =>
+    this.sortedNotesByType(this.notes().filter((note: Note) => note.noteType !== 'general'))
+  );
+
   /** Provision activity notes, grouped by provision activity type */
-  provisionActivityNotes: Record<string, string[]>;
-  /** Provision activity original date */
-  provisionActivityOriginalDate: any[] = [];
+  readonly provisionActivityNotes: Signal<Record<string, string[]> | undefined> = computed(() => {
+    const notesByType: Record<string, string[]> = {};
+    (this.metadata().provisionActivity ?? [])
+      .filter((provision: ProvisionActivity) => provision.note)
+      .forEach((provision: ProvisionActivity) => {
+        notesByType[provision.type] ??= [];
+        notesByType[provision.type].push(provision.note);
+      });
+    return Object.keys(notesByType).length > 0 ? notesByType : undefined;
+  });
+
+  /**
+   * Provision activity original date, for every type but publication.
+   * The raw provision activities carry a `type`, the `key` of the template filters
+   * only exists once they have been grouped by the `documentProvisionActivity` pipe.
+   */
+  readonly provisionActivityOriginalDate: Signal<ProvisionActivity[]> = computed(() =>
+    (this.metadata().provisionActivity ?? [])
+      .filter((provision: ProvisionActivity) => provision.type !== 'bf:Publication')
+      .filter((provision: ProvisionActivity) => 'original_date' in provision)
+  );
+
   /** Temporal coverages, formatted for display */
-  temporalCoverages: string[] = [];
-  /** Title variants */
-  titleVariants: any = {};
-  /** Work access point */
-  workAccessPoint: any[] = [];
+  readonly temporalCoverages: Signal<string[]> = computed(() => {
+    const coverages: string[] = [];
+    (this.metadata().temporalCoverage ?? []).forEach((coverage: TemporalCoverage) => {
+      const parts: string[] = [];
+      if (coverage.date) {
+        parts.push(this.formatTemporalDate(coverage.date));
+      } else if (coverage.start_date || coverage.end_date) {
+        parts.push(
+          [coverage.start_date, coverage.end_date]
+            .filter((date: string) => date)
+            .map((date: string) => this.formatTemporalDate(date))
+            .join(' - ')
+        );
+      }
+      if (coverage.period_code?.length) {
+        parts.push(`(${coverage.period_code.join(', ')})`);
+      }
+      if (parts.length > 0) {
+        coverages.push(parts.join(' '));
+      }
+    });
+    return coverages;
+  });
+
+  /** Title variants, grouped by title type */
+  readonly titleVariants: Signal<Record<string, string[]>> = computed(() => {
+    const variants: Record<string, string[]> = {};
+    (this.metadata().title ?? [])
+      .filter((title: RawTitle) => title.type !== 'bf:Title')
+      .forEach((title: RawTitle) => {
+        variants[title.type] ??= [];
+        const result = [];
+        result.push(title.mainTitle[0].value);
+        if ('subtitle' in title) {
+          result.push(title.subtitle[0].value);
+        }
+        let variantTitle = result.join(': ');
+        const variantData = [];
+        if ('part' in title) {
+          title.part.forEach((part) => {
+            const variantNumberData = [];
+            if ('partNumber' in part) {
+              variantNumberData.push(part.partNumber[0].value);
+            }
+            if ('partName' in part) {
+              variantNumberData.push(part.partName[0].value);
+            }
+            variantData.push(variantNumberData.join(', '));
+          });
+        }
+        if (variantData.length > 0) {
+          variantTitle += `. ${variantData.join('. ')}`;
+        }
+        variants[title.type].push(variantTitle);
+      });
+    return variants;
+  });
+
+  /**
+   * Work access points.
+   * Depends on the interface language, as the formatted value holds a translated
+   * language label: a language change has to invalidate the computed values.
+   */
+  readonly workAccessPoint: Signal<string[]> = computed(() => {
+    // Read the language to depend on it
+    this.language();
+    return (this.metadata().work_access_point ?? [])
+      .map((workAccess: WorkAccessPoint) => this.formatWorkAccessPoint(workAccess));
+  });
 
   /**
    * Get Current language interface
@@ -73,20 +223,6 @@ export class DocumentDescriptionComponent implements OnInit {
    */
   get currentLanguage() {
     return this.translateService.getCurrentLang();
-  }
-
-  /** On init hook */
-  ngOnInit(): void {
-    this.processCartographicAttributes();
-    this.processIdentifiedBy();
-    this.processNotesExceptGeneral();
-    this.processNotesGeneral();
-    this.processProvisionActivityNote();
-    this.processProvisionActivityOriginalDate();
-    this.processSeriesStatement();
-    this.processTemporalCoverage();
-    this.processTitleVariants();
-    this.processWorkAccessPoint();
   }
 
   /**
@@ -122,275 +258,65 @@ export class DocumentDescriptionComponent implements OnInit {
     return ratios.length > 0 ? ratios.join(' / ') : null;
   }
 
-  /** Process cartographic attributes */
-  private processCartographicAttributes(): void {
-    const metadata = this.record()?.metadata;
-    if ('cartographicAttributes' in metadata) {
-      metadata.cartographicAttributes.forEach((attribute: any) => {
-        if (
-          'projection' in attribute
-          || 'equinox' in attribute
-          || ('coordinates' in attribute && 'label' in attribute.coordinates)
-        ) {
-          this.cartographicAttributes.push(attribute);
-        }
-      });
+  /**
+   * Format a work access point for display.
+   * @param workAccess - the work access point to format
+   * @returns the parts of the access point, each ended by a period
+   */
+  private formatWorkAccessPoint(workAccess: WorkAccessPoint): string {
+    const parts: string[] = [];
+    if (workAccess.creator) {
+      parts.push(...this.formatWorkAccessCreator(workAccess.creator));
     }
+    parts.push(workAccess.title);
+    (workAccess.part ?? []).forEach((part) => {
+      parts.push(part.partNumber, part.partName);
+    });
+    parts.push(
+      ...(workAccess.form_subdivision ?? []),
+      workAccess.miscellaneous_information,
+      workAccess.language ? this.translateService.instant('lang_' + workAccess.language) : undefined,
+      ...(workAccess.medium_of_performance_for_music ?? []),
+      workAccess.key_for_music,
+      workAccess.arranged_statement_for_music,
+      workAccess.date_of_work
+    );
+    return parts.filter((part: string) => part).map((part: string) => `${part}.`).join(' ');
   }
 
-  /** Process identified by */
-  private processIdentifiedBy(): void {
-    const metadata = this.record()?.metadata;
-    if ('identifiedBy' in metadata) {
-      metadata.identifiedBy.forEach((id: any) => {
-        const details = [];
-        // Replace bf:Local by source
-        const idType = (id.type === 'bf:Local') ? id.source : id.type;
-        // Format qualifier, status and note
-        if (id.qualifier) {
-          details.push(id.qualifier);
-        }
-        if (id.status) {
-          details.push(id.status);
-        }
-        if (id.note) {
-          details.push(id.note);
-        }
-        this.identifiedBy.push({
-          type: idType,
-          value: id.value,
-          details: details.join(', ')
-        });
-      });
-    }
-  }
-
-  /** Process General notes */
-  private processNotesGeneral(): void {
-    const metadata = this.record()?.metadata;
-    if ('note' in metadata) {
-      this.notesGeneral = this._sortedNotesByType(
-        metadata.note.filter((el: any) => el.noteType === 'general')
-      );
-    }
-  }
-
-  /** Process all without general */
-  private processNotesExceptGeneral(): void {
-    const metadata = this.record()?.metadata;
-    if ('note' in metadata) {
-      this.notesExceptGeneral = this._sortedNotesByType(
-        metadata.note.filter((el: any) => el.noteType !== 'general')
-      );
-    }
-  }
-
-  /** Process provision activity notes.*/
-  private processProvisionActivityNote(): void {
-    const metadata = this.record()?.metadata;
-    if ('provisionActivity' in metadata) {
-      const notesByType: Record<string, string[]> = {};
-      metadata.provisionActivity
-        .filter((provision: ProvisionActivity) => provision.note)
-        .forEach((provision: ProvisionActivity) => {
-          notesByType[provision.type] ??= [];
-          notesByType[provision.type].push(provision.note);
-        });
-      if (Object.keys(notesByType).length > 0) {
-        this.provisionActivityNotes = notesByType;
+  /**
+   * Format the creator of a work access point.
+   * @param agent - the creator to format
+   * @returns the parts of the creator, to be ended by a period by the caller
+   */
+  private formatWorkAccessCreator(agent: WorkAccessAgent): string[] {
+    if ('bf:Person' === agent.type) {
+      const name = [agent.preferred_name];
+      if (agent.numeration) {
+        name.push(agent.numeration);
+      } else if (agent.fuller_form_of_name) {
+        name.push(`(${agent.fuller_form_of_name})`);
       }
+      // The name, the qualifier of a numbered person and the dates are comma separated
+      const person = [
+        name.filter((element: string) => element).join(' '),
+        agent.numeration ? agent.qualifier : undefined,
+        [agent.date_of_birth, agent.date_of_death].filter((date: string) => date).join('-')
+      ];
+      return [
+        person.filter((element: string) => element).join(', '),
+        // The qualifier of an unnumbered person is a part of its own
+        agent.numeration ? undefined : agent.qualifier
+      ];
     }
-  }
-
-  /**
-   * Process provision activity original date, for every type but publication.
-   * The raw provision activities carry a `type`, the `key` of the template filters
-   * only exists once they have been grouped by the `documentProvisionActivity` pipe.
-   */
-  private processProvisionActivityOriginalDate(): void {
-    const metadata = this.record()?.metadata;
-    if ('provisionActivity' in metadata) {
-      this.provisionActivityOriginalDate = metadata.provisionActivity
-      .filter((provision: any) => provision.type !== 'bf:Publication')
-      .filter((provision: any) => 'original_date' in provision)
-    }
-  }
-
-  /**
-   * Process series statement.
-   * The statement of the 'default' language comes first, the translations follow.
-   */
-  private processSeriesStatement(): void {
-    const metadata = this.record()?.metadata;
-    if ('seriesStatement' in metadata) {
-      metadata.seriesStatement.forEach((statement: any) => {
-        const texts = statement._text ?? [];
-        this.seriesStatement.push(
-          ...texts.filter((text: any) => text.language === 'default'),
-          ...texts.filter((text: any) => text.language !== 'default')
-        );
-      });
-    }
-  }
-
-  /** Process temporal coverage.*/
-  private processTemporalCoverage(): void {
-    const metadata = this.record()?.metadata;
-    if ('temporalCoverage' in metadata) {
-      metadata.temporalCoverage.forEach((coverage: TemporalCoverage) => {
-        const parts: string[] = [];
-        if (coverage.date) {
-          parts.push(this._formatTemporalDate(coverage.date));
-        } else if (coverage.start_date || coverage.end_date) {
-          parts.push(
-            [coverage.start_date, coverage.end_date]
-              .filter((date: string) => date)
-              .map((date: string) => this._formatTemporalDate(date))
-              .join(' - ')
-          );
-        }
-        if (coverage.period_code?.length) {
-          parts.push(`(${coverage.period_code.join(', ')})`);
-        }
-        if (parts.length > 0) {
-          this.temporalCoverages.push(parts.join(' '));
-        }
-      });
-    }
-  }
-
-  /** Process title variants */
-  private processTitleVariants(): void {
-    const metadata = this.record()?.metadata;
-    if ('title' in metadata) {
-      const titles = metadata.title.filter((title: any) => title.type !== 'bf:Title');
-      titles.forEach((title: any) => {
-        if (!(title.type in this.titleVariants)) {
-          this.titleVariants[title.type] = [];
-        }
-        const result = [];
-        result.push(title.mainTitle[0].value);
-        if ('subtitle' in title) {
-          result.push(title.subtitle[0].value);
-        }
-        let variantTitle = result.join(': ');
-        const variantData = [];
-        if ('part' in title) {
-          title.part.forEach((part: any) => {
-            const variantNumberData = [];
-            if ('partNumber' in part) {
-              variantNumberData.push(part.partNumber[0].value);
-            }
-            if ('partName' in part) {
-              variantNumberData.push(part.partName[0].value);
-            }
-            variantData.push(variantNumberData.join(', '));
-          });
-        }
-        if (variantData.length > 0) {
-          variantTitle += `. ${variantData.join('. ')}`;
-        }
-        this.titleVariants[title.type].push(variantTitle);
-      });
-    }
-  }
-
-  /** Process work access point */
-  private processWorkAccessPoint(): void {
-    const metadata = this.record()?.metadata;
-    if ('work_access_point' in metadata) {
-      metadata.work_access_point.forEach((workAccess: any) => {
-        let agentFormatted = '';
-        if (workAccess.creator) {
-          const agent = workAccess.creator;
-          if ('bf:Person' === agent.type) {
-            // Person
-            const name = [];
-            if (agent.preferred_name) {
-              name.push(agent.preferred_name);
-            }
-            if (agent.numeration) {
-              name.push(agent.numeration);
-            } else {
-              if (agent.fuller_form_of_name) {
-                name.push(' (' + agent.agent.fuller_form_of_name + ')');
-              }
-            }
-            if (name.length > 0) {
-              agentFormatted += name.join(' ') + ', ';
-            }
-            if (agent.numeration && agent.qualifier) {
-              agentFormatted += agent.qualifier + ', ';
-            }
-            const dates = [];
-            ['date_of_birth', 'date_of_death'].forEach((key: string) => {
-              if (key in agent) {
-                dates.push(agent[key]);
-              }
-            });
-            if (dates.length > 0) {
-              agentFormatted += dates.join('-') + '. ';
-            }
-            if (!(agent.numeration) && agent.qualifier) {
-              agentFormatted += agent.qualifier + '. ';
-            }
-          } else {
-            // Organisation
-            if (agent.preferred_name) {
-              agentFormatted += agent.preferred_name + '. ';
-            }
-            if (agent.subordinate_unit) {
-              agent.subordinate_unit.forEach((sub: any) => {
-                agentFormatted += sub + '. ';
-              });
-            }
-            if (agent.numbering || agent.conference_date || agent.place) {
-              const conf = [];
-              ['numbering', 'conference_date', 'place'].forEach((key: string) => {
-                if (key in agent) {
-                  conf.push(agent[key]);
-                }
-              });
-              if (conf.length > 0) {
-                agentFormatted += '(' + conf.join(' : ') + ') ';
-              }
-            }
-          }
-        }
-        agentFormatted += workAccess.title + '. ';
-        if (workAccess.part) {
-          workAccess.part.forEach((part: any) => {
-            ['partNumber', 'partName'].forEach((key: string) => {
-              if (key in part) {
-                agentFormatted += part[key] + '. ';
-              }
-            });
-          });
-        }
-        if (workAccess.form_subdivision) {
-          agentFormatted += workAccess.form_subdivision.join('. ') + '. ';
-        }
-        if (workAccess.miscellaneous_information) {
-          agentFormatted += workAccess.miscellaneous_information + '. ';
-        }
-        if (workAccess.language) {
-          agentFormatted += this.translateService.instant('lang_' + workAccess.language) + '. ';
-        }
-        if (workAccess.medium_of_performance_for_music) {
-          agentFormatted += workAccess.medium_of_performance_for_music.join('. ') + '. ';
-        }
-        if (workAccess.key_for_music) {
-          agentFormatted += workAccess.key_for_music + '. ';
-        }
-        if (workAccess.arranged_statement_for_music) {
-          agentFormatted += workAccess.arranged_statement_for_music + '. ';
-        }
-        if (workAccess.date_of_work) {
-          agentFormatted += workAccess.date_of_work + '. ';
-        }
-        this.workAccessPoint.push(agentFormatted.trim());
-      });
-    }
+    // Organisation
+    const conference = [agent.numbering, agent.conference_date, agent.place]
+      .filter((element: string) => element);
+    return [
+      agent.preferred_name,
+      ...(agent.subordinate_unit ?? []),
+      conference.length > 0 ? `(${conference.join(' : ')})` : undefined
+    ];
   }
 
   /**
@@ -399,24 +325,22 @@ export class DocumentDescriptionComponent implements OnInit {
    * @param date - the raw date, i.e. '+1945-05-08'
    * @returns the date without its leading '+'
    */
-  private _formatTemporalDate(date: string): string {
+  private formatTemporalDate(date: string): string {
     return date.startsWith('+') ? date.slice(1) : date;
   }
 
   /**
    * Sorted notes by type
    * @param notes - Array of notes
-   * @returns sorted by type or null
+   * @returns sorted by type or undefined when there is no note
    */
-  private _sortedNotesByType(notes: { noteType: string, label: string }[]): any {
+  private sortedNotesByType(notes: Note[]): Record<string, string[]> | undefined {
     if (notes.length === 0) {
-      return;
+      return undefined;
     }
-    const sortedByType = {};
+    const sortedByType: Record<string, string[]> = {};
     notes.forEach(note => {
-      if (!(note.noteType in sortedByType)) {
-        sortedByType[note.noteType] = [];
-      }
+      sortedByType[note.noteType] ??= [];
       sortedByType[note.noteType].push(note.label);
     });
     return sortedByType;

--- a/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
+++ b/projects/shared/src/lib/component/documents/document-description/document-description.component.ts
@@ -48,8 +48,8 @@ export class DocumentDescriptionComponent implements OnInit {
   readonly isPublicView = input(false);
   /** Cartographic attributes */
   cartographicAttributes: any[] = [];
-  /** Edition statement */
-  editionStatement: any[] = [];
+  /** Series statement */
+  seriesStatement: any[] = [];
   /** Identified bye */
   identifiedBy: any[] = [];
   /** All notes without general */
@@ -78,12 +78,12 @@ export class DocumentDescriptionComponent implements OnInit {
   /** On init hook */
   ngOnInit(): void {
     this.processCartographicAttributes();
-    this.processEditionStatement();
     this.processIdentifiedBy();
     this.processNotesExceptGeneral();
     this.processNotesGeneral();
     this.processProvisionActivityNote();
     this.processProvisionActivityOriginalDate();
+    this.processSeriesStatement();
     this.processTemporalCoverage();
     this.processTitleVariants();
     this.processWorkAccessPoint();
@@ -133,28 +133,6 @@ export class DocumentDescriptionComponent implements OnInit {
           || ('coordinates' in attribute && 'label' in attribute.coordinates)
         ) {
           this.cartographicAttributes.push(attribute);
-        }
-      });
-    }
-  }
-
-  /** Process edition statement */
-  private processEditionStatement(): void {
-    const metadata = this.record()?.metadata;
-    if ('seriesStatement' in metadata) {
-      metadata.seriesStatement.forEach((element: any) => {
-        if ('_text' in element) {
-          const elementText = element._text;
-          const keys = Object.keys(elementText);
-          const indexDefault = keys.indexOf('default');
-          if (indexDefault > -1) {
-            this.editionStatement.push(elementText.default);
-            keys.splice(indexDefault, 1);
-          }
-
-          keys.forEach(key => {
-            this.editionStatement.push(elementText[key]);
-          });
         }
       });
     }
@@ -224,13 +202,34 @@ export class DocumentDescriptionComponent implements OnInit {
     }
   }
 
-  /** Process provision activity original date */
+  /**
+   * Process provision activity original date, for every type but publication.
+   * The raw provision activities carry a `type`, the `key` of the template filters
+   * only exists once they have been grouped by the `documentProvisionActivity` pipe.
+   */
   private processProvisionActivityOriginalDate(): void {
     const metadata = this.record()?.metadata;
     if ('provisionActivity' in metadata) {
       this.provisionActivityOriginalDate = metadata.provisionActivity
-      .filter((element: any) => element.key !== 'bf:Publication')
+      .filter((provision: any) => provision.type !== 'bf:Publication')
       .filter((provision: any) => 'original_date' in provision)
+    }
+  }
+
+  /**
+   * Process series statement.
+   * The statement of the 'default' language comes first, the translations follow.
+   */
+  private processSeriesStatement(): void {
+    const metadata = this.record()?.metadata;
+    if ('seriesStatement' in metadata) {
+      metadata.seriesStatement.forEach((statement: any) => {
+        const texts = statement._text ?? [];
+        this.seriesStatement.push(
+          ...texts.filter((text: any) => text.language === 'default'),
+          ...texts.filter((text: any) => text.language !== 'default')
+        );
+      });
     }
   }
 

--- a/projects/shared/src/lib/component/documents/document-description/model/document-description-model.ts
+++ b/projects/shared/src/lib/component/documents/document-description/model/document-description-model.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-FileCopyrightText: UCLouvain
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** A provision activity of a document, as described by the `provisionActivity` field. */
+export type ProvisionActivity = {
+  type: string;
+  note?: string;
+  original_date?: string;
+};
+
+/** A value of a document field, in a given language ('default' for the main one). */
+export type LocalizedText = {
+  language: string;
+  value: string;
+};
+
+/** A series statement of a document, as described by the `seriesStatement` field. */
+export type SeriesStatement = {
+  _text?: LocalizedText[];
+};
+
+/** A cartographic attribute of a document, as described by MARC 255. */
+export type CartographicAttribute = {
+  projection?: string;
+  equinox?: string;
+  coordinates?: { label?: string };
+};
+
+/** A classification of a document, as described by the `classification` field. */
+export type Classification = {
+  classificationPortion: string;
+  type: string;
+  subdivision?: string[];
+  edition?: string;
+  assigner?: string;
+};
+
+/** A scale of a document, as described by the `scale` field. */
+export type Scale = {
+  label: string;
+  type?: string;
+  ratio_linear_horizontal?: string;
+  ratio_linear_vertical?: string;
+};
+
+/** An identifier of a document, as described by the `identifiedBy` field. */
+export type RawIdentifier = {
+  type: string;
+  value: string;
+  source?: string;
+  qualifier?: string;
+  status?: string;
+  note?: string;
+};
+
+/** A title of a document, as described by the `title` field. */
+export type RawTitle = {
+  type: string;
+  mainTitle: { value: string }[];
+  subtitle?: { value: string }[];
+  part?: {
+    partNumber?: { value: string }[];
+    partName?: { value: string }[];
+  }[];
+};
+
+/** A temporal content coverage of a document, as described by MARC 045. */
+export type TemporalCoverage = {
+  type: string;
+  date?: string;
+  start_date?: string;
+  end_date?: string;
+  period_code?: string[];
+};
+
+/** A note of a document, as described by the `note` field. */
+export type Note = {
+  noteType: string;
+  label: string;
+};
+
+/** The creator of a work access point, as described by MARC 100, 110 and 111. */
+export type WorkAccessAgent = {
+  type: string;
+  preferred_name?: string;
+  numeration?: string;
+  fuller_form_of_name?: string;
+  qualifier?: string;
+  date_of_birth?: string;
+  date_of_death?: string;
+  subordinate_unit?: string[];
+  numbering?: string;
+  conference_date?: string;
+  place?: string;
+};
+
+/** A work access point of a document, as described by the `work_access_point` field. */
+export type WorkAccessPoint = {
+  title: string;
+  creator?: WorkAccessAgent;
+  part?: { partNumber?: string, partName?: string }[];
+  form_subdivision?: string[];
+  miscellaneous_information?: string;
+  language?: string;
+  medium_of_performance_for_music?: string[];
+  key_for_music?: string;
+  arranged_statement_for_music?: string;
+  date_of_work?: string;
+};
+
+/** An identifier of a document, formatted for display. */
+export type Identifier = {
+  type: string;
+  value: string;
+  details: string;
+};
+
+/**
+ * The metadata of a document, restricted to the fields displayed by the description.
+ * Fields only forwarded to another component, or whose shape is too deep to be worth
+ * describing here, are left loosely typed.
+ */
+export type DocumentMetadata = {
+  acquisitionTerms?: string[];
+  adminMetadata?: {
+    source?: string;
+    descriptionModifier?: string[];
+    descriptionLanguage?: string;
+    descriptionConventions?: string[];
+  };
+  bookFormat?: string[];
+  cartographicAttributes?: CartographicAttribute[];
+  classification?: Classification[];
+  colorContent?: string[];
+  contentMediaCarrier?: { carrierType: string, contentType?: string[] }[];
+  copyrightDate?: string[];
+  credits?: string[];
+  dimensions?: string[];
+  dissertation?: { label?: { value: string }[] }[];
+  fiction_statement?: string;
+  hasReproduction?: any[];
+  identifiedBy?: RawIdentifier[];
+  illustrativeContent?: string[];
+  intendedAudience?: { value: string }[];
+  issuance?: { main_type: string, subtype: string };
+  language?: { value: string, note?: string }[];
+  note?: Note[];
+  originalLanguage?: string[];
+  originalTitle?: string[];
+  otherEdition?: any[];
+  otherPhysicalFormat?: any[];
+  productionMethod?: string[];
+  provisionActivity?: ProvisionActivity[];
+  relatedTo?: any[];
+  scale?: Scale[];
+  sequence_numbering?: string;
+  seriesStatement?: SeriesStatement[];
+  supplement?: any[];
+  supplementaryContent?: string[];
+  tableOfContents?: string[];
+  temporalCoverage?: TemporalCoverage[];
+  title?: RawTitle[];
+  ui_responsibilities?: string[];
+  usageAndAccessPolicy?: { label: string }[];
+  work_access_point?: WorkAccessPoint[];
+};

--- a/projects/shared/src/lib/view/entity-link.component.spec.ts
+++ b/projects/shared/src/lib/view/entity-link.component.spec.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { EntityLinkComponent } from './entity-link.component';
+
+describe('EntityLinkComponent', () => {
+  let component: EntityLinkComponent;
+  let fixture: ComponentFixture<EntityLinkComponent>;
+  let translateService: TranslateService;
+
+  const rousseau = {
+    authorized_access_point: 'Rousseau, Jean-Jacques',
+    authorized_access_point_en: 'Rousseau, Jean-Jacques (en)',
+    authorized_access_point_fr: 'Rousseau, Jean-Jacques (fr)',
+    pids: { remote: '1' },
+    resource_type: 'remote'
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), EntityLinkComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
+    translateService = TestBed.inject(TranslateService);
+    translateService.use('fr');
+    fixture = TestBed.createComponent(EntityLinkComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('resourceName', 'contribution');
+    fixture.componentRef.setInput('entity', rousseau);
+  });
+
+  it('should label the link in the current language', () => {
+    expect(component.linkName()).toEqual('Rousseau, Jean-Jacques (fr)');
+  });
+
+  it('should fall back on the language agnostic access point', () => {
+    fixture.componentRef.setInput('entity', { authorized_access_point: 'Local entity' });
+    expect(component.linkName()).toEqual('Local entity');
+  });
+
+  it('should follow a language change', () => {
+    translateService.use('en');
+    expect(component.linkName()).toEqual('Rousseau, Jean-Jacques (en)');
+  });
+
+  /**
+   * This component is rendered inside `@for` blocks tracked by index: navigating to
+   * another record rebinds the `entity` input instead of recreating the component,
+   * so every derived value has to be recomputed.
+   */
+  it('should refresh the link when the entity input is rebound', () => {
+    expect(component.linkName()).toEqual('Rousseau, Jean-Jacques (fr)');
+    fixture.componentRef.setInput('entity', {
+      authorized_access_point_fr: 'Voltaire (fr)',
+      pids: { remote: '2' },
+      resource_type: 'remote'
+    });
+    expect(component.linkName()).toEqual('Voltaire (fr)');
+    expect(component.queryParams()).toEqual({
+      q: 'contribution.entity.pids.remote:2',
+      simple: '0'
+    });
+  });
+
+  it('should search on the entity pid when it has a resource type', () => {
+    expect(component.queryParams()).toEqual({
+      q: 'contribution.entity.pids.remote:1',
+      simple: '0'
+    });
+  });
+
+  it('should search on the access point when the entity has no resource type', () => {
+    fixture.componentRef.setInput('entity', { authorized_access_point: 'Local entity' });
+    expect(component.queryParams()).toEqual({
+      q: 'contribution.entity.authorized_access_point_fr:"Local entity"',
+      simple: '0'
+    });
+  });
+
+  it('should build the external link from the router params and the query params', () => {
+    fixture.componentRef.setInput('external', true);
+    fixture.componentRef.setInput('routerLinkParams', ['/', 'global', 'search', 'documents']);
+    expect(component.externalHrefLink())
+      .toEqual('/global/search/documents?q=contribution.entity.pids.remote:1&simple=0');
+  });
+});

--- a/projects/shared/src/lib/view/entity-link.component.ts
+++ b/projects/shared/src/lib/view/entity-link.component.ts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Component, inject, OnDestroy, OnInit, input, ChangeDetectionStrategy} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Params, RouterLink } from '@angular/router';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
-import { Subscription } from 'rxjs';
+import { map } from 'rxjs';
 import { Entity } from '../classes/entity';
-import { RouterLink } from '@angular/router';
+import { EntityLinkEntity } from './model/entity-link-model';
 
 @Component({
     selector: 'shared-entity-link',
@@ -13,24 +15,24 @@ import { RouterLink } from '@angular/router';
       <a
         [class]="className()"
         [routerLink]="routerLinkParams()"
-        [queryParams]="queryParams"
-      >{{ linkName }}</a>
+        [queryParams]="queryParams()"
+      >{{ linkName() }}</a>
     } @else {
       <a
         [class]="className()"
-        [attr.href]="externalHrefLink"
-      >{{ linkName }}</a>
+        [attr.href]="externalHrefLink()"
+      >{{ linkName() }}</a>
     }
   `,
     imports: [RouterLink],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntityLinkComponent implements OnInit, OnDestroy {
+export class EntityLinkComponent {
 
   private translateService: TranslateService = inject(TranslateService);
 
   /** Entity field metadata */
-  readonly entity = input<any>(undefined);
+  readonly entity = input<EntityLinkEntity | undefined>(undefined);
 
   /** Resource field name */
   readonly resourceName = input<string>(undefined);
@@ -44,52 +46,35 @@ export class EntityLinkComponent implements OnInit, OnDestroy {
   /** Make link external */
   readonly external = input(false);
 
-  /** Link label name */
-  linkName: string;
+  /** Current interface language */
+  private readonly language = toSignal(
+    this.translateService.onLangChange.pipe(map((event: LangChangeEvent) => event.lang)),
+    { initialValue: this.translateService.getCurrentLang() }
+  );
 
-  /** External link href */
-  externalHrefLink: string;
+  /**
+   * Link label, in the current interface language when the entity provides it.
+   * Derived from the `entity` input and not computed once: this component is rendered
+   * inside `@for` blocks tracked by index, so navigating to another record only rebinds
+   * the input, without recreating the component.
+   */
+  readonly linkName: Signal<string> = computed(() => {
+    const entity: EntityLinkEntity = this.entity() ?? {};
+    const accessPoint = `authorized_access_point_${this.language()}`;
+    return accessPoint in entity ? entity[accessPoint] : entity.authorized_access_point;
+  });
 
-  /** Query params */
-  queryParams: object = {};
+  /** Query params of the search this link points to */
+  readonly queryParams: Signal<Params> = computed(() => {
+    const entity: EntityLinkEntity = this.entity() ?? {};
+    const query = 'resource_type' in entity
+      ? `${this.resourceName()}.entity.pids.${entity.resource_type}:${entity.pids[entity.resource_type]}`
+      : `${this.resourceName()}.entity.authorized_access_point_${this.language()}:"${this.linkName()}"`;
+    return { q: query, simple: '0' };
+  });
 
-  subscriptions: Subscription = new Subscription();
-
-  /** OnInit hook */
-  ngOnInit(): void {
-    this.subscriptions.add(
-      this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-        this.translateEntity(event.lang);
-      })
-    );
-    this.translateEntity(this.translateService.getCurrentLang());
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
-
-  private translateEntity(lang: string): void{
-    const entity = this.entity();
-    this.linkName = `authorized_access_point_${lang}` in entity
-      ? entity[`authorized_access_point_${lang}`]
-      : entity.authorized_access_point;
-    const entityValue = this.entity();
-    if ('resource_type' in entityValue) {
-      const pid = entityValue.pids[entityValue.resource_type];
-      this.queryParams = {
-        q: `${this.resourceName()}.entity.pids.${entityValue.resource_type}:${pid}`,
-        simple: '0',
-      };
-    } else {
-      this.queryParams = {
-        q: `${this.resourceName()}.entity.authorized_access_point_${lang}:"${this.linkName}"`,
-        simple: '0',
-      }
-    }
-    if (this.external()) {
-      // This link is used to redirect to the jinja view of the entity.
-      this.externalHrefLink = Entity.generateHrefLink(this.routerLinkParams(), this.queryParams);
-    }
-  }
+  /** External link href, used to redirect to the jinja view of the entity */
+  readonly externalHrefLink: Signal<string> = computed(() =>
+    Entity.generateHrefLink(this.routerLinkParams(), this.queryParams())
+  );
 }

--- a/projects/shared/src/lib/view/model/entity-link-model.ts
+++ b/projects/shared/src/lib/view/model/entity-link-model.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** An entity of a record field, restricted to the fields the entity link reads. */
+export type EntityLinkEntity = {
+  authorized_access_point?: string;
+  resource_type?: string;
+  pids?: Record<string, string>;
+} & Partial<
+  /** Access point of a given language, i.e. `authorized_access_point_fre` */
+  Record<`authorized_access_point_${string}`, string>
+>;


### PR DESCRIPTION
fix(documents): correct two description fields (commit 1)

Both were processing a metadata shape that does not exist: the series
statement never came out with its default language first, and the
original date never excluded publications. The series statement is also
renamed, editionStatement being a distinct field rendered elsewhere.

---

fix: refresh values derived from a rebound input (commit 2)

Detail views and entity links are reused, not recreated, when navigating
to another record: their inputs are rebound. Everything derived once in
an ngOnInit kept describing the previous record.

* derive the document description, the related entities, the remote
  matches and the entity links from their inputs
* drop the holdings and the library filter when the document changes
* cover the input rebind with tests

