### PR TITLE
feat(fees): show both owning and transaction libs

### DIFF
--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.html
@@ -3,10 +3,15 @@ SPDX-FileCopyrightText: Fondation RERO+
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 @if (transactions) {
-  <form [formGroup]="form" (ngSubmit)="onSubmitForm()">
+  <form class="ui:block ui:w-full" [formGroup]="form" (ngSubmit)="onSubmitForm()">
     <formly-form [form]="form" [fields]="formFields" [model]="model" />
 
-    <p-scrollPanel class="ui:my-6 ui:w-full ui:max-h-[500px]">
+    <div
+      class="ui:my-6 ui:w-full ui:max-h-[500px] ui:overflow-x-hidden ui:overflow-y-auto"
+      tabindex="0"
+      role="region"
+      [attr.aria-label]="'Transaction details' | translate"
+    >
     @for (transaction of transactions; track transaction.pid) {
       <p-panel class="ui:mb-2" [header]="transaction.type|translate">
         <div class="ui:ml-4 ui:mb-2">
@@ -27,11 +32,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         </div>
       </p-panel>
     }
-    </p-scrollPanel>
+    </div>
 
-    <div class="ui:flex ui:justify-end">
+    <div class="ui:flex ui:w-full ui:justify-end">
       <p-button type="submit" [label]="'Save'|translate" [disabled]="this.form.status !== 'VALID' || httpPending.isPending()" />
     </div>
   </form>
 }
-

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction-event-form/patron-transaction-event-form.component.ts
@@ -11,7 +11,6 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { forkJoin, Observable } from 'rxjs';
 import { Bind } from 'primeng/bind';
 import { Panel } from 'primeng/panel';
-import { ScrollPanel } from 'primeng/scrollpanel';
 import { Button } from 'primeng/button';
 import { CurrencyPipe } from '@angular/common';
 import { DateTranslatePipe, HttpPendingService } from '@rero/ng-core';
@@ -20,7 +19,7 @@ import { DateTranslatePipe, HttpPendingService } from '@rero/ng-core';
 @Component({
     selector: 'admin-patron-transaction-form',
     templateUrl: './patron-transaction-event-form.component.html',
-    imports: [FormsModule, ReactiveFormsModule, FormlyModule, Bind, ScrollPanel, TranslateDirective, Button, CurrencyPipe, DateTranslatePipe, TranslatePipe, Panel],
+    imports: [FormsModule, ReactiveFormsModule, FormlyModule, Bind, TranslateDirective, Button, CurrencyPipe, DateTranslatePipe, TranslatePipe, Panel],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatronTransactionEventFormComponent implements OnInit {

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transaction/patron-transaction.component.html
@@ -11,10 +11,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           {{ t.creation_date | dateTranslate :'shortDate' }}
         </div>
       </div>
-      <div class="ui:col-span-3">{{ t.type | translate }}</div>
-      <div class="ui:col-span-3">
+      <div class="ui:col-span-2">{{ t.type | translate }}</div>
+      <div class="ui:col-span-2">
         @if (t.library) {
           <span>{{ t.library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}</span>
+        }
+      </div>
+      <div class="ui:col-span-2">
+        @if (t.transaction_library && t.transaction_library?.pid !== t.library?.pid) {
+          <span>{{ t.transaction_library.pid | getRecord: 'libraries' : 'field' : 'name' | async }}</span>
         }
       </div>
       <div class="ui:col-span-2 ui:flex ui:justify-end">{{ transactionAmount() | currency: organisation.default_currency }}</div>
@@ -54,4 +59,3 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     }
   </div>
 }
-

--- a/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
+++ b/projects/admin/src/app/circulation/patron/patron-transactions/patron-transactions.component.html
@@ -22,8 +22,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         @if (tabs.engagedFees.transactions().length > 0) {
           <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:py-4 ui:px-2 ui:my-1 ui:text-lg ui:font-bold ui:items-center ui:border-t ui:border-surface">
             <div class="ui:col-span-2" translate>Date</div>
-            <div class="ui:col-span-3" translate>Category</div>
-            <div class="ui:col-span-3" translate>Library</div>
+            <div class="ui:col-span-2" translate>Category</div>
+            <div class="ui:col-span-2" translate>Library</div>
+            <div class="ui:col-span-2" translate>Transaction library</div>
             <div class="ui:col-span-2 ui:text-right">
               {{ 'Total amount' | translate }}: {{ statistics()['feesEngaged'] | currency: organisation.default_currency }}
             </div>
@@ -95,9 +96,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         @if (tabs.historyFees.transactions().length > 0) {
           <div class="ui:grid ui:grid-cols-12 ui:gap-4 ui:py-4 ui:my-1 ui:text-lg ui:font-bold ui:items-center">
             <div class="ui:col-span-2" translate>Date</div>
-            <div class="ui:col-span-3" translate>Category</div>
-            <div class="ui:col-span-3" translate>Library</div>
+            <div class="ui:col-span-2" translate>Category</div>
+            <div class="ui:col-span-2" translate>Library</div>
+            <div class="ui:col-span-2" translate>Transaction library</div>
             <div class="ui:col-span-2 ui:flex ui:justify-end" translate>Amount</div>
+            <div class="ui:col-span-2"></div>
           </div>
           <div>
             @for (t of tabs.historyFees.transactions(); track t.pid) {

--- a/projects/admin/src/app/classes/patron-transaction.ts
+++ b/projects/admin/src/app/classes/patron-transaction.ts
@@ -27,6 +27,7 @@ export class PatronTransaction {
   note?: string = null;
   document?: any = null;
   library?: any = null;
+  transaction_library?: any = null;
   loan?: any = null;
   patron: any = null;
 


### PR DESCRIPTION
**feat(fees): show both owning and transaction libs**
* Display the transaction library besides the owning library if
  there is a transaction library.
* Requires https://github.com/rero/rero-ils/pull/4230
* Closes https://github.com/rero/rero-ils/issues/2542

The feature focuses on this commit.

---- 

**fix(circulation): prevent pay dialog layout issue**

Safari could incorrectly calculate the scroll panel dimensions while the
pay-all dialog was opening. This caused the payment button to be clipped
until switching browser tabs forced a layout refresh.

- Keep the payment action visible and right-aligned in Safari.
- Avoid stale layout calculations when opening the pay-all dialog.
- Preserve scrolling for long transaction lists.