### PR TITLE
fix(items): refresh record state

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
@@ -576,14 +576,16 @@ describe('OrderDetailStore', () => {
       expect(store.orderLines()).toEqual([]);
     });
 
-    it('should leave account_statement unchanged (server reload will update it)', () => {
+    it('should call reloadOrder after order line deletion', () => {
       const store = setupStore();
       store.setFromRecord({ metadata: mockOrder });
-      TestBed.tick();
+      TestBed.tick(); // let order-change effect run first
+      vi.clearAllMocks(); // reset call counts before the deletion
+      acqOrderServiceSpy.getOrder.mockReturnValue(of(mockOrder));
 
       lastDeletedOrderLine.set(mockOrderLine);
       TestBed.tick();
-      expect(store.order()?.account_statement.provisional.total_amount).toBe(100);
+      expect(acqOrderServiceSpy.getOrder).toHaveBeenCalledWith('1', 1);
     });
   });
 

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
@@ -201,13 +201,14 @@ export const OrderDetailStore = signalStore(
           store.loadHistory(pid);
         });
 
-        // Remove deleted order line from state optimistically.
+        // Remove deleted order line from state and reload the order to refresh financial data.
         effect(() => {
           const line = acqOrderService.lastDeletedOrderLine();
           if (!line) return;
           patchState(store, {
             orderLines: untracked(() => store.orderLines()).filter(l => l.pid !== line.pid),
           });
+          store.reloadOrder(untracked(() => store.order()?.pid));
         });
 
         // Remove deleted receipt from state and reload the order to refresh financial data.

--- a/projects/admin/src/app/acquisition/routes/orders-route.spec.ts
+++ b/projects/admin/src/app/acquisition/routes/orders-route.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Location } from '@angular/common';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { RecordData, RecordService } from '@rero/ng-core';
+import { AppStore } from '@rero/shared';
+import { of } from 'rxjs';
+import { AcqReceiptApiService } from '../api/acq-receipt-api.service';
+import { IAcqReceipt } from '../classes/receipt';
+import { RouteToolService } from '../../routes/route-tool.service';
+import { OrdersRoute } from './orders-route';
+
+describe('OrdersRoute', () => {
+  const lastDeletedReceipt = signal<IAcqReceipt | null>(null);
+  const permissions = {
+    canRead: { can: true, message: '' },
+    canUpdate: { can: true, message: '' },
+    canDelete: { can: false, message: 'Order already sent.' },
+  };
+  const routeToolServiceSpy = {
+    appStore: { canAccess: vi.fn() },
+    apiService: { getExportEndpointByType: vi.fn() },
+    permissions: vi.fn().mockReturnValue(of(permissions)),
+  };
+
+  beforeEach(() => {
+    lastDeletedReceipt.set(null);
+    routeToolServiceSpy.permissions.mockClear();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: RouteToolService, useValue: routeToolServiceSpy },
+        { provide: Location, useValue: {} },
+        { provide: AppStore, useValue: {} },
+        { provide: RecordService, useValue: {} },
+        { provide: AcqReceiptApiService, useValue: { lastDeletedReceipt } },
+      ],
+    });
+  });
+
+  it('should reload order permissions after deleting one of its receipts', () => {
+    const type = TestBed.runInInjectionContext(() => new OrdersRoute().getTypes()[0]);
+    const record = { metadata: { pid: '1' } } as unknown as RecordData;
+    const subscription = type.permissions!(record).subscribe();
+    TestBed.tick();
+
+    expect(routeToolServiceSpy.permissions).toHaveBeenCalledTimes(1);
+
+    lastDeletedReceipt.set({ acq_order: { pid: '1' } } as IAcqReceipt);
+    TestBed.tick();
+    expect(routeToolServiceSpy.permissions).toHaveBeenCalledTimes(2);
+
+    lastDeletedReceipt.set({ acq_order: { pid: '2' } } as IAcqReceipt);
+    TestBed.tick();
+    expect(routeToolServiceSpy.permissions).toHaveBeenCalledTimes(2);
+
+    subscription.unsubscribe();
+  });
+});

