### PR TITLE
fix(search): read the hits total through searchTotalValue

### DIFF
--- a/projects/admin/src/app/api/document-api.service.ts
+++ b/projects/admin/src/app/api/document-api.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import type { EsResult } from '@rero/ng-core';
-import { RecordService } from '@rero/ng-core';
+import { RecordService, searchTotalValue } from '@rero/ng-core';
 import { IAvailability, IAvailabilityService } from '@rero/shared';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -31,7 +31,7 @@ export class DocumentApiService implements IAvailabilityService {
   getLinkedDocumentsCount(documentPid: string): Observable<number> {
     return this.recordService.getRecords(
       this.RESOURCE_NAME, { query: `partOf.document.pid:${documentPid}`, page: 1, itemsPerPage: 1 }
-    ).pipe(map((result: EsResult) => result.hits.total.value));
+    ).pipe(map((result: EsResult) => searchTotalValue(result.hits.total)));
   }
 
   /**

--- a/projects/admin/src/app/menu/store/menu.store.ts
+++ b/projects/admin/src/app/menu/store/menu.store.ts
@@ -5,6 +5,7 @@ import { computed, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import type { EsResult } from '@rero/ng-core';
+import { searchTotalValue } from '@rero/ng-core';
 import { AppStore, PERMISSION_OPERATOR } from '@rero/shared';
 import { patchState, signalStore, withComputed, withHooks, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
@@ -209,7 +210,7 @@ export const MenuStore = signalStore(
             return of([] as LibraryRecord[]);
           }
           return libraryApiService.findByLibrariesPidAndOrderBy$(pids).pipe(
-            map((results: EsResult) => results.hits.total.value > 0
+            map((results: EsResult) => searchTotalValue(results.hits.total) > 0
               ? results.hits.hits.map((library) => ({
                 metadata: {
                   pid: String(library.metadata['pid']),

--- a/projects/admin/src/app/record/circulation-logs/circulation-logs.component.ts
+++ b/projects/admin/src/app/record/circulation-logs/circulation-logs.component.ts
@@ -18,7 +18,7 @@ import { CirculationItemScanComponent } from './circulation-log/circulation-item
 import { CirculationLogLoanComponent } from './circulation-log/circulation-log-loan/circulation-log-loan.component';
 import { Button } from 'primeng/button';
 import { TitleCasePipe } from '@angular/common';
-import { DateTranslatePipe } from '@rero/ng-core';
+import { DateTranslatePipe, searchTotalValue } from '@rero/ng-core';
 import { CirculationLogRecordTypePipe } from './pipe/circulation-log-record-type.pipe';
 
 @Component({
@@ -84,7 +84,7 @@ export class CirculationLogsComponent implements OnInit, OnDestroy {
         switchMap(() => this.circulationLogsQuery(1))
       ).subscribe((response: EsResult) => {
         this.page.set(1);
-        this.recordsTotal.set(response.hits.total.value);
+        this.recordsTotal.set(searchTotalValue(response.hits.total));
         this.records.set(response.hits.hits);
         this.loadedRecord.set(true);
       })

--- a/projects/public-search/src/app/patron-profile/patron-profile-histories/patron-profile-histories.component.ts
+++ b/projects/public-search/src/app/patron-profile/patron-profile-histories/patron-profile-histories.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { ChangeDetectionStrategy, Component, effect, inject, OnInit, signal, untracked } from '@angular/core';
 import { _, TranslateDirective } from "@ngx-translate/core";
+import { searchTotalValue } from '@rero/ng-core';
 import { Paginator, ShowMorePagerComponent } from '@rero/shared';
 import { PanelModule } from 'primeng/panel';
 import { OperationLogsApiService } from '../../api/operation-logs-api.service';
@@ -65,7 +66,7 @@ export class PatronProfileHistoriesComponent implements OnInit {
     if (!this.paginator) return;
     this._historyQuery(1).subscribe((response) => {
       if (!('hits' in response)) return;
-      this.paginator.setRecordsCount(response.hits.total.value);
+      this.paginator.setRecordsCount(searchTotalValue(response.hits.total));
       this.records.set(response.hits.hits);
       this.loaded.set(true);
     });

--- a/projects/public-search/src/app/patron-profile/store/ill-requests-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/ill-requests-feature.ts
@@ -3,6 +3,7 @@
 import { computed, inject, type Signal } from '@angular/core';
 import { patchState, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { searchTotalValue } from '@rero/ng-core';
 import { BaseApi, nextPager, Pager } from '@rero/shared';
 import { PaginatorState } from 'primeng/paginator';
 import { catchError, finalize, of, pipe, switchMap, tap } from 'rxjs';
@@ -80,7 +81,7 @@ export function withIllRequestsFeature<_>() {
                 if (!('hits' in response)) return;
                 patchState(store, {
                   illRequests: response.hits.hits,
-                  illRequestsTotal: response.hits.total.value,
+                  illRequestsTotal: searchTotalValue(response.hits.total),
                 });
               }),
               catchError(error => {

--- a/projects/public-search/src/app/patron-profile/store/request-feature.ts
+++ b/projects/public-search/src/app/patron-profile/store/request-feature.ts
@@ -4,7 +4,7 @@ import { computed, inject, type Signal } from '@angular/core';
 import { patchState, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { _, TranslateService } from '@ngx-translate/core';
-import { CONFIG } from '@rero/ng-core';
+import { CONFIG, searchTotalValue } from '@rero/ng-core';
 import { nextPager, Pager } from '@rero/shared';
 import { MessageService } from 'primeng/api';
 import { PaginatorState } from 'primeng/paginator';
@@ -107,7 +107,7 @@ export function withRequestsFeature<_>() {
                 if (!('hits' in response)) return;
                 patchState(store, {
                   requests: response.hits.hits,
-                  requestsTotal: response.hits.total.value,
+                  requestsTotal: searchTotalValue(response.hits.total),
                 });
               }),
               catchError(error => {

--- a/projects/shared/src/lib/component/operation-logs/operation-logs.component.ts
+++ b/projects/shared/src/lib/component/operation-logs/operation-logs.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, Injector,
 import { FormsModule } from '@angular/forms';
 import { _, TranslatePipe } from "@ngx-translate/core";
 import type { EsResult, RecordData } from '@rero/ng-core';
-import { DateTranslatePipe } from '@rero/ng-core';
+import { DateTranslatePipe, searchTotalValue } from '@rero/ng-core';
 import { Bind } from 'primeng/bind';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { PaginatorState } from 'primeng/paginator';
@@ -59,7 +59,7 @@ export class OperationLogsComponent implements OnInit {
   readonly operationLogsResult = signal<EsResult | undefined>(undefined);
 
   /** Total of records */
-  readonly recordTotals = computed(() => this.operationLogsResult()?.hits.total.value ?? 0);
+  readonly recordTotals = computed(() => searchTotalValue(this.operationLogsResult()?.hits.total));
   /** Array of records */
   readonly records = computed<RecordData[]>(() => this.operationLogsResult()?.hits.hits ?? []);
 


### PR DESCRIPTION
ng-core widened `EsResult.hits.total` to `SearchTotal` — a number, a string or the raw search engine object. The seven places still reading `hits.total.value` directly no longer compile.

* Read the total through the `searchTotalValue()` helper, which accepts every shape and returns 0 for a missing or unusable total.

Behaviour is unchanged on the current endpoints: given the search engine object, the helper returns exactly the former `total.value`. The `RecordService.totalHits()` call sites already accepted all three shapes and are left untouched.

A more thourough refactor/fix of these problems will be handled by issue https://github.com/rero/rero-ils/issues/4220.