### PR TITLE
fix(acquisition): restore the default order lines sort option

### DIFF
--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.spec.ts
@@ -369,9 +369,9 @@ describe('OrderDetailStore', () => {
   describe('setSortCriteria', () => {
     it('should update the linesSortCriteria state', () => {
       const store = setupStore();
-      expect(store.linesSortCriteria()).toBe('priority');
-      store.setSortCriteria('-priority');
       expect(store.linesSortCriteria()).toBe('-priority');
+      store.setSortCriteria('priority');
+      expect(store.linesSortCriteria()).toBe('priority');
     });
   });
 
@@ -389,15 +389,15 @@ describe('OrderDetailStore', () => {
       return store;
     };
 
-    it('should sort by priority ascending by default', () => {
+    it('should sort by priority descending by default', () => {
       const store = setupSortedStore();
-      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
     });
 
-    it('should sort by priority descending', () => {
+    it('should sort by priority ascending', () => {
       const store = setupSortedStore();
-      store.setSortCriteria('-priority');
-      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineA', 'lineB']);
+      store.setSortCriteria('priority');
+      expect(store.sortedOrderLines().map(l => l.pid)).toEqual(['lineB', 'lineA']);
     });
 
     it('should sort by document title ascending', () => {

--- a/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
+++ b/projects/admin/src/app/acquisition/components/order/order-detail-view/store/order-detail.store.ts
@@ -34,7 +34,7 @@ export const OrderDetailStore = signalStore(
     order: undefined,
     orderPermissions: undefined,
     orderLines: [],
-    linesSortCriteria: 'priority',
+    linesSortCriteria: '-priority',
     receipts: [],
     receiptPermissions: undefined,
     historyVersions: [],


### PR DESCRIPTION
Commit 62c09c3d dropped the `priority` (ascending) option from the order lines sort menu, but the store still defaulted to that value: the select matched no option and rendered empty.