--- a/projects/admin/src/app/acquisition/routes/orders-route.ts
+++ b/projects/admin/src/app/acquisition/routes/orders-route.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: UCLouvain
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ResolveFn, Routes } from '@angular/router';
 import { _ } from '@ngx-translate/core';
 import {
@@ -16,11 +17,13 @@ import {
   RouteDataTypesInterface,
 } from '@rero/ng-core';
 import { PERMISSIONS, PERMISSION_OPERATOR } from '@rero/shared';
-import { Observable, map, of } from 'rxjs';
+import { Observable, filter, map, merge, of, skip, switchMap } from 'rxjs';
 import { acqOrderLineGuard } from '../../guard/acq-order-line.guard';
 import { CAN_ACCESS_ACTIONS, canAccessGuard } from '../../guard/can-access.guard';
 import { permissionGuard } from '../../guard/permission.guard';
 import { BaseRoute } from '../../routes/base-route';
+import { AcqReceiptApiService } from '../api/acq-receipt-api.service';
+import { IAcqReceipt } from '../classes/receipt';
 import { OrderBriefViewComponent } from '../components/order/order-brief-view/order-brief-view.component';
 import { OrderDetailViewComponent } from '../components/order/order-detail-view/order-detail-view.component';
 import { OrderReceiptViewComponent } from '../components/receipt/receipt-form/order-receipt-view.component';
@@ -78,8 +81,12 @@ export const ordersRoutes: Routes = [
   },
 ];
 
-class OrdersRoute extends BaseRoute implements RouteDataTypesInterface {
+export class OrdersRoute extends BaseRoute implements RouteDataTypesInterface {
   protected recordService = inject(RecordService);
+  private readonly deletedReceipt$ = toObservable(inject(AcqReceiptApiService).lastDeletedReceipt).pipe(
+    skip(1),
+    filter((receipt): receipt is IAcqReceipt => receipt !== null)
+  );
 
   /** Route name */
   readonly name = 'acq_orders';
@@ -94,7 +101,14 @@ class OrdersRoute extends BaseRoute implements RouteDataTypesInterface {
       detailComponent: OrderDetailViewComponent,
       searchFilters: [this.expertSearchFilter()],
       canAdd: () => of({ can: this.routeToolService.appStore.canAccess(PERMISSIONS.ACOR_CREATE), message: '' }),
-      permissions: (record: RecordData) => this.routeToolService.permissions(record, this.recordType, true),
+      permissions: (record: RecordData) => merge(
+        of(null),
+        this.deletedReceipt$.pipe(
+          filter((receipt) => receipt.acq_order.pid === record.metadata['pid'])
+        )
+      ).pipe(
+        switchMap(() => this.routeToolService.permissions(record, this.recordType, true))
+      ),
       processFilterName: (filter: IFilter) => this.processFilterName(filter),
       preCreateRecord: (data: any) => this._addDefaultInformation(data),
       preUpdateRecord: (data: any) => this._cleanRecord(data),

--- a/projects/admin/src/app/record/detail-view/document-detail-view/holdings/serial-holding-item/serial-holding-item.component.html
+++ b/projects/admin/src/app/record/detail-view/document-detail-view/holdings/serial-holding-item/serial-holding-item.component.html
@@ -3,33 +3,33 @@ SPDX-FileCopyrightText: Fondation RERO+
 SPDX-FileCopyrightText: UCLouvain
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-@if (item && ((item().metadata.issue && item().metadata.issue.status !== itemIssueStatus.DELETED) || item().metadata.type === 'provisional')) {
+@if (editableItem() && ((editableItem().metadata.issue && editableItem().metadata.issue.status !== itemIssueStatus.DELETED) || editableItem().metadata.type === 'provisional')) {
     <div class="ui:grid ui:grid-cols-12 ui:gap-x-4 ui:py-1 ui:px-1 ui:grow ui:items-center">
       <div class="ui:col-span-3 ui:flex">
-        @if (item().metadata._masked) {
-          <admin-record-masked [record]="item()" />
+        @if (editableItem().metadata._masked) {
+          <admin-record-masked [record]="editableItem()" />
         }
         @if (permissions()) {
-          <a [routerLink]="['/records', 'items', 'detail', item().metadata.pid]" name="barcode">
-            {{ item().metadata.barcode }}
+          <a [routerLink]="['/records', 'items', 'detail', editableItem().metadata.pid]" name="barcode">
+            {{ editableItem().metadata.barcode }}
           </a>
         } @else {
-          {{ item().metadata.barcode }}
+          {{ editableItem().metadata.barcode }}
         }
       </div>
       <div class="ui:col-span-3">
         <shared-availability
           recordType="item"
-          [record]="item()"
+          [record]="editableItem()"
           [apiService]="itemApiService"
         />
       </div>
       <div class="ui:col-span-3">
-        {{ item().metadata.enumerationAndChronology }}
+        {{ editableItem().metadata.enumerationAndChronology }}
       </div>
       <div class="ui:col-span-3 ui:flex ui:items-center">
         <div class="ui:grow">
-          <shared-inherited-call-number class-="ui:grow" [item]="item()" />
+          <shared-inherited-call-number class-="ui:grow" [item]="editableItem()" />
         </div>
         @if (permissions()) {
           <div class="ui:flex ui:gap-1 ui:justify-end">
@@ -39,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               size="small"
               [title]="'Item request'|translate"
               outlined
-              (onClick)="addRequest(item().metadata.pid, 'item')"
+              (onClick)="addRequest(editableItem().metadata.pid, 'item')"
               [pTooltip]="cannotRequestTooltipContent"
               tooltipPosition="top"
               [disabled]="!permissions().canRequest?.can"
@@ -54,7 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 size="small"
                 [title]="'Edit'|translate"
                 outlined
-                [routerLink]="['/records', 'items', 'edit', item().metadata.pid]"
+                [routerLink]="['/records', 'items', 'edit', editableItem().metadata.pid]"
               />
             }
             <p-button
@@ -78,22 +78,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </div>
       <div class="ui:col-span-12 ui:pt-0">
         @if (permissions()) {
-          @for (note of item().metadata.notes; track $index) {
+          @for (note of editableItem().metadata.notes; track $index) {
             <admin-holding-item-note [note]="note" />
           }
-          <admin-holding-item-temporary-item-type [record]="item()" />
+          <admin-holding-item-temporary-item-type [record]="editableItem()" />
         }
         <!-- TEMPORARY LOCATION -->
-        @if (permissions() && item().metadata.temporary_location) {
+        @if (permissions() && editableItem().metadata.temporary_location) {
           <dl class="metadata">
             <dt translate>Temporary location</dt>
             <dd>
-              {{ item().metadata.temporary_location.pid | getRecord: 'locations' : 'field': 'name' | async }}
+              {{ editableItem().metadata.temporary_location.pid | getRecord: 'locations' : 'field': 'name' | async }}
             </dd>
           </dl>
         }
         <!-- ITEM IN COLLECTION -->
-        @let itemPid = item().metadata.pid;
+        @let itemPid = editableItem().metadata.pid;
         @if (permissions() && itemPid) {
           @let collections = itemPid | itemInCollection | async;
           @if (collections && collections.length > 0) {


### PR DESCRIPTION
Some views were not automatically refreshed after related records changed, leaving stale information and permissions visible. These changes ensure the affected components reflect the latest state without requiring a full page reload.

* requires https://github.com/rero/rero-ils/pull/4234

For serial items:
* Refresh serial item information after a successful request.
* Keep the availability status in sync without a full page reload.
* Closes rero/rero-ils#4222

For orders:
* Reload order data after deleting an order line.
* Refresh order permissions after deleting a related receipt.
* Refresh financial information when deleting a order line